### PR TITLE
Allow tests to be run from a subdirectory of a directory with spaces in it's name

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -223,7 +223,7 @@ Config.prototype.getFileSet = function(want, dontWant, callback){
   async.reduce(want, [], function(allThatIWant, patternEntry, next){
     var pattern = isa(patternEntry, String) ? patternEntry : patternEntry.src
     var attrs = patternEntry.attrs || []
-    fileset(pattern, dontWant, function(err, files){
+    fileset([self.resolvePath(pattern)], dontWant, function(err, files){
       if (err) return next(err, allThatIWant)
       next(null, allThatIWant.concat(files.map(function(f){
         f = self.reverseResolvePath(f)

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -200,6 +200,14 @@ describe('Config', function(){
 				done()
 			})
 		})
+		it('can read files from directories with spaces', function(done){
+			config.set('cwd', 'tests/space test/')
+			config.set('src_files', 'test.js')
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([fileEntry('test.js')])
+				done()
+			})
+		})
 		it('respects order', function(done){
 			config.set('src_files', [
 				'integration/browser_tests.bat',

--- a/tests/space test/test.js
+++ b/tests/space test/test.js
@@ -1,0 +1,3 @@
+function testSpaces() {
+	return "A test for spaces in the parent's directory name";
+}


### PR DESCRIPTION
Pass pattern to the fileset function as an array. Files with a space in the file name will not work in the src_files configuration option as that would conflict with the ability to pass multiple files as a space delimited string.
