### PR TITLE
Fix .travis.yml miss setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
 - 0.8
-- 0.10
+- "0.10"


### PR DESCRIPTION
It seems like to use node.js `0.1` on Travis CI.

https://travis-ci.org/airportyh/testem/builds/8809648
![](http://gyazo.com/8a5b5f372e04d350578cbbae63b29700.png)

I changed a value from `0.10` to `"0.10"`, it became like this.

https://travis-ci.org/kjirou/testem/builds/8814359
![](http://gyazo.com/a7f3535aafb22eecc314bfc23a4de55c.png)
