### PR TITLE
Specify multiple commands per hook

### DIFF
--- a/lib/base_app.js
+++ b/lib/base_app.js
@@ -43,6 +43,7 @@ BaseApp.prototype = {
     , startOnStartHook: function(callback){
         var on_start = this.config.get('on_start')
         if (on_start){
+            this.onStartProcess = []
             var hooks = _.isArray(on_start) ? on_start : [on_start]
             var self = this
             var doHook = function(i){
@@ -53,8 +54,8 @@ BaseApp.prototype = {
                     var cmd = on_start.command ? self.template(on_start.command) : self.template(on_start)
                     var waitForText = on_start.wait_for_text
                     log.info('Starting on_start hook: ' + cmd, + self)
-                    self.onStartProcess = exec(cmd)
-                    self.onStartProcess.stdout.on('data', function(data){
+                    self.onStartProcess[i] = exec(cmd)
+                    self.onStartProcess[i].stdout.on('data', function(data){
                         var text = '' + data
                         if (text && text.indexOf(waitForText) !== -1){
                             doHook(i + 1)
@@ -72,7 +73,9 @@ BaseApp.prototype = {
     }
     , runExitHook: function (callback) {
         if(this.onStartProcess) {
-            this.onStartProcess.kill('SIGTERM');
+            for(var i = this.onStartProcess.length - 1; i >=0; i--){
+                this.onStartProcess[i].kill('SIGTERM');
+            }
         }
         this.runHook('on_exit', callback)
     }


### PR DESCRIPTION
This is an experimental piece of code that will allow one to specify multiple commands for any of the curent hook by putting them in an array.  It is more of a thought experiment at this time and certainly needs some test coverage, but I wanted to throw it out there (not expecting anyone to actually pull it just yet) to see if there was any interest in pursuing it further and to see if I am on the right track with my implementation approach.  Obviously one can get by w/o this by simply creating bash scripts if one needs to run multiple commands, but being able to do it directly in testem is more platform independent and more light weight.  Comments?
