### PR TITLE
make console output tap compliant.

### DIFF
--- a/lib/appviewconsole.js
+++ b/lib/appviewconsole.js
@@ -89,7 +89,7 @@ AppView.prototype = {
         browsers.forEach(function(browser){
         
             browser.results.tests.forEach(function(test){
-                var testName = browser.name + ' - ' + test.name
+                var testName = ' - ' + browser.name + '  ' + test.name
                 if (test.failed === 0){
                     producer.write({
                         id: id++,


### PR DESCRIPTION
to make this work with the jenkins tap plugin, we need tap compliant output.
