### PR TITLE
report the presence of pending tests

### DIFF
--- a/lib/test_results.js
+++ b/lib/test_results.js
@@ -9,6 +9,7 @@ var TestResults = Backbone.Model.extend({
       topLevelError: null
       , failed: 0
       , passed: 0
+      , pending: 0
       , total: 0
       , tests: new Backbone.Collection
       , all: false
@@ -16,15 +17,19 @@ var TestResults = Backbone.Model.extend({
   }
   , addResult: function(result){
     var total = this.get('total')
+      , pending = this.get('pending')
       , passed = this.get('passed')
       , failed = this.get('failed')
     total++
-    if (result.failed == 0)
+    if (result.pending)
+      pending++
+    else if (result.failed == 0)
       passed++
     else
       failed++
     this.set({
       total: total
+      , pending: pending
       , passed: passed
       , failed: failed
       , items: result.items

--- a/lib/ui/runner_tabs.js
+++ b/lib/ui/runner_tabs.js
@@ -91,7 +91,8 @@ var RunnerTab = exports.RunnerTab = View.extend({
           }else{
             var passed = results.get('passed')
             var total = results.get('total')
-            var allPassed = passed === total
+            var pending = results.get('pending')
+            var allPassed = (passed + pending) === total
             var hasTests = total > 0
             var failCuzNoTests = !hasTests && config.get('fail_on_zero_tests')
             var hasError = runner.get('messages').filter(function(m){
@@ -138,11 +139,18 @@ var RunnerTab = exports.RunnerTab = View.extend({
     var config = appview.app.config
     var runner = this.get('runner')
     var results = runner.get('results')
-    var equal = results ? results.get('passed') === results.get('total') : true
-    var hasTests = results ? results.get('total') > 0 : false
+    var equal = true
+    var hasTests = false
+    if (results) {
+      var passed = results.get('passed')
+      var pending = results.get('pending')
+      var total = results.get('total')
+      var equal = (passed + pending) === total
+      var hasTests = total > 0
+    }
     var failCuzNoTests = !hasTests && config.get('fail_on_zero_tests')
     var success = !failCuzNoTests && equal
-    return success ? 'green' : 'red'
+    return success ? (pending ? 'yellow' : 'green') : 'red'
   }
   , startSpinner: function(){
     this.stopSpinner()
@@ -201,8 +209,16 @@ var RunnerTab = exports.RunnerTab = View.extend({
     var col = this.col + index * width
     var runner = this.get('runner')
     var results = runner.get('results')
-    var resultsDisplay = results ? results.get('passed') + '/' + results.get('total') : ''
-    var equal = results ? results.get('passed') === results.get('total') : true
+    var resultsDisplay = ''
+    var equal = true
+
+    if (results) {
+      var total = results.get('total')
+      var passed = results.get('passed')
+      var pending = results.get('pending')
+      resultsDisplay = passed + '/' + total
+      equal = (passed + pending) === total
+    }
 
     if (results && results.get('all')){
       resultsDisplay += ' ' + ((this.get('allPassed') && equal) ? Chars.success : Chars.fail)
@@ -230,7 +246,8 @@ var RunnerTab = exports.RunnerTab = View.extend({
     var runner = this.get('runner')
     var results = runner.get('results')
     var name = runner.get('name')
-    var resultsDisplay = results ? (results.get('passed') + '/' + results.get('total')) : 'finished'
+    var resultsDisplay = results
+      ? (results.get('passed') + '/' + results.get('total')) : 'finished'
     var msg = "Test'em : " + name + ' : ' + resultsDisplay
     growl(msg)
   }

--- a/lib/ui/split_log_panel.js
+++ b/lib/ui/split_log_panel.js
@@ -202,6 +202,7 @@ var SplitLogPanel = module.exports = View.extend({
     var topLevelError = results ? results.get('topLevelError') : null
     var tests = null
     var out = ''
+    var pendingOut = ''
 
     if (topLevelError){
       out += "Top Level:\n" + indent(topLevelError) + '\n\n'
@@ -209,6 +210,7 @@ var SplitLogPanel = module.exports = View.extend({
 
     if (results && (tests = results.get('tests'))){
       var total = results.get('total')
+      var pending = results.get('pending')
       var allDone = results.get('all')
       if (!total){
         out = allDone ? 'No tests were run :(' : 'Please be patient :)'
@@ -220,7 +222,16 @@ var SplitLogPanel = module.exports = View.extend({
            out += failedTests.map(failedTestDisplay).join('\n')
         }else{ // All passed
           if (allDone){
-            out += Chars.success + ' ' + total + ' tests complete.'
+            var pendingTests = tests.filter(function(test){
+              return test.get('pending') > 0
+            })
+            out += Chars.success + ' ' + total + ' tests complete (' + pending + ' pending).'
+            if (pending){
+              pendingOut += '\n\n'
+              pendingOut += pendingTests.map(function(test) {
+                return '[PENDING] ' + test.get('name')
+              }).join('\n')
+            }
           }else{
             out += 'Looking good...'
           }
@@ -229,6 +240,7 @@ var SplitLogPanel = module.exports = View.extend({
     }
 
     return StyledString(out, {foreground: 'cyan'})
+      .append(StyledString(pendingOut, {foreground: 'yellow'}))
   }
   , getMessagesText: function(){
     var messages = this.get('runner').get('messages')

--- a/public/testem/buster_adapter.js
+++ b/public/testem/buster_adapter.js
@@ -17,6 +17,7 @@ function busterAdapter(socket){
         failed: 0
         , passed: 0
         , total: 0
+        , pending: 0
         , tests: []
     }
 
@@ -36,6 +37,7 @@ function busterAdapter(socket){
             passed: 1
             , failed: 0
             , total: 1
+            , pending: 0
             , id: id++
             , name: currContext ? (currContext.name + ' ' + test.name) : test.name
         }
@@ -49,6 +51,7 @@ function busterAdapter(socket){
             passed: 0
             , failed: 1
             , total: 1
+            , pending: 0
             , id: id++
             , name: currContext ? (currContext.name + ' ' + test.name) : test.name
             , items: [{    
@@ -62,10 +65,24 @@ function busterAdapter(socket){
         results.total++
     }
 
+    function onDeferred(test){
+        var test = {
+            passed: 0
+            , failed: 0
+            , total: 1
+            , pending: 1
+            , id: id++
+            , name: currContext ? (currContext.name + ' ' + test.name) : test.name
+        }
+        emit('test-result', test)
+        results.total++
+    }
+
     runner.on('test:success', onSuccess)
     runner.on('test:failure', onFailure)
     runner.on('test:error', onFailure)
     runner.on('test:timeout', onFailure)
+    runner.on('test:deferred', onDeferred)
 
     runner.on('suite:end', function(){
         emit('all-test-results', results)

--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -13,6 +13,7 @@ function mochaAdapter(socket){
 		{ failed: 0
 	    , passed: 0
 	    , total: 0
+	    , pending: 0
 	    , tests: []
 		}
 	var id = 1
@@ -46,6 +47,7 @@ function mochaAdapter(socket){
 					{ passed: 1
 					, failed: 0
 					, total: 1
+					, pending: 0
 					, id: id++
 					, name: name
 					, items: []
@@ -65,11 +67,25 @@ function mochaAdapter(socket){
 					{ passed: 0
 					, failed: 1
 					, total: 1
+					, pending: 0
 					, id: id++
 					, name: name
 					, items: items
 					}
 				results.failed++
+				results.total++
+				results.tests.push(tst)
+				emit('test-result', tst)
+			}else if (test.pending){
+				var tst =
+				{ passed: 0
+				, failed: 0
+				, total: 1
+				, pending: 1
+				, id: id++
+				, name: name
+				, items: []
+				}
 				results.total++
 				results.tests.push(tst)
 				emit('test-result', tst)

--- a/tests/browser_runner_tests.js
+++ b/tests/browser_runner_tests.js
@@ -37,6 +37,7 @@ describe('BrowserRunner', function(){
       results.reset()
       expect(results.get('total')).to.equal(0)
       expect(results.get('passed')).to.equal(0)
+      expect(results.get('pending')).to.equal(0)
     })
   })
   it('emits start-tests and resets when startTests', function(){
@@ -63,7 +64,9 @@ describe('BrowserRunner', function(){
     expect(results.get('failed')).to.equal(1)
     socket.emit('test-result', {failed: 0})
     expect(results.get('passed')).to.equal(1)
-    expect(results.get('tests').length).to.equal(2)
+    socket.emit('test-result', {pending: 1})
+    expect(results.get('pending')).to.equal(1);
+    expect(results.get('tests').length).to.equal(3)
   })
   it('sets "all" on all-tests-results', function(){
     socket.emit('all-test-results')

--- a/tests/ui/runner_tabs_tests.js
+++ b/tests/ui/runner_tabs_tests.js
@@ -94,6 +94,7 @@ describe('RunnerTab', function(){
           results.set('all', true)
           results.set('passed', 0)
           results.set('total', 0)
+          results.set('pending', 0)
       })
 
       it('renders failure-x', function(){
@@ -107,6 +108,10 @@ describe('RunnerTab', function(){
               '     0/0 ✘     ┃    ',
               '               ┗    ',
               '                    ' ])
+      })
+
+      it('renders the tab red', function(){
+          expect(tab.color()).to.equal('red')
       })
   })
 
@@ -133,7 +138,8 @@ describe('RunnerTab', function(){
     })
     it('renders test results', function(done){
       results.set('passed', 1)
-      results.set('total', 1)
+      results.set('total', 2)
+      results.set('pending', 1)
       process.nextTick(function(){
         expect(screen.buffer).to.be.deep.equal([
           '                    ',
@@ -141,16 +147,17 @@ describe('RunnerTab', function(){
           '                    ',
           ' ━━━━━━━━━━━━━━┓    ',
           '       Bob     ┃    ',
-          '     1/1 ◞     ┃    ',
+          '     1/2 ◞     ┃    ',
           '               ┗    ',
           '                    ' ])
         done()
       })
     })
-    it('renders check mark if all passed', function(){
+    it('renders check mark if none failed', function(){
       results.set({
         passed: 1
-        , total: 1
+        , total: 2
+        , pending: 1
         , all: true
       })
       expect(screen.buffer).to.be.deep.equal([ 
@@ -159,11 +166,32 @@ describe('RunnerTab', function(){
         '                    ',
         ' ━━━━━━━━━━━━━━┓    ',
         '       Bob     ┃    ',
-        '     1/1 ✔     ┃    ',
+        '     1/2 ✔     ┃    ',
         '               ┗    ',
         '                    ' ])
     })
-
+    context('when there are no pending tests', function(){
+      it('renders the tab green', function(){
+        results.set({
+          passed: 1
+          , pending: 0
+          , total: 1
+          , all: true
+        })
+        expect(tab.color()).to.equal('green')
+      })
+    })
+    context('when there are pending tests', function(){
+      it('renders the tab yellow', function(){
+        results.set({
+          passed: 0
+          , pending: 1
+          , total: 1
+          , all: true
+        })
+        expect(tab.color()).to.equal('yellow')
+      })
+    })
   })
 })
 

--- a/tests/ui/split_log_panel_tests.js
+++ b/tests/ui/split_log_panel_tests.js
@@ -50,12 +50,35 @@ describe('SplitLogPanel', function(){
     })
     it('gives result when has results and all is true', function(){
       results.set('total', 1)
+      results.set('pending', 0)
       var tests = new Backbone.Collection([
         new Backbone.Model({ name: 'blah', passed: true })
       ])
       results.set('tests', tests)
       results.set('all', true)
-      expect(panel.getResultsDisplayText().unstyled()).to.equal('✔ 1 tests complete.')
+      expect(panel.getResultsDisplayText().unstyled()).to.equal('✔ 1 tests complete (0 pending).')
+    })
+    it('shows pending tests in yellow when has results, all is true, no tests failed and there are pending tests', function(){
+      results.set('total', 1)
+      results.set('pending', 1)
+      var tests = new Backbone.Collection([
+        new Backbone.Model({ name: 'blah', pending: true })
+      ])
+      results.set('tests', tests)
+      results.set('all', true)
+
+      var text = panel.getResultsDisplayText()
+
+      expect(text.children).to.have.length(2)
+
+      var resultText = text.children[0]
+      var pendingText = text.children[1]
+
+      expect(resultText.str).to.equal('✔ 1 tests complete (1 pending).')
+      expect(resultText.attrs.foreground).to.equal('cyan')
+
+      expect(pendingText.str).to.equal('\n\n[PENDING] blah')
+      expect(pendingText.attrs.foreground).to.equal('yellow')
     })
     it('shows "failed" when failure', function(){
       results.set('total', 1)


### PR DESCRIPTION
I find it helpful to see if there are pending (not yet implemented) tests and, if so, which.

If no test fails and there are pending tests, tabs will be rendered yellow, and the names of those tests (also in yellow) will be listed inside the log panel.

Unfortunately this currently only works with Buster and Mocha because they actually report pending tests.
Jasmine does not report any pending tests but rather excludes them entirely from the run.
And QUnit has no notion of pending tests at all.
