### PR TITLE
Prevent serving any files from outside the current working directory

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -13,6 +13,7 @@ var Express = require('express')
   , BrowserRunner = require('./runners').BrowserRunner
   , Mustache = require('./mustache.exp')
   , fs = require('fs')
+  , path = require('path')
   , util = require('util')
   , async = require('async')
   , glob = require('glob')
@@ -136,9 +137,15 @@ Server.prototype = {
             res.setHeader('Pragma', 'No-cache')
             delete req.headers['if-modified-since']
             delete req.headers['if-none-match']
-            var path = req.params[0]
-            self.emit('file-requested', path)
-            res.sendfile(path)
+            var pathRequested = path.resolve(process.cwd(), req.params[0])
+            if (pathRequested.indexOf(process.cwd()) === -1 && !config.get('unsafe_file_serving')) {
+                res.status(403)
+                res.write('403 Forbidden')
+                res.end()
+            } else {
+                self.emit('file-requested', pathRequested)
+                res.sendfile(pathRequested)
+            }
         })
     
 


### PR DESCRIPTION
At present, if you visit `http://localhost:7357//etc/passwd` you will see the file. It's very dangerous to run a web server as the current user with full access to the file system.

This change will return a 403 if any file outside of the current working directory is requested.

The user can turn this behavior off by changing the `unsafe_file_serving` config boolean to true.
