### PR TITLE
Fix race condition with display

### DIFF
--- a/lib/ui/runner_tabs.js
+++ b/lib/ui/runner_tabs.js
@@ -43,9 +43,9 @@ var RunnerTab = exports.RunnerTab = View.extend({
             , appview: appview
             , visible: visible
         })
-        
+
         this.spinnerIdx = 0
-        
+
         this.observe(appview, {
             'change:currentTab': function(){
                 self.set('selected', appview.get('currentTab') === self.get('index'))
@@ -94,7 +94,7 @@ var RunnerTab = exports.RunnerTab = View.extend({
         this.observe(appview, 'change:isPopupVisible', function(appview, popupVisible){
             self.updateSplitPanelVisibility()
         })
-        
+
         this.observe(this, {
             'change:selected': function(){
                 self.updateSplitPanelVisibility()
@@ -114,7 +114,10 @@ var RunnerTab = exports.RunnerTab = View.extend({
         this.splitPanel.set('visible', this.get('selected') && !appview.isPopupVisible())
     }
     , color: function(){
-        return this.get('allPassed') ? 'green' : 'red'
+        var runner = this.get('runner')
+        var results = runner.get('results')
+        var equal = results ? results.get('passed') === results.get('total') : true
+        return equal ? 'green' : 'red'
     }
     , startSpinner: function(){
         this.stopSpinner()
@@ -142,7 +145,7 @@ var RunnerTab = exports.RunnerTab = View.extend({
     }
     , renderRunnerName: function(){
         if (this.isPopupVisible()) return
-        
+
         var index = this.get('index')
         var line = this.line
         var width = this.width
@@ -172,9 +175,10 @@ var RunnerTab = exports.RunnerTab = View.extend({
         var runner = this.get('runner')
         var results = runner.get('results')
         var resultsDisplay = results ? results.get('passed') + '/' + results.get('total') : ''
+        var equal = results ? results.get('passed') === results.get('total') : true
 
         if (results && results.get('all')){
-            resultsDisplay += ' ' + (this.get('allPassed') ? Chars.success : Chars.fail)
+            resultsDisplay += ' ' + ((this.get('allPassed') && equal) ? Chars.success : Chars.fail)
         }else if (!results && runner.get('allPassed') !== undefined){
             resultsDisplay = runner.get('allPassed') ? Chars.success : Chars.fail
         }else{
@@ -237,7 +241,7 @@ var RunnerTab = exports.RunnerTab = View.extend({
         screen.position(col, line)
 
         screen.write((firstCol ? Chars.horizontal : Chars.topLeft) +
-            Array(width - 1).join(Chars.horizontal) + 
+            Array(width - 1).join(Chars.horizontal) +
                 Chars.topRight)
         for (var i = 1; i < height - 1; i++){
             if (!firstCol){
@@ -299,7 +303,7 @@ var RunnerTabs = exports.RunnerTabs = Backbone.Collection.extend({
     }
     , blankOutBackground: function(){
         if (this.isPopupVisible()) return
-        
+
         var cols = this.appview.get('cols')
         for (var i = 0; i < TabHeight; i++){
             screen


### PR DESCRIPTION
The `allPassed` values are not always correct.

The `total` and `passed` values are always correct.

I'm sure this can be better fixed in the model somehow.

This race condition occurs when using the TAP protocol on node tests
