### PR TITLE
IE6 compatibility: htmlfile socket.io transport doesn't work

### DIFF
--- a/public/testem/socket.io.js
+++ b/public/testem/socket.io.js
@@ -2596,11 +2596,13 @@ var io = {};
     this.socket.setBuffer(true);
 
     function stateChange () {
-      if (this.readyState == 4) {
-        this.onreadystatechange = empty;
+      /* "this" is not the XHR on IE6, it is the window */
+      var thisXHR = self.sendXHR;
+      if (thisXHR.readyState == 4) {
+        thisXHR.onreadystatechange = empty;
         self.posting = false;
 
-        if (this.status == 200){
+        if (thisXHR.status == 200){
           self.socket.setBuffer(false);
         } else {
           self.onClose();


### PR DESCRIPTION
I have had IE6 tests fail to report their results due to a fault in socket.io. IE6 would connect and run tests but not report any results back to testem.

The stateChange() handler (see patch) has this === window rather than this === sendXHR as is expected. So it fails in its check for readyState == 4 and thus never sets buffer to false.

I have tested the other onreadystatechange handlers in the socket.io.js file and they do not suffer from this issue. When using the htmlfile transport there seem to be a few different technologies being used... a bit confusing.

I wanted to investigate whether this is a fault in the main socket.io but I actually couldn't easily find where this piece of code came from... it is a few versions behind.

I was able to reproduce the original bug using my own IE6 in a VM and using BrowserStack.
