### PR TITLE
Checking to make sure the server starts before continuing

### DIFF
--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -44,8 +44,10 @@ App.prototype = {
     }.bind(this))
   },
   startServer: function(callback){
-    log.info('Starting server')
-    this.server.start()
+    log.info('Starting server');
+    this.server.start(function(err) {
+      callback(err);
+    });
     this.server.once('server-start', function(){
       callback(null)
     }.bind(this))

--- a/lib/dev_mode_app.js
+++ b/lib/dev_mode_app.js
@@ -40,7 +40,9 @@ function App(config){
       on('file-requested', this.onFileRequested.bind(this))
       on('browser-login', this.onBrowserLogin.bind(this))
     }
-    this.server.start()
+    this.server.start(function(err) {
+      this.quit(1, err);
+    }.bind(this))
   })
 
   process.on('uncaughtException', function(err){

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,17 +33,20 @@ function Server(config){
 }
 Server.prototype = {
   __proto__: EventEmitter.prototype
-  , start: function(){
+  , start: function(errorCallback){
     this.createExpress()
     // Start the server!
     // Create socket.io sockets
     this.server = http.createServer(this.express)
     this.io = SocketIO.listen(this.server)
     this.io.sockets.on('connection', this.onClientConnected.bind(this))
-    this.server.listen(this.config.get('port'))
-    process.nextTick(function(){
+    this.server.on('listening', function() {
       this.emit('server-start')
-    }.bind(this))
+    }.bind(this));
+    this.server.on('error', function(e) {
+      errorCallback(e);
+    });
+    this.server.listen(this.config.get('port'))
   }
   , stop: function(callback){
     this.server.close(callback)


### PR DESCRIPTION
If another process was already bound to port 7357, the built-in HTTP
server would fail to start up. This wasn't detected, so PhantomJS was
started anyway, and would try connecting to whatever process already
had 7357 open. And then everything would hang.

The error reporting here could probably use some improvement, but this
is enough to prevent it from hanging (which is brutal in CI mode).
