### PR TITLE
Support CI specific hooks by prefixing the regular hook with "_ci"

### DIFF
--- a/lib/ci/hook_runner.js
+++ b/lib/ci/hook_runner.js
@@ -8,7 +8,7 @@ function HookRunner(config, Proc){
 }
 HookRunner.prototype = {
   run: function(hook, callback){
-    var hookCfg = this.config.get(hook)
+    var hookCfg = this.config.get(hook + '_ci') || this.config.get(hook)
     if (!hookCfg){
       return callback(null)
     }


### PR DESCRIPTION
For example, so you can have an on_start configuration for development and a different one for CI

A suggestion in the form of a pull request. It may be that, more generally, different configuration sets can be specified with a command-line switch that would allow all of the config's root keys to be suffixed so you change configuration easily. Obviously you can use separate conf files, but often there will be a lot of shared content. Perhaps it would be an alternative to allow multiple conf files to be specified and they could be merged... that would negate the need for this approach, although this may be more convenient.
