### PR TITLE
Pass arguments to the reporter constructor

### DIFF
--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -16,13 +16,17 @@ function App(config, finalizer){
   this.server = new Server(this.config)
   this.cleanExit = finalizer || cleanExit
   var reporterName = this.config.get('reporter')
-  var TestReporter = test_reporters[reporterName]
-  if (!TestReporter){
-    console.error('Test reporter `' + reporterName + '` not found.')
-    this.cleanExit(1)
-    return
+  if (typeof reporterName === "string") {
+    var TestReporter = test_reporters[reporterName]
+    if (!TestReporter){
+      console.error('Test reporter `' + reporterName + '` not found.')
+      this.cleanExit(1)
+      return
+    }
+    this.reporter = new TestReporter
+  } else {
+    this.reporter = reporterName
   }
-  this.reporter = new TestReporter
   this.Process = Process
   this.hookRunners = {}
   this.results = []


### PR DESCRIPTION
This allows to pass arguments to the test reporter constructor from the configuration object.

In my use case I'm trying to use `testem` as a normal node module.
I can `require('testem')` and set most of the configuration options I need.

However it's impossible to specify the arguments of the test reporter constructor.

Main reason why I need this is because I'm trying to drive testem from a script and I can't `spawn` processes because stdout is not drained correctly in node 0.10 and testem never exits.
