### PR TITLE
Allow POST requests in the testing server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -67,6 +67,9 @@ Server.prototype = {
         app.get(/^(.+)$/, function(req, res){
             self.serveStaticFile(req.params[0], req, res)
         })
+        app.post(/^(.+)$/, function(req, res){
+            self.serveStaticFile(req.params[0], req, res)
+        })
     }
     , configureExpress: function(app){
         var self = this
@@ -74,6 +77,7 @@ Server.prototype = {
         app.configure(function(){
             app.engine("html", Mustache)
             app.set("view options", {layout: false})
+            app.use(Express.bodyParser())
             app.use(function(req, res, next){
                 if (self.ieCompatMode)
                     res.setHeader('X-UA-Compatible', 'IE=' + self.ieCompatMode)

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -100,6 +100,13 @@ describe('Server', function(){
     })
   })
 
+  it('gets a file using a POST request', function(done) {
+    request.post(baseUrl + 'web/hello.js', function(err, req, text) {
+      expect(text).to.equal(fs.readFileSync('tests/web/hello.js').toString())
+      done()
+    })
+  })
+
   function assertUrlReturnsFileContents(url, file, done){
     request(url, function(err, req, text){
       expect(text).to.equal(fs.readFileSync(file).toString())


### PR DESCRIPTION
In my tests I often do some network testing (AJAX stuff, HTML form submitting, ...) and I need to test POST requests as well. Right now the POST request are refused.

This small change should do the trick. I also tried to cover it in tests.
