### PR TITLE
Fixes Underscore 1.5.0 _.bindAll(this) in Testem

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -40,7 +40,7 @@ var EventLogger = Backbone.Model.extend({
 } )
 
 var Api = function() {
-  _.bindAll( this, _.functions(this) )
+  _.bindAll.apply(_, [this].concat(_.functions(this)))
 }
 
 Api.prototype.setup = function(mode, dependency){


### PR DESCRIPTION
- the 1.5.0 release of underscore removed the ability to use _.bindAll
  without enumerating any method names; this commit is the intended way
  to get the same behaviour as documented in https://github.com/documentcloud/underscore/commit/bf657be243a075b5e72acc8a83e6f12a564d8f55
