### PR TITLE
Use the YAMLish soft wraps format in the tap_reporter.js

### DIFF
--- a/lib/ci/test_reporters/tap_reporter.js
+++ b/lib/ci/test_reporters/tap_reporter.js
@@ -25,7 +25,7 @@ TapReporter.prototype = {
         return key !== 'passed'
       })
       .map(function(key){
-        return key + ': "' + err[key] + '"'
+        return key + ': >\n' + strutils.indent(err[key])
       })
     return strutils.indent([
       '---',


### PR DESCRIPTION
This code can enable to use error messages in the TAP safely.

The original code wraps error messages by using (").
In some case Jenkins TAP plugin raises ParserException.
This code use  the YAMLish soft wraps format instead.
# http://testanything.org/wiki/index.php/YAMLish

Example: Invalid TAP output

```
not ok 1 Browser - test
    ---
        stack: "line1
        .cache["dojo/aspect"] ...
        "
    ...
1..1
# tests 1
# pass  0
# fail  1
```

(can confirm by http://instanttap.appspot.com/ )
