### PR TITLE
on_start hook 

### DIFF
--- a/lib/base_app.js
+++ b/lib/base_app.js
@@ -19,6 +19,11 @@ function BaseApp(config){
                 self.emit('all-runners-complete')
             }
         })
+
+    log.info("Starting on_start hook (long-running process): " + this.config.get('on_start'));
+    if(this.config.get('on_start')) {
+        this.on_start_process = exec(this.config.get('on_start'))
+    }
 }
 BaseApp.prototype = {
     __proto__: EventEmitter.prototype
@@ -29,6 +34,9 @@ BaseApp.prototype = {
         this.runHook('after_tests', callback)
     }
     , runExitHook: function (callback) {
+        if(this.on_start_process) {
+            this.on_start_process.kill('SIGTERM');
+        }
         this.runHook('on_exit', callback)
     }
     , runHook: function(hook, callback){


### PR DESCRIPTION
I've opened this pull request to track and discuss an implementation for an "on_start" hook.

The "on_start" hook is intended to be a long-running process that testem will start when testem starts and will terminate when testem terminates.

An example use-case is a tunnel:

`on_start: ssh -NR "*:8000:localhost:7357" publichost.com`
