### PR TITLE
fix garbled UTF-8 characters

### DIFF
--- a/public/testem/buster-test.css
+++ b/public/testem/buster-test.css
@@ -44,7 +44,7 @@ body.buster-test {
 
 .buster-test .success h3:before {
     color: #3c3;
-    content: "âœ“";
+    content: "✓";
     padding-right: 6px;
 }
 
@@ -66,7 +66,7 @@ body.buster-test {
 
 .buster-test .failure h3:before,
 .buster-test .error h3:before {
-    content: "âœ–";
+    content: "✖";
     padding-right: 6px;
 }
 
@@ -75,7 +75,7 @@ body.buster-test {
 }
 
 .buster-test .deferred h3:before {
-    content: "âœŽ";
+    content: "✎";
     padding-right: 6px;
 }
 
@@ -199,3 +199,4 @@ body.buster-test {
     content: "ERR";
     border-color: #c00;
 }
+


### PR DESCRIPTION
`buster-test.css` is garbled

![Test em 22 2013-04-04 23-03-48](https://f.cloud.github.com/assets/19714/339218/7a2bb5e8-9d30-11e2-9674-dc4a8ab1169c.jpg)
