### PR TITLE
Handle connection reset error - ECONNRESET

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -78,8 +78,8 @@ Server.prototype = {
     app.get(/^(.+)$/, serveStaticFile)
     app.post(/^(.+)$/, serveStaticFile)
 
-    function serveStaticFile(req, res){
-      self.serveStaticFile(req.params[0], req, res)
+    function serveStaticFile(req, res, next){
+      self.serveStaticFile(req.params[0], req, res, next)
     }
   }
   , configureExpress: function(app){
@@ -139,13 +139,13 @@ Server.prototype = {
       })
     }
   }
-  , serveHomePage: function(req, res){
+  , serveHomePage: function(req, res, next){
     var config = this.config
     var routes = config.get('routes') || config.get('route') || {}
     if (routes['/']){
-      this.serveStaticFile('/', req, res)
+      this.serveStaticFile('/', req, res, next)
     }else{
-      this.renderDefaultTestPage(req, res)
+      this.renderDefaultTestPage(req, res, next)
     }
   }
   , serveTestemClientJs: function(req, res){
@@ -203,7 +203,7 @@ Server.prototype = {
       , uri: bestMatch || uri.substring(1)
     }
   }
-  , serveStaticFile: function(uri, req, res){
+  , serveStaticFile: function(uri, req, res, next){
     var self = this
     var config = this.config
     var routeRes = this.route(uri)
@@ -233,7 +233,12 @@ Server.prototype = {
             res.render(dirListingPage, {files: files})
           })
         }else{
-          res.sendfile(filePath)
+          res.sendfile(filePath, function (err) {
+            if (err && err.code != "ECONNRESET") {
+              next(err);
+            }
+            // else ignore ECONNRESET error and messages with no error
+          })
         }
       })   
     }


### PR DESCRIPTION
This is going to be hard to explain...

I get a weird error when I try to run multiple testem in sequence only on Internet Explorer.
The error happens randomly and is rather generic `Fatal error: Can't set headers after they are sent.`

Background: I use [testem-multi](https://github.com/sideroad/testem-multi) to run multiple instances of testem in sequence. What it does is scanning my test folder and generate a `testem.json` file for each `index.html`, then it requires testem as a module and launches it in continous integration.
This was working perfectly fine in node 0.8 but sometimes it goes in error when running tests in Internet Explorer on node 0.10

Using longjhon I get a more useful error description

```
Error: read ECONNRESET
    at errnoException (net.js:901:11)
    at onread (net.js:556:19)
---------------------------------------------
    at Readable.on (_stream_readable.js:689:33)
    at res.sendfile (c:\myproject\node_modules\grunt-testem\node_modules\testem-multi\node_modules\testem\node_modules\express\lib\response.js:299:14)
    at c:\myproject\node_modules\grunt-testem\node_modules\testem-multi\node_modules\testem\lib\server.js:266:15
    at Object.oncomplete (fs.js:107:15)
```

I tracked done the issue and the error is raised when the browser is killed at the end of tests while it's still trying to download some resources.
In my environment this happens usually for some images or css files.

Why is this happening only on Internet Explorer? Probably because it's the only browser than when killed is sending a connection reset.
Why only on node 0.10? Probably [because of this](http://stackoverflow.com/questions/17245881/node-js-econnreset)

The fix for my use case is to add a callback on `sendFile`, this method is used to manually handle errors. In case of 'ECONNRESET' I simply ignore it.

Sorry but I can't provide an example where to reproduce the error nor a test case :cry: 
