### PR TITLE
Feature: allow configuring Socket.io to connect from different server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -143,6 +143,7 @@ Server.prototype = {
     res.setHeader('Content-Type', 'text/javascript')
 
     res.write(';(function(){')
+    res.write('var socketConnectionPath = "' + req.protocol + '://' + req.host + ':' + this.config.get('port') + '";')
     var files = [
       'socket.io.js'
       , 'json2.js'

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -183,7 +183,7 @@ function getId(){
 function init(){
     takeOverConsole()
     interceptWindowOnError()
-    socket = io.connect()
+    socket = io.connect(socketConnectionPath)
     var id = getId()
     socket.emit('browser-login', 
         getBrowserName(navigator.userAgent), 


### PR DESCRIPTION
We wanted to continue to use the socket connection to send back the test results to the testem server from within our Django single page app running on a different port, so this change makes sure the socket connects on the right port.

i.e. pull in testem.js being served at localhost:9090/testem.js on a page served at localhost:8080, and it'll connect to the socket on localhost:9090.
