### PR TITLE
Wrap default jasmine test runner logic in window.onload

### DIFF
--- a/views/jasminerunner.html
+++ b/views/jasminerunner.html
@@ -4,14 +4,21 @@
 <title>Test'em Runner</title>
 <script src="/testem/jasmine.js"></script>
 <script src="/testem/jasmine-html.js"></script>
+<script>
+  (function() {
+    var jasmineEnv = jasmine.getEnv()
+    jasmineEnv.addReporter(new jasmine.HtmlReporter)
+
+    window.onload = function() {
+      jasmineEnv.execute()
+    };
+  })();
+</script>
+
 {{#scripts}}<script src="{{.}}"></script>{{/scripts}}
 <script src="/testem.js"></script>
 <link rel="stylesheet" href="/testem/jasmine.css">
 </head>
 <body>
-<script>
-jasmine.getEnv().addReporter(new jasmine.HtmlReporter)
-jasmine.getEnv().execute()
-</script>
 </body>
 </html>


### PR DESCRIPTION
This change should NOT break any existing spec suites. It wraps the jasmine suite execution in a `window.onload` event and moves it up in the DOM. This better replicates the default runner in, for example, the jasmine gem.

For my use, I need this change because I stub out window.onload in order to defer the execution of the suite. I also thought that other people might find it useful if the default jasmine runner acted the same as the jasmine gem.
