### PR TITLE
Fixes #122

### DIFF
--- a/lib/runners.js
+++ b/lib/runners.js
@@ -230,15 +230,7 @@ var ProcessRunner = Backbone.Model.extend({
             } else if (Array.isArray(stack)) {
                 stack = stack.join("\n")
             } else {
-                var keys = Object.keys(stack)
-                stack = keys.map(function (key) {
-                    var values = Object.keys(stack[key])
-                        .map(function (key2) {
-                            return key2 + " " + stack[key][key2]
-                        })
-
-                    return [key].concat(values).join("\n")
-                }).join("\n")
+                stack = JSON.stringify(stack, null, "\t")
             }
           
             test.items.push({


### PR DESCRIPTION
The issue here is that [tape](https://github.com/substack/tape) outputs an object to TAP with a stack property that's an object instead of an array.

[As seen here](https://github.com/substack/tape/blob/master/lib/render.js#L84).

This means we need to handle the stack parsing more carefully. The object parsing is currently just JSON.stringify with some whitespace.

cc @substack How should tap consumers handle these things?
