### PR TITLE
offered more flexibility in how to map source and destination directorie...

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -58,13 +58,9 @@ Server.prototype = {
             exp.use(Express.static(__dirname + '/../public'))
 
             // Load other static dirs that you want pathed relative to test server
-            // Example
-            // static_dirs:
-            // - app
-            // - temp
             var dirs = config.get('static_dirs') || []
             for (var i = 0; i < dirs.length; i++) {
-                exp.use(Express.static(path.resolve(dirs[i])))
+                exp.use(dirs[i].dest, Express.static(path.resolve(dirs[i].source)))
             }
         })
         exp.get('/', function(req, res){


### PR DESCRIPTION
I went ahead and made the mapping a bit more configurable making both the source folder and static folder configurable.

Below is an example of the proposed testem.json configuration object I'm using in my yeoman project. It was important to do this because if you just serve up yeoman's app and temp directories testem's express server will end up serving yeoman's index.html instead of it's own. This offers more finite control.

Using this below I've got a fully integrated CoffeeScript + RequireJS + Yeoman + Testem goodness :smiley: 

``` javascript
{
  "test_page": "test/suite.html",
  "static_dirs": [
    {
      "source": "temp/scripts",
      "dest": "/scripts"
    },
    {
      "source": "temp/styles",
      "dest": "/styles"    
    },
    {
      "source": "app/templates",
      "dest": "/templates"
    }
  ],
  "launch_in_dev": [
    "PhantomJS"
  ],
  "before_tests": "coffee -c test/specs/**/*.coffee",
  "after_tests": "rm test/specs/**/*.js",
  "src_files": [
    "app/templates/**/*.tmpl",
    "temp/scripts/**/*.js",
    "test/specs/**/*.coffee"
  ]
}
```
