### PR TITLE
change module url

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
        "winston": "0.3.4",
        "charm": "0.0.5",
        "js-yaml": "0.3.5",
-       "tap": "git://github.com/isaacs/node-tap.git#0.2.4",
+       "tap": "https://github.com/isaacs/node-tap.git#0.2.4",
        "commander": "0.5.2",
        "glob" : "3.0.1",
        "async" : "0.1.15"


### PR DESCRIPTION
I'd like to suggest this change as in my case the git protocol is blocked which makes testem unusable as I can't install it.
