### PR TITLE
Allow the browser client to detect IE10

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -75,7 +75,7 @@ patchSocketIOReconnect()
 
 function getBrowserName(userAgent){
     var regexs = [
-        /MS(?:(IE) ([0-9]\.[0-9]))/,
+        /MS(?:(IE) (1?[0-9]\.[0-9]))/,
         /(Chrome)\/([0-9]+\.[0-9]+)/,
         /(Firefox)\/([0-9a-z]+\.[0-9a-z]+)/,
         /(Opera).*Version\/([0-9]+\.[0-9]+)/,


### PR DESCRIPTION
Currently, IE 10 is detected as `Mozilla 5.0`. After this patch, it shows as `IE 10.0`.
