### PR TITLE
Use SIGTERM instead of SIGKILL as default launcher kill signal

### DIFF
--- a/lib/ci_mode_app.js
+++ b/lib/ci_mode_app.js
@@ -161,7 +161,7 @@ App.prototype = {
                 }
                 if (!gotResults) self.emit('all-test-results', results)
                 self.outputTap(results, launcher)
-                launcher.kill('SIGKILL')
+                launcher.kill()
                 finish()
             })
             

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -107,7 +107,7 @@ Launcher.prototype = {
         var process = this.process
         process.stdout.removeAllListeners()
         process.stderr.removeAllListeners()
-        sig = sig || 'SIGKILL'
+        sig = sig || 'SIGTERM'
 
         process.once('exit', function(){
             process.removeAllListeners()


### PR DESCRIPTION
This gives launcher processes the opportunity to clean up.
