### PR TITLE
added configurable static_dirs for pathing for platforms like yeoman

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -64,7 +64,6 @@ Server.prototype = {
             // - temp
             var dirs = config.get('static_dirs') || []
             for (var i = 0; i < dirs.length; i++) {
-                console.log(path.resolve(dirs[i]))
                 exp.use(Express.static(path.resolve(dirs[i])))
             }
         })


### PR DESCRIPTION
I added this specifically to support yeoman but I could see it being helpful for other platforms as well. All this does is essentially maps multiple configurable paths to the express server.

Would anyone else have use for this?
