### PR TITLE
Strip quotes and ampersands from xunit testcase names

### DIFF
--- a/lib/ci/test_reporters/xunit_reporter.js
+++ b/lib/ci/test_reporters/xunit_reporter.js
@@ -40,16 +40,17 @@ XUnitReporter.prototype = {
     var launcher = result.launcher
     result = result.result
     var error = result.error
+    var testname = result.name.replace(/\"|\&/g, '')
     if (error){
       return '  <testcase name="' +
-        launcher + ' ' + result.name + '">' +
-        '<failure name="' + result.name + '" ' +
+        launcher + ' ' + testname + '">' +
+        '<failure name="' + testname + '" ' +
         'message="' + error.message + '">' +
         (!error.stack ? '' : '<![CDATA[' + error.stack + ']]') +
         '</failure></testcase>'
     }else{
       return '  <testcase name="' +
-        launcher + ' ' + result.name + '"/>'
+        launcher + ' ' + testname + '"/>'
     }
   },
   failures: function(){


### PR DESCRIPTION
We're getting XML errors with xunit output related to double quotes and entities like &amp;nbsp showing up in our test names. In this pull request I've updated the xunit reporter to strip those out of the testcase name attribute, which resolves our XML parsing errors.
