### PR TITLE
Allow empty file progOption to ease programmatic access

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -3,15 +3,39 @@ var Config = require('./config')
 var Backbone = require('backbone')
 
 /*
-  progOptions:
-  file: test file
-  port: 7357
-  launch: list of launchers to use
-  skip: list of launchers to skip
-  test_page: the page to use to run tests
-  timeout: timeout for a browser
-  framework: test framework to use
-  src_files: list of files or file patterns
+  CLI-level options:
+
+  file:                 [String]  configuration file (testem.json, .testem.json, testem.yml, .testem.yml)
+  host:                 [String]  server host to use (localhost)
+  port:                 [Number]  server port to use (7357)
+  launch:               [Array]   list of launchers to use for current runs (defaults to current mode)
+  skip:                 [Array]   list of launchers to skip
+  debug:                [Boolean] debug mode (false)
+  test_page:            [String]  path to the page to use to run tests
+  growl:                [Boolean] enables growl (false)
+
+  Config-level options:
+
+  launch_in_dev:        [Array]   list of launchers to use for dev runs
+  launch_in_ci:         [Array]   list of launchers to use for CI runs
+  timeout:              [Number]  timeout for a browser
+  framework:            [String]  test framework to use
+  url:                  [String]  url server runs at (http://{host}:{port}/)
+  src_files:            [Array]   list of files or file patterns to use
+  serve_files:          [Array]   list of files or file patterns to inject into test playground (defaults to src_files)
+  watch_files:          [Array]   list of files or file patterns to watch changes of (defaults to src_files)
+  css_files:            [Array]   additionals stylesheets to include
+  cwd:                  [Path]    directory to use as root
+  parallel:             [Number]  max number of parallel runners (1)
+  routes:               [Hash]    overrides for assets paths
+  fail_on_zero_tests:   [Boolean] whether process should exit with error status when no tests found
+
+  Available hooks:
+
+  on_start:             Runs on suite startup
+  before_tests:         Runs before every run of tests
+  after_tests:          Runs after every run of tests
+  on_exit:              Runs before suite exits
 */
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -66,7 +66,9 @@ Config.prototype.cwd = function(){
 
 Config.prototype.readConfigFile = function(configFile, callback){
   var self = this
-  if (configFile.match(/\.json$/)){
+  if (!configFile){ // allow empty configFile for programmatic setups
+    if (callback) callback.call(self)
+  }else if (configFile.match(/\.json$/)){
     this.readJSON(configFile, callback)
   }else if (configFile.match(/\.yml$/)){
     this.readYAML(configFile, callback)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "jsdom": "~0.5.2",
     "bodydouble": "~0.1.1",
     "ispy": "~0.1.1",
-    "concat-stream": "~1.0.0"
+    "concat-stream": "~1.0.0",
+    "sinon": "~1.7.3"
   },
   "bin": {
     "testem": "./testem.js"

--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -1,0 +1,24 @@
+var Api = require('../lib/api')
+var sinon = require('sinon')
+var Config = require('../lib/config')
+var expect = require('chai').expect
+
+describe('Api', function(){
+
+  beforeEach(function(){
+    sinon.stub(Config.prototype, 'read')
+  })
+
+  afterEach(function(){
+    Config.prototype.read.restore()
+  })
+
+  it('forwards config', function(){
+    var api = new Api()
+    api.startDev({parallel: 5, on_exit: "test"})
+    expect(api.config.read.callCount).to.equal(1)
+    expect(api.config.get('on_exit')).to.equal('test')
+    expect(api.config.get('parallel')).to.equal(5)
+  })
+
+})

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -28,6 +28,19 @@ describe('Config', function(){
 		expect(config.get('file')).to.equal(progOptions.file)
 	})
 
+	describe('accepts empty config file', function(){
+		var config
+		beforeEach(function(done){
+			var progOptions = {framework: 'mocha', src_files: 'impl.js,tests.js'}
+			config = new Config('dev', progOptions)
+			config.read(done)
+		})
+		it('gets properties from config file', function(){
+			expect(config.get('framework')).to.equal('mocha')
+			expect(String(config.get('src_files'))).to.equal('impl.js,tests.js')
+		})
+	})
+
 	describe('read yaml config file', function(){
 		beforeEach(function(done){
 			config.read(done)


### PR DESCRIPTION
Testem is not very friendly for external programmatic access right now. It's a real pain i.e. to implement grunt-base wrapper around it. Here's the first small step towards better API – an ability to omit `progOptions.file` to make it do nothing without errors. Additionally I've refreshed comments containing the list of available options and added some tests ensuring config data gets passed well.
