### PR TITLE
Adding sunos (SmartOS) support

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -221,6 +221,17 @@ function browsersForPlatform(){
         supported: findableByWhich
       }
     ]
+  }else if (platform === 'sunos') {
+	return [
+      {
+        name: 'PhantomJS',
+        exe: 'phantomjs',
+        args: function(app){
+          return [path.dirname(__dirname) + '/assets/phantom.js', this.getUrl()]
+        },
+        supported: findableByWhich
+      }
+	];
   }else{
     return []
   }


### PR DESCRIPTION
I'd love to use testem on SmartOS. I have no idea what other browsers would be supported, but I'm pretty sure that the most common use case (JoyentCloud) would be headless and phantomjs works great on their platform.
