### PR TITLE
Handle schema string in src_files and serve_files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -200,9 +200,22 @@ Config.prototype.printLauncherInfo = function(){
 }
 
 Config.prototype.getFileSet = function(want, dontWant, callback){
-    if (isa(want, Array)) want = want.join(' ')
+    var serveFiles = [],
+        re = /^(https?:)?\/\//;
+
     if (isa(dontWant, Array)) dontWant = dontWant.join(' ')
-    fileset(want, dontWant, callback)
+    if (!isa(want, Array)) want = want.split(' ');
+
+    want.forEach(function(wanting, i, array) {
+        if(wanting.match(re)) {
+            serveFiles.push(wanting);
+        }
+    });
+
+    fileset(want.join(' '), dontWant, { nosort: true }, function(err, files) {
+        Array.prototype.push.apply(serveFiles, files);
+        callback(err, serveFiles);
+    });
 }
 
 Config.prototype.getSrcFiles = function(callback){

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -181,6 +181,61 @@ describe('Config', function(){
 				done()
 			})
 		})
+		it('can use remote schemas', function(done){
+			config.set('src_files', [
+				'http://example.com/a.js',
+				'https://exmaple.com/b.js',
+				'//example.com/c.js'
+			])
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([
+					'http://example.com/a.js',
+					'https://exmaple.com/b.js',
+					'//example.com/c.js'
+				])
+				done()
+			})
+		})
+		it('can also use remote schemas with globs', function(done){
+			config.set('src_files', [
+				'config_tests.js',
+				'http://example.com/a.js',
+				'integration/*',
+				'https://exmaple.com/b.js',
+				'//example.com/c.js'
+			])
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([
+					'http://example.com/a.js',
+					'https://exmaple.com/b.js',
+					'//example.com/c.js',
+					'config_tests.js',
+					'integration/browser_tests.bat',
+					'integration/browser_tests.sh'
+				])
+				done()
+			})
+		})
+		it('can also use remote schemas with globs and respects exclusions', function(done){
+			config.set('src_files', [
+				'config_tests.js',
+				'http://example.com/a.js',
+				'integration/*',
+				'https://exmaple.com/b.js',
+				'//example.com/c.js'
+			])
+			config.set('src_files_ignore', '**/*.sh')
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([
+					'http://example.com/a.js',
+					'https://exmaple.com/b.js',
+					'//example.com/c.js',
+					'config_tests.js',
+					'integration/browser_tests.bat'
+				])
+				done()
+			})
+		})
 	})
 
 	describe('getServeFiles', function(){


### PR DESCRIPTION
This pulls adds the ability to have `<insert your protocol here>://` urls in `src_files` and `serve_files`. 
A common use case for this is loading jQuery in you test suite via the infamous google CDN eg. `//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js`
