### PR TITLE
Wrong browser ID when test page starts with a number

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -178,7 +178,7 @@ var addListener = window.addEventListener ?
     function(obj, evt, cb){ obj.attachEvent('on' + evt, cb) }
 
 function getId(){
-    var m = location.href.match(/^.+\/([0-9]+)/)
+    var m = location.href.match(/^.+\/([0-9]+)\//)
     return m ? m[1] : null
 }
 


### PR DESCRIPTION
Hi, I'm not sure whether this should be fixed or not :smile: but I spent some time to understand what was wrong with my test pages, so here's a fix.

When the test page starts with a number (e.g. `1.html`) the browser computes the wrong id thus preventing correct communication through the socket.

The fix is trivial and simply checks that there's another slash after the id.

This won't be enough when the user wants test pages like this `/tests/1234/test_page.html`

I tried to write a test for this, but when I run `npm test` on windows I get many errors, so I gave up :tongue: 

This issues doesn't necessarily have to be fixed. It's enough that people are aware that putting numbers in the test page is not a good idea.
