### PR TITLE
Replace <url> parameter in launcher commands

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -85,7 +85,8 @@ Launcher.prototype = {
             }
 			
 		}else if (settings.command){
-			this.process = child_process.exec(settings.command, options)
+			var cmd = settings.command.replace(/<url>/g, url)
+			this.process = child_process.exec(cmd, options)
 			this.process.on('exit', self.onExit.bind(self))
 			self.emit('processStarted', self.process)
 			if (cb) cb(self.process)


### PR DESCRIPTION
Allows you to put a url parameter in a launcher command. For example:

``` yaml
launchers:
  mybrowser:
    command: mybrowser.exe <url>
    protocol: browser
```
