### PR TITLE
Programmatic control of testem

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,86 @@
+var log = require('winston'),
+    Config = require('./config'),
+    catchem = require('./catchem'),
+    _ = require('underscore'),
+    Backbone = require('backbone'),
+    ProcessRunner = require('./runners').ProcessRunner;
+
+/*
+    progOptions:
+    file: test file
+    port: 7357
+    launch: list of launchers to use
+    skip: list of launchers to skip
+    test_page: the page to use to run tests
+    timeout: timeout for a browser
+    framework: test framework to use
+    src_files: list of files or file patterns
+*/
+
+
+var EventLogger = Backbone.Model.extend({
+    initialize: function(attrs){
+        this.set({
+            name: attrs.name
+            , allPassed: true
+            , messages: new Backbone.Collection()
+        })
+    },
+    clear: function() {
+        this.get('messages').reset([])
+    },
+    hasMessages: function() {
+        var messages = this.get('messages')
+        return messages.length > 0
+    },
+    hasResults: function() { return false; },
+    addMessage: function( type, message, color ){
+        var messages = this.get('messages')
+        messages.push({ type: type, text: message, color: color })
+    },
+    startTests: function() {}
+} )
+
+
+catchem.on('err', function(e){
+    log.error(e.message)
+    log.error(e.stack)
+})
+
+var Api = function() {
+    _.bindAll( this )
+}
+
+Api.prototype.setup = function(mode, dependency){
+    var self = this,
+        App = require(dependency),
+        config = new Config(mode, this.options)
+    config.read(function() {
+        self.app = new App(config)
+    })
+}
+
+Api.prototype.startDev = function(options){
+    this.options = options
+    this.setup('dev', './dev_mode_app.js')
+}
+
+Api.prototype.restart = function() {
+    this.app.startTests( function() {} )
+}
+
+Api.prototype.startCI = function(options){
+    this.options = options
+    this.setup('ci', './ci_mode_app.js')
+}
+
+Api.prototype.getLogger = function( name ) {
+    var logger = new EventLogger({ name: name })
+    return logger
+}
+
+Api.prototype.addTab = function( logger ) {
+    this.app.runners.push( logger )
+}
+
+module.exports = Api

--- a/lib/ui/split_log_panel.js
+++ b/lib/ui/split_log_panel.js
@@ -220,7 +220,7 @@ var SplitLogPanel = module.exports = View.extend({
         messages.forEach(function(message){
             var type = message.get('type')
             var text = message.get('text')
-            var color = type === 'error' ? 'red' : 'yellow'
+            var color = message.get('color') || ( type === 'error' ? 'red' : 'yellow' )
             retval = retval.concat(StyledString(text, {foreground: color}))
         })
         return retval

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "bin": {
     "testem": "./testem.js"
   },
+  "main": "./lib/api.js",
   "bundleDependencies": [
     "tap"
   ],


### PR DESCRIPTION
This adds an api modules to testem and registers it as the main module so that a developer can require testem into their project and launch it that way. I've included a very brief set of snippets to show how the general calls work. It's pretty bare-bones, but it's currently everything we needed. Thanks so much for your help and thanks for testem!

``` javascript
var Api = require('testem')
var api = new Api()
api.startDev( {
  /*
    progOptions:
    file: test file
    port: 7357
    launch: list of launchers to use
    skip: list of launchers to skip
    test_page: the page to use to run tests
    timeout: timeout for a browser
    framework: test framework to use
    src_files: list of files or file patterns
*/
} )

// to add a tab to testem, you can first create a logger and then add messages to it like so:
var logger = api.getLogger('title')
api.addTab(logger)
logger.addMessage( 'type', 'message text', 'blue' )

// you can clear the logger's tab by calling clear:
logger.clear()

// to restart the tests at anytime, you can call restart:
api.restart();
```
