### PR TITLE
Made testem.yml support css files to better replicate jasmine functionality

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -65,6 +65,8 @@ Server.prototype = {
             var framework = config.get('framework') || 'jasmine'
               , test_page = config.get('test_page')
               , src_files = config.get('src_files')
+              , css_files = config.get('css_files')
+
             res.header('Cache-Control', 'No-cache')
             res.header('Pragma', 'No-cache')
             function render(err, files){
@@ -74,7 +76,10 @@ Server.prototype = {
                     , mocha: __dirname + '/../views/mocharunner.html'
                 }[framework]
                 res.render(runnerPage, {
-                    locals: {scripts: files}
+                    locals: {
+                      scripts: files,
+                      styles: css_files
+                    }
                 })
             }
 

--- a/views/jasminerunner.html
+++ b/views/jasminerunner.html
@@ -1,25 +1,28 @@
 <!doctype html>
 <html>
 <head>
-<title>Test'em Runner</title>
-<script src="/testem/jasmine.js"></script>
-<script src="/testem.js"></script>
-<script src="/testem/jasmine-html.js"></script>
-<script>
-  (function() {
-    var jasmineEnv = jasmine.getEnv()
-    jasmineEnv.addReporter(new jasmine.HtmlReporter)
+  <title>Test'em Runner</title>
+  <script src="/testem/jasmine.js"></script>
+  <script src="/testem.js"></script>
+  <script src="/testem/jasmine-html.js"></script>
+  <script>
+    (function() {
+      var jasmineEnv = jasmine.getEnv()
+      jasmineEnv.addReporter(new jasmine.HtmlReporter)
 
-    window.onload = function() {
-      jasmineEnv.execute()
-    };
-  })();
-</script>
+      window.onload = function() {
+        jasmineEnv.execute()
+      };
+    })();
+  </script>
 
-{{#scripts}}<script src="{{.}}"></script>{{/scripts}}
+  {{#scripts}}<script src="{{.}}"></script>{{/scripts}}
 
-<link rel="stylesheet" href="/testem/jasmine.css">
+  <link rel="stylesheet" href="/testem/jasmine.css">
+
+  {{#styles}}<link rel="stylesheet" href="{{.}}">{{/styles}}
 </head>
 <body>
+  <div id="jasmine_content"></div>
 </body>
 </html>


### PR DESCRIPTION
I'm not a fan of testing css, but for legacy projects, this would be a nice feature to support.
- added support for `css_files` in the testem.yml (for jasmine only)
- added a `#jasmine_content` div to the jasmine runner view to better replicate default jasmine gem behavior

These two things are necessary for me to use testem in a legacy project. Please consider accepting this pull request.

Note that these changes were made in the jasmine view only. If you want css_files support in the other systems, we'll have to add them there as well. Let me know if you want me to do that.
