### PR TITLE
Make keyboard commands and compile errors show up in the debug log

### DIFF
--- a/lib/dev_mode_app.js
+++ b/lib/dev_mode_app.js
@@ -198,7 +198,13 @@ App.prototype = {
           var errMsgs = StyledString('\n' + stdout).foreground('yellow')
             .concat(StyledString('\n' + stderr).foreground('red'))
           view.setErrorPopupMessage(title.concat(errMsgs))
-          log.log('error', titleText, { stdout: stdout, stderr: stderr })
+          log.log( 'warn'
+                 , titleText
+                 , { command: command
+                   , stdout: stdout
+                   , stderr: stderr
+                   }
+                 )
           return
         }else{
           view.clearErrorPopupMessage()


### PR DESCRIPTION
In debugging a deeper issue (testem often not finding any tests, rerunning and/or reseting after having run tests, before you could see the output), I am adding some events to the debug log that help navigate what is going on.

(If you are cool with these, I'll probably trickle in a few other info level messages too, that pick up on when and why tests reran, which is what I am really digging for at the moment.)
