### PR TITLE
express & socket.io package.json version lock fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "express": "== 2.5.10",
+    "express": "2.5.10",
     "mustache": "0.4.0",
-    "socket.io": "== 0.9.10",
+    "socket.io": "0.9.10",
     "winston": "0.3.4",
     "charm": "0.0.5",
     "js-yaml": "0.3.5",


### PR DESCRIPTION
Avoiding the 'npm install' to attempt resolving ' 2.5.10' version of the
express package. This makes the from cache only (--no-registry) npm install
to go through again.
