### PR TITLE
Add attributes support to generated script tags

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -200,9 +200,54 @@ Config.prototype.printLauncherInfo = function(){
 }
 
 Config.prototype.getFileSet = function(want, dontWant, callback){
-    if (isa(want, Array)) want = want.join(' ')
     if (isa(dontWant, Array)) dontWant = dontWant.join(' ')
-    fileset(want, dontWant, callback)
+    if (!isa(want, Array)) want = want.split(' ');
+
+    var globs = [], matches = [], remaining = want.length;
+
+    // once we have all the files from all the "wanted" globs
+    // order the resulting files by the order thier glob was provided
+    function next(normalisedResults) {
+        var ret = [], files = [], globs = Object.keys(want);
+        normalisedResults.forEach(function(resultObj) {
+            var index = globs.indexOf(resultObj.glob),
+                attrs = resultObj.attrs;
+
+            files[index] = [];
+
+            resultObj.files.forEach(function(file) {
+                files[index].push({ src: file, attrs: attrs });
+            });
+        });
+        files.forEach(function(aa) {
+            Array.prototype.push.apply(ret, aa);
+        });
+        return ret;
+    }
+
+    // normalize wants
+    function normalizeWant(want) {
+        var ret = {};
+        want.forEach(function(wanting) {
+            var glob = isa(wanting, Object) ? wanting.src : wanting,
+                attrs = isa(wanting, Object) ? wanting.attrs : [];
+
+            ret[glob] = attrs;
+        });
+        return ret;
+    }
+
+    want = normalizeWant(want);
+
+    // normalised glob results for each wanted glob
+    var normalisedResults = [];
+    Object.keys(want).forEach(function(glob) {
+        fileset(glob, dontWant, { nosort: true }, function(err, files) {
+            normalisedResults.push({ files: files, attrs: want[glob], glob: glob });
+            if(err) callback(err, []);
+            else if(--remaining === 0) callback(err, next(normalisedResults));
+        })
+    });
 }
 
 Config.prototype.getSrcFiles = function(callback){

--- a/lib/dev_mode_app.js
+++ b/lib/dev_mode_app.js
@@ -107,7 +107,11 @@ App.prototype = {
                 self.watchFiles(watch_files)
             }
             config.getSrcFiles(function(err, files){
-                self.watchFiles(files)
+               var newFiles = [];
+                files.forEach(function(fileObj) {
+                    newFiles.push(fileObj.src);
+                });
+                self.watchFiles(newFiles)
             })
             if (cb) cb.call(self)
         })

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -161,7 +161,7 @@ describe('Config', function(){
 		it('gets src files', function(done){
 			config.set('src_files', ['config_tests.js'])
 			config.getSrcFiles(function(err, files){
-				expect(files).to.deep.equal(['config_tests.js'])
+				expect(files).to.deep.equal([{src:'config_tests.js', attrs:[]}])
 				done()
 			})
 		})
@@ -169,7 +169,7 @@ describe('Config', function(){
 			config.set('src_files', ['integration/*'])
 			config.set('src_files_ignore', ['**/*.sh'])
 			config.getSrcFiles(function(err, files){
-				expect(files).to.deep.equal(['integration/browser_tests.bat'])
+				expect(files).to.deep.equal([{src:'integration/browser_tests.bat', attrs:[]}])
 				done()
 			})
 		})
@@ -177,7 +177,42 @@ describe('Config', function(){
 			config.set('src_files', 'integration/*')
 			config.set('src_files_ignore', '**/*.sh')
 			config.getSrcFiles(function(err, files){
-				expect(files).to.deep.equal(['integration/browser_tests.bat'])
+				expect(files).to.deep.equal([{src:'integration/browser_tests.bat', attrs:[]}])
+				done()
+			})
+		})
+		it('populates attributes', function(done){
+			config.set('src_files', [{src:'config_tests.js', attrs: [ 'data-foo="true"', 'data-bar' ]}])
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([{src:'config_tests.js', attrs:['data-foo="true"', 'data-bar']}])
+				done()
+			})
+		})
+		it('populates attributes for only the desired globs', function(done){
+			config.set('src_files', [
+				{src:'config_tests.js', attrs: [ 'data-foo="true"', 'data-bar' ]},
+				'integration/*'
+			])
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([
+					{src:'config_tests.js', attrs:['data-foo="true"', 'data-bar']},
+					{src:'integration/browser_tests.bat', attrs:[]},
+					{src:'integration/browser_tests.sh', attrs:[]}
+				])
+				done()
+			})
+		})
+		it('populates attributes for only the desired globs and excludes usig src_files_ignore', function(done){
+			config.set('src_files', [
+				{src:'config_tests.js', attrs: [ 'data-foo="true"', 'data-bar' ]},
+				'integration/*'
+			])
+			config.set('src_files_ignore', '**/*.sh')
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([
+					{src:'config_tests.js', attrs:['data-foo="true"', 'data-bar']},
+					{src:'integration/browser_tests.bat', attrs:[]}
+				])
 				done()
 			})
 		})
@@ -188,7 +223,7 @@ describe('Config', function(){
 			config.set('src_files', 'integration/*')
 			config.set('src_files_ignore', '**/*.sh')
 			config.getServeFiles(function(err, files){
-				expect(files).to.deep.equal(['integration/browser_tests.bat'])
+				expect(files).to.deep.equal([{ src:'integration/browser_tests.bat', attrs:[]}])
 				done()
 			})
 		})
@@ -196,7 +231,42 @@ describe('Config', function(){
 			config.set('serve_files', 'integration/*')
 			config.set('serve_files_ignore', '**/*.sh')
 			config.getServeFiles(function(err, files){
-				expect(files).to.deep.equal(['integration/browser_tests.bat'])
+				expect(files).to.deep.equal([{ src:'integration/browser_tests.bat', attrs:[]}])
+				done()
+			})
+		})
+		it('populates attributes', function(done){
+			config.set('serve_files', [{src:'config_tests.js', attrs: [ 'data-foo="true"', 'data-bar' ]}])
+			config.getServeFiles(function(err, files){
+				expect(files).to.deep.equal([{src:'config_tests.js', attrs:['data-foo="true"', 'data-bar']}])
+				done()
+			})
+		})
+		it('populates attributes for only the desired globs', function(done){
+			config.set('serve_files', [
+				{src:'config_tests.js', attrs: [ 'data-foo="true"', 'data-bar' ]},
+				'integration/*'
+			])
+			config.getServeFiles(function(err, files){
+				expect(files).to.deep.equal([
+					{src:'config_tests.js', attrs:['data-foo="true"', 'data-bar']},
+					{src:'integration/browser_tests.bat', attrs:[]},
+					{src:'integration/browser_tests.sh', attrs:[]}
+				])
+				done()
+			})
+		})
+		it('populates attributes for only the desired globs and excludes usig serve_files_ignore', function(done){
+			config.set('serve_files', [
+				{src:'config_tests.js', attrs: [ 'data-foo="true"', 'data-bar' ]},
+				'integration/*'
+			])
+			config.set('serve_files_ignore', '**/*.sh')
+			config.getServeFiles(function(err, files){
+				expect(files).to.deep.equal([
+					{src:'config_tests.js', attrs:['data-foo="true"', 'data-bar']},
+					{src:'integration/browser_tests.bat', attrs:[]}
+				])
 				done()
 			})
 		})
@@ -245,8 +315,8 @@ describe('getTemplateData', function(){
 				port: 8081,
 				src_files: ['web/*.js'],
 				serve_files: [
-					'web/hello.js',
-					'web/hello_tests.js'
+					{src:'web/hello.js', attrs: []},
+					{src:'web/hello_tests.js', attrs: []}
 				]
 			})
 			done()

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -19,7 +19,7 @@ describe('Server', function(){
             port: port,
             src_files: [
                 'web/hello.js',
-                'web/hello_tests.js'
+                {src:'web/hello_tests.js', attrs: ['data-foo="true"', 'data-bar']}
             ]
         })
         baseUrl = 'http://localhost:' + port + '/'
@@ -86,7 +86,7 @@ describe('Server', function(){
                 , '<html>'
                 , '<head>'
                 , '        <script src="web/hello.js"></script>'
-                , '        <script src="web/hello_tests.js"></script>'
+                , '        <script src="web/hello_tests.js" data-foo="true"  data-bar ></script>'
                 , '    </head>'
                 ].join('\n'))
             done()

--- a/tests/web/tests_template.html
+++ b/tests/web/tests_template.html
@@ -2,6 +2,6 @@
 <html>
 <head>
     {{#serve_files}}
-    <script src="{{.}}"></script>
+    <script src="{{src}}"{{#attrs}} {{&.}} {{/attrs}}></script>
     {{/serve_files}}
 </head>

--- a/views/busterrunner.html
+++ b/views/busterrunner.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="/testem/buster-test.css">
 <script src="/testem/buster-test.js"></script>
 <script src="/testem.js"></script>
-{{#scripts}}<script src="{{.}}"></script>{{/scripts}}
+{{#scripts}}<script src="{{src}}"{{#attrs}} {{&.}} {{/attrs}}></script>{{/scripts}}
 </head>
 <body></body>
 </html>

--- a/views/customrunner.html
+++ b/views/customrunner.html
@@ -3,7 +3,7 @@
 <head>
   <title>Test'em</title>
   <script src="/testem.js"></script>
-  {{#scripts}}<script src="{{.}}"></script>{{/scripts}}
+  {{#scripts}}<script src="{{src}}"{{#attrs}} {{&.}} {{/attrs}}></script>{{/scripts}}
 </head>
 <body>
 </body>

--- a/views/jasminerunner.html
+++ b/views/jasminerunner.html
@@ -16,7 +16,7 @@
     })();
   </script>
 
-  {{#scripts}}<script src="{{.}}"></script>{{/scripts}}
+  {{#scripts}}<script src="{{src}}"{{#attrs}} {{&.}} {{/attrs}}></script>{{/scripts}}
 
   <link rel="stylesheet" href="/testem/jasmine.css">
 

--- a/views/mocharunner.html
+++ b/views/mocharunner.html
@@ -6,7 +6,7 @@
 <script src="/testem/mocha.js"></script>
 <script src="/testem.js"></script>
 <script>mocha.setup('bdd')</script>
-{{#scripts}}<script src="{{.}}"></script>{{/scripts}}
+{{#scripts}}<script src="{{src}}"{{#attrs}} {{&.}} {{/attrs}}></script>{{/scripts}}
 </head>
 <body>
 <div id="mocha"></div>

--- a/views/qunitrunner.html
+++ b/views/qunitrunner.html
@@ -4,7 +4,7 @@
 <title>Test'em</title>
 <script src="/testem/qunit.js"></script>
 <script src="/testem.js"></script>
-{{#scripts}}<script src="{{.}}"></script>{{/scripts}}
+{{#scripts}}<script src="{{src}}"{{#attrs}} {{&.}} {{/attrs}}></script>{{/scripts}}
 <link rel="stylesheet" href="/testem/qunit.css"/>
 </head>
 <body>


### PR DESCRIPTION
This pulls adds an expanded format for `src_files` and `serve_files` that allows attributes to be added the generated script tags when not using a custom test page.

There are many use cases for this eg:
- requirejs' `data-main` attributes
- blanketjs `data-cover-only` (among all it's other config)

This does not introduce a BC break, simple adds an extended format. 

This also now syncs to order of generated script tags with the order of `src_files` and `serve_files`.
