### PR TITLE
zero tests should fail the test suite

### DIFF
--- a/lib/ci_mode_app.js
+++ b/lib/ci_mode_app.js
@@ -246,11 +246,19 @@ App.prototype = {
   }
   , outputTap: function(results, launcher){
     var producer = this.tapProducer
+    var tests = results.get('tests')
 
     console.log() // new line
-        
-    results.get('tests').forEach(function(test){
-      var testName = launcher ? 
+
+    if (tests.length === 0) {
+      this.failed = true
+      producer.results.bailedOut = true
+      // fake out TAP so that 0 tests is a failure
+      producer.results.testsTotal = {toString:function(){return '0'}}
+    }
+
+    tests.forEach(function(test){
+      var testName = launcher ?
         ' - ' + launcher.name + ' ' + test.get('name') :
         test.get('name')
       if (!test.get('failed')){
@@ -275,7 +283,6 @@ App.prototype = {
         if (item.stdout) line.stdout = item.stdout
         if (item.stderr) line.stderr = item.stderr
         producer.write(line)
-                
       }
     }.bind(this))
 

--- a/lib/ui/runner_tabs.js
+++ b/lib/ui/runner_tabs.js
@@ -72,6 +72,7 @@ var RunnerTab = exports.RunnerTab = View.extend({
       , 'tests-end': function(){
         self.stopSpinner()
         self.renderResults()
+        self.renderRunnerName()
         if (config.get('growl')){
           self.growlResults()
         }
@@ -91,10 +92,11 @@ var RunnerTab = exports.RunnerTab = View.extend({
             var passed = results.get('passed')
             var total = results.get('total')
             var allPassed = passed === total
+            var hasTests = total > 0
             var hasError = runner.get('messages').filter(function(m){
               return m.get('type') === 'error'
             }).length > 0
-            self.set('allPassed', allPassed && !hasError)
+            self.set('allPassed', allPassed && hasTests && !hasError)
           }
         }
         , 'change:all': function(){
@@ -133,7 +135,9 @@ var RunnerTab = exports.RunnerTab = View.extend({
     var runner = this.get('runner')
     var results = runner.get('results')
     var equal = results ? results.get('passed') === results.get('total') : true
-    return equal ? 'green' : 'red'
+    var hasTests = results.get('total') > 0
+    var success = hasTests && equal
+    return success ? 'green' : 'red'
   }
   , startSpinner: function(){
     this.stopSpinner()

--- a/tests/ui/runner_tabs_tests.js
+++ b/tests/ui/runner_tabs_tests.js
@@ -70,6 +70,45 @@ describe('RunnerTab', function(){
     })*/
   })
 
+  context('has no tests', function(){
+      beforeEach(function(){
+          screen.$setSize(20, 8)
+          results = new Backbone.Model()
+          runner = new Backbone.Model({
+            name: 'Bob'
+            , messages: new Backbone.Collection
+            , results: results
+          })
+          runner.hasMessages = function(){ return false }
+          appview = new Backbone.Model({currentTab: 0})
+          appview.app = {config: {}}
+          appview.isPopupVisible = function(){ return false }
+          tab = new RunnerTab({
+            runner: runner
+            , appview: appview
+            , selected: true
+            , index: 0
+            , screen: screen
+          })
+          results.set('all', true)
+          results.set('passed', 0)
+          results.set('total', 0)
+      })
+
+      it('renders failure-x', function(){
+          tab.render()
+          expect(screen.buffer).to.be.deep.equal([
+              '                    ',
+              '                    ',
+              '                    ',
+              ' ━━━━━━━━━━━━━━┓    ',
+              '       Bob     ┃    ',
+              '     0/0 ✘     ┃    ',
+              '               ┗    ',
+              '                    ' ])
+      })
+  })
+
   context('has results', function(){
     beforeEach(function(){
       screen.$setSize(20, 8)


### PR DESCRIPTION
There are times when you have a problem with your test setup, which can cause your tests to not be registered. When this happens, 0 tests are registered, and the test suite passes.

Test suites should not pass on 0 tests. It means that either (1) you just set up your test suite or (2) something went horribly wrong in your test setup. I can see where you may not want to show a failure to people in scenario (1), but I feel that saving users in scenario (2) seems like a much larger win.

This PR implements this for dev and ci modes. There are a few quirks of the implementation:
1. `lib/ci_mode_app.js:257` TAP has the same assumption that zero tests in a suite passes that suite. This works around that with a messy hack. Since you are already bundling tap in testem, perhaps this should be a change to that bundled version instead. Let me know what you think.
2. `lib/ui/runner_tabs.js:75` This code fixes an issue introduced by the rest of the changes that caused the launcher name in tabs to start out red (because of zero tests), then never turn green when the test suite finishes. This fixes that problem.
