### PR TITLE
use json-stringify-safe

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -231,7 +231,7 @@ function takeOverConsole(){
                         return value
                     }
 
-                    return JSON.stringify(value, null, "\t")
+                    return stringify(value, null, "\t")
                 })
                 .join(' ')
             var doDefault = Testem.handleConsoleMessage(message)
@@ -289,6 +289,25 @@ window.Testem = {
         this.evtHandlers[evt].push(callback)
     }
     , handleConsoleMessage: function(){}
+}
+
+function getSerialize (fn) {
+  var seen = [];
+  return function(key, value) {
+    var ret = value;
+    if (typeof value === 'object' && value) {
+      if (seen.indexOf(value) !== -1)
+        ret = '[Circular]';
+      else
+        seen.push(value);
+    }
+    if (fn) ret = fn(key, ret);
+    return ret;
+  }
+}
+
+function stringify(obj, fn, spaces) {
+  return JSON.stringify(obj, getSerialize(fn), spaces);
 }
 
 


### PR DESCRIPTION
This means that `console.log(window)` doesn't blow up.

It is however very long in the console ;)
