### PR TITLE
URIs allowed for src_files and serve_files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,7 @@ var pad = require('./strutils').pad
 var isa = require('./isa')
 var fileset = require('fileset')
 var fileExists = fs.exists || path.exists
+var url = require('url')
 
 function Config(appMode, progOptions, config){
   this.appMode = appMode
@@ -253,6 +254,14 @@ Config.prototype.getFileSet = function(want, dontWant, callback){
   async.reduce(want, [], function(allThatIWant, patternEntry, next){
     var pattern = isa(patternEntry, String) ? patternEntry : patternEntry.src
     var attrs = patternEntry.attrs || []
+    var patternUrl = url.parse(pattern)
+
+    if (patternUrl.protocol == 'file:'){
+      pattern = patternUrl.hostname+patternUrl.path
+    } else if (patternUrl.protocol){
+      return next(null, allThatIWant.concat({src: pattern, attrs: attrs}))
+    }
+
     fileset([self.resolvePath(pattern)], dontWant, function(err, files){
       if (err) return next(err, allThatIWant)
       next(null, allThatIWant.concat(files.map(function(f){

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -288,6 +288,19 @@ describe('Config', function(){
 				done()
 			})
 		})
+		it('allows URLs', function(done){
+			config.set('src_files', [
+				'file://integration/*', 'http://codeorigin.jquery.com/jquery-2.0.3.min.js'
+			])
+			config.getSrcFiles(function(err, files){
+				expect(files).to.deep.equal([
+					fileEntry('integration/browser_tests.bat'),
+					fileEntry('integration/browser_tests.sh'),
+					fileEntry('http://codeorigin.jquery.com/jquery-2.0.3.min.js')
+				])
+				done()
+			})
+		})
 	})
 
 	describe('getServeFiles', function(){


### PR DESCRIPTION
Sometimes it can be useful to allow direct inclusion of scripts that are outside of your project (or are getting served with another building server from another local port). This tiny patch allows usage of properly-built URIs with `src_files` and `serve_files`.

It carefully handles `file:` URI scheme so this also is a semantic improvement.

Test included.
