### PR TITLE
testem ci: show only failed tests

### DIFF
--- a/lib/ci/test_reporter.js
+++ b/lib/ci/test_reporter.js
@@ -37,8 +37,8 @@ TestReporter.prototype = {
     ].join('\n')
   },
   display: function(prefix, result){
-    console.log(this.resultDisplay(prefix, result))
     if (result.error){
+      console.log(this.resultDisplay(prefix, result))
       console.log(this.errorDisplay(result.error))
     }
   },


### PR DESCRIPTION
this pull request is just to discuss the idea.

We are using `testem ci` for quick headless testing, but will hundreds of passed tests is quite verbose, so I'd like to have only the failed tests displayed. Is that possible at all, without breaking this TAP syntax? Sorry I've no clue about TAP, really.

But if it doesn't break it, I'm happy to add a CLI parameter for this mode, just let me know.
