### PR TITLE
Support for glob src_files, and additional watch lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ to structure your sources files into separate directories, or want to have finer
     - hello.js
     - hello_spec.js
 
+The src_files can also be glob patterns (See: isaacs/node-glob)
+
+    src_files:
+    - js/**/*.js
+    - spec/**/*.js
+
 Custom Test Pages
 -----------------
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,11 +3,15 @@ var Express = require('express')
   , BrowserClient = require('./browserclient')
   , Mustache = require('./mustache.exp')
   , fs = require('fs')
+  , util = require('util')
+  , async = require('async')
+  , glob = require('glob')
   , isa = require('./isa')
   , log = require('winston')
   //, log = new (require('log'))('info', fs.createWriteStream('testem.log2'))
     
 // Convience functions
+  // callback()
 var getipaddr = require('./getipaddr')
         
 require('./socket.io.patch')
@@ -69,14 +73,15 @@ Server.prototype = {
                 var url = '/runner/' + this.config.test_page
                 res.redirect(url + '#testem')
             }else if (isa(this.config.src_files, Array)){
-                var files = this.config.src_files
-                render(files)
-            }else if(isa(this.config.src_files, Function)){
-                this.config.src_files(function(err, files){
-                    if (err)
-                        throw err
+                this.globFiles(this.config.src_files, function(files){
                     render(files)
-                }.bind(this))
+                })
+            }else if(isa(this.config.src_files, Function)){
+              this.config.src_files(function(err, files){
+                if (err)
+                  throw err
+                render(files)
+              }.bind(this))
             }
 
         }.bind(this))
@@ -92,6 +97,11 @@ Server.prototype = {
 
         // Create socket.io sockets
         this.io = SocketIO.listen(this.exp)
+
+        // Force xhr-polling if you have issues with
+        // reserved bits in Chrome and websockets.
+        //this.io.set('transports', ['xhr-polling'])
+
         //io.set('close timeout', 8)
         //io.set('heartbeat timeout', 3)
 
@@ -100,22 +110,81 @@ Server.prototype = {
         // Start the server!
         this.exp.listen(this.config.port)
     },
-    monitorFiles: function(callback){
-        this.unwatchFiles()
-        if (this.config.test_page){
-            this.trackFile(this.config.test_page)
-            callback()
-        }else if (isa(this.config.src_files, Array)){
-            var files = this.config.src_files
-            files.forEach(this.trackFile.bind(this))
-            callback()
-        }else if(isa(this.config.src_files, Function)){
-            this.config.src_files(function(err, files){
+    // The fileHandler will recieve the list of files for
+    // each pattern passed.
+    //
+    // fileHandler(files) {
+    //    // do something with the files
+    // }
+    globFiles: function(globPatterns, fileHandler){
+        var globPattern = function(memo, pattern, cb){
+            log.info('Looking to glob files using :' + pattern);
+            //log.debug('Currently matching files: ' + util.inspect(memo))
+            glob(pattern, function(err, files){
+                if(err) {
+                    log.error('Failed to glob path: ' + pattern)
+                    cb(err)
+                }
+                memo[pattern] = files
+                cb(null, memo)
+            })
+        }
+
+        // we want to have control over
+        // the order in which the scripts are added
+        // using reduce allows us to collect the
+        // results and remove any duplicates
+        async.reduce(globPatterns, {}, globPattern, function(err, matchedFiles){
+            log.debug('For patterns: ' + util.inspect(globPatterns) + '\n discovered matching files: ' + util.inspect(matchedFiles))
+
+            var allFiles = []
+            globPatterns.forEach(function(pattern){
+                allFiles = allFiles.concat(matchedFiles[pattern])
+            })
+
+            var added = {}
+            var filteredForDuplicates = []
+            allFiles.forEach(function(file){
+                if(file in added){
+                    return
+                }
+                filteredForDuplicates.push(file)
+                added[file] = true; 
+            })
+            log.info('Glob files found: ' + util.inspect(filteredForDuplicates))
+            fileHandler(filteredForDuplicates)
+        })
+    },
+    monitorListedFiles: function(configFiles, callback) {
+        if (isa(configFiles, Array)){
+            var self = this
+            this.globFiles(configFiles, function(files){
+                files.forEach(function(file){
+                    log.debug('Tracking file:' + file)
+                    self.trackFile(file)
+                })
+                callback()
+            })
+        } else if (isa(configFiles, Function)){
+            configFiles(function(err, files){
                 if (!err){
                     files.forEach(this.trackFile.bind(this))
                     callback()
                 }
             }.bind(this))
+        }
+    },
+    monitorFiles: function(callback){
+        this.unwatchFiles()
+        if (this.config.test_page){
+            this.trackFile(this.config.test_page)
+            callback()
+        } else if (this.config.src_files) {
+            this.monitorListedFiles(this.config.src_files, callback)
+        } 
+
+        if (this.config.watch_files) {
+            this.monitorListedFiles(this.config.watch_files, callback)
         }
     },
     trackFile: function(filepath){

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
        "charm": "0.0.5",
        "js-yaml": "0.3.5",
        "tap": "0.2.0",
-       "commander": "0.5.2"
+       "commander": "0.5.2",
+       "glob" : "3.0.1",
+       "async" : "0.1.15"
    },
    "bin" : {
        "testem" : "./testem.js"


### PR DESCRIPTION
## src_files glob support

This change allows the user to specify globs in their
testem.yml.  For example:

```
src_files:
  - js/vendor/curl/curl.js
  - js/amd-app/config.js
  - js/amd-app/**/*.js
  - js/spec/config-override.js
  - js/spec/specs.js
```

Note that src_files is intelligent enough to removed duplicates added by latter
glob patterns.  This allows flexibility and control.  For example the
amd-app/config.js is loaded before the rest of amd-app.
## watch_files support

```
watch_files:
  - js/amd-app/**/*.js
  - js/vendor/**/backbone.js
  - js/vendor/**/jquery.js
  - js/vendor/**/underscore-amd.js
  - js/vendor/**/underscore.js
```

For AMD loaders is is desirble to not load everything in src_files.  Instead
specify any additional glob patterns for files to watch (e.g. those loaded by
and AMD loader.
