### PR TITLE
Fix xunit_reporter generating invalid xml.

### DIFF
--- a/lib/ci/test_reporters/xunit_reporter.js
+++ b/lib/ci/test_reporters/xunit_reporter.js
@@ -46,7 +46,7 @@ XUnitReporter.prototype = {
         launcher + ' ' + testname + '">' +
         '<failure name="' + testname + '" ' +
         'message="' + error.message + '">' +
-        (!error.stack ? '' : '<![CDATA[' + error.stack + ']]') +
+        (!error.stack ? '' : '<![CDATA[' + error.stack + ']]>') +
         '</failure></testcase>'
     }else{
       return '  <testcase name="' +


### PR DESCRIPTION
I noticed this when I started digging into the xunit_reporter. It seems when it creates the cdata tag it was leaving off the closing `>`. This is causing some parsers to fail.
