### PR TITLE
allow exit code of tests to be detected by travis-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "tests"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha --timeout 3000 -R nyan tests/*_tests.js tests/ui/*_tests.js; cd ..",
+    "test": "./node_modules/.bin/mocha --timeout 3000 -R nyan tests/*_tests.js tests/ui/*_tests.js",
     "cover": "cover run ./node_modules/.bin/_mocha tests/*_tests.js tests/ui/*_tests.js; cover report html; open cover_html/index.html"
   },
   "devDependencies": {


### PR DESCRIPTION
It appears that travis-ci has been detecting the exit code of `cd ..` (which is always 0) instead of the result of running the tests for the project. As a result, travis-ci builds are always green.

This changed was made here. f1381f532b2eb09ee3602425efa9d731c5794137

In current master, there are some failing tests. https://travis-ci.org/airportyh/testem/jobs/6943429#L1477

```
1) SplitLogPanel targetPanel has both results and messages is the top if focused on top:
     Error: done() called multiple times
      at multiple (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runnable.js:177:31)
      at done (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runnable.js:183:26)
      at Object.Runnable.run.duration [as _onTimeout] (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runnable.js:199:9)
      at Timer.list.ontimeout (timers.js:101:19)
  2) SplitLogPanel scrolling delegates scrollDown to the target Panel:
     TypeError: Attempted to wrap targetPanel which is already wrapped
      at Object.wrapMethod (/home/travis/build/airportyh/testem/node_modules/sinon/lib/sinon.js:70:23)
      at Object.stub (/home/travis/build/airportyh/testem/node_modules/sinon/lib/sinon/stub.js:55:22)
      at Context.<anonymous> (/home/travis/build/airportyh/testem/tests/ui/split_log_panel_tests.js:181:15)
      at Test.Runnable.run (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runnable.js:213:32)
      at Runner.runTest (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:351:10)
      at Runner.runTests.next (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:397:12)
      at next (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:277:14)
      at Runner.hooks (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:286:7)
      at next (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:234:23)
      at Runner.hook (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:254:5)
      at process.startup.processNextTick.process._tickCallback (node.js:245:9)
  3) SplitLogPanel targetPanel has both results and messages "before each" hook:
     TypeError: Attempted to wrap hasResults which is already wrapped
      at Object.wrapMethod (/home/travis/build/airportyh/testem/node_modules/sinon/lib/sinon.js:70:23)
      at Object.stub (/home/travis/build/airportyh/testem/node_modules/sinon/lib/sinon/stub.js:55:22)
      at Context.describe.scrollUp scrollDown pageUp pageDown halfPageUp halfPageDown.split.forEach.targetPanel (/home/travis/build/airportyh/testem/tests/ui/split_log_panel_tests.js:157:15)
      at Hook.Runnable.run (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runnable.js:213:32)
      at next (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:243:10)
      at Runner.hook (/home/travis/build/airportyh/testem/node_modules/mocha/lib/runner.js:254:5)
      at process.startup.processNextTick.process._tickCallback (node.js:245:9)

The command "npm test" exited with 0.
```

This pull request fixes the ci issue locally. The test failures are not fixed here.
