### PR TITLE
Ability to programmatically override process termination for CI mode

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -88,9 +88,9 @@ Api.prototype.configureLogging = function(){
   }
 }
 
-Api.prototype.startDev = function(options){
+Api.prototype.startDev = function(options, finalizer){
   this.options = options
-  this.setup('dev', './dev_mode_app.js')
+  this.setup('dev', './dev_mode_app.js', finalizer)
 }
 
 Api.prototype.restart = function() {

--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -139,10 +139,9 @@ App.prototype = {
   },
 
   exit: function(){
-    if (!this.exited) {
-      this.cleanExit(this.getExitCode())
-      this.exited = true
-    }
+    if (this.exited) return
+    this.cleanExit(this.getExitCode())
+    this.exited = true
   }
 }
 

--- a/lib/dev_mode_app.js
+++ b/lib/dev_mode_app.js
@@ -20,9 +20,11 @@ var Launcher = require('./launcher')
 var BaseApp = require('./base_app')
 var StyledString = require('styled_string')
 
-function App(config){
+function App(config, finalizer){
   var self = this
   BaseApp.call(this, config)
+  this.exited = false
+  this.finalizer = finalizer || process.exit
   this.fileWatcher = new FileWatcher
   this.fileWatcher.on('change', this.onFileChanged.bind(this))
   this.fileWatcher.on('emfile', this.onEMFILE.bind(this))
@@ -183,6 +185,8 @@ App.prototype = {
     this.connectBrowser(browserName, id, client)
   }
   , quit: function(code, err){
+    if (this.exited) return
+
     var self = this
     this.emit('exit')
     this.cleanUpLaunchers(function(){
@@ -191,7 +195,8 @@ App.prototype = {
         else die()
         function die(){
           if (err) console.error(err.stack)
-          process.exit(code)
+          self.finalizer(code)
+          self.exited = true
         }
       })
     })


### PR DESCRIPTION
For the cases when Testem is running inside another toolbelt, it's inappropriate to directly shut process down. This PR adds ability to override finalization routine with custom JS callback. With this it's now possible to execute a pack of Testem runs with different configurations from one process.
