### PR TITLE
Fix some display test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "views"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha --timeout 3000 tests/*_tests.js tests/*/*_tests.js",
+    "test": "mocha --timeout 3000 tests/*_tests.js tests/*/*_tests.js",
     "cover": "cover run ./node_modules/.bin/_mocha tests/*_tests.js tests/*/*_tests.js; cover report html; open cover_html/index.html"
   },
   "devDependencies": {

--- a/tests/ui/error_messages_panel_tests.js
+++ b/tests/ui/error_messages_panel_tests.js
@@ -1,9 +1,13 @@
 var expect = require('chai').expect
 var screen = require('./fake_screen')
 var ErrorMessagesPanel = require('../../lib/dev/ui/error_messages_panel')
+var Chars = require('../../lib/chars')
 
 describe('ErrorMessagesPanel', function(){
   var panel
+  var tab, runner, appview, results, ___ = []
+  ___.length = 11
+  ___ = ___.join(Chars.horizontal)
   beforeEach(function(){
     screen.$setSize(12, 12)
     panel = new ErrorMessagesPanel({
@@ -20,35 +24,35 @@ describe('ErrorMessagesPanel', function(){
   it('renders', function(){
     panel.render()
     expect(screen.buffer).to.be.deep.equal([
-      '┏━━━━━━━━━━┓',
-      '┃blah      ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┃          ┃',
-      '┗━━━━━━━━━━┛' ])
+      Chars.topLeft + ___ + Chars.topRight,
+      Chars.vertical + 'blah      ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.vertical + '          ' + Chars.vertical,
+      Chars.bottomLeft + ___ + Chars.bottomRight ])
   })
   it('wraps the text', function(){
     panel.set('text', "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?")
     panel.render()
     expect(screen.buffer).to.be.deep.equal([
-      '┏━━━━━━━━━━┓',
-      '┃Sed ut per┃',
-      '┃spiciatis ┃',
-      '┃unde omnis┃',
-      '┃ iste natu┃',
-      '┃s error si┃',
-      '┃t voluptat┃',
-      '┃em accusan┃',
-      '┃tium dolor┃',
-      '┃emque laud┃',
-      '┃antium, to┃',
-      '┗━━━━━━━━━━┛' ])
+      Chars.topLeft + ___ + Chars.topRight,
+      Chars.vertical + 'Sed ut per' + Chars.vertical,
+      Chars.vertical + 'spiciatis ' + Chars.vertical,
+      Chars.vertical + 'unde omnis' + Chars.vertical,
+      Chars.vertical + ' iste natu' + Chars.vertical,
+      Chars.vertical + 's error si' + Chars.vertical,
+      Chars.vertical + 't voluptat' + Chars.vertical,
+      Chars.vertical + 'em accusan' + Chars.vertical,
+      Chars.vertical + 'tium dolor' + Chars.vertical,
+      Chars.vertical + 'emque laud' + Chars.vertical,
+      Chars.vertical + 'antium, to' + Chars.vertical,
+      Chars.bottomLeft + ___ + Chars.bottomRight ])
   })
   it('does not render if not visible', function(){
     screen.$setSize(12, 12)

--- a/tests/ui/runner_tabs_tests.js
+++ b/tests/ui/runner_tabs_tests.js
@@ -3,11 +3,14 @@ var screen = require('./fake_screen')
 var Backbone = require('backbone')
 var runnertabs = require('../../lib/dev/ui/runner_tabs')
 var Config = require('../../lib/config')
+var Chars = require('../../lib/chars')
 var RunnerTab = runnertabs.RunnerTab
 var RunnerTabs = runnertabs.RunnerTabs
 
 describe('RunnerTab', function(){
-  var tab, runner, appview, results
+  var tab, runner, appview, results, ___ = []
+  ___.length = 15
+  ___ = ___.join(Chars.horizontal)
 
   context('has no results', function(){
     beforeEach(function(){
@@ -30,39 +33,42 @@ describe('RunnerTab', function(){
     })
 
     it('renders spinner', function(){
+      var border = ' ' + ___ + Chars.topRight + '    '
       expect(screen.buffer).to.be.deep.equal([
         '                    ',
         '                    ',
         '                    ',
-        ' ━━━━━━━━━━━━━━┓    ',
-        '       Bob     ┃    ',
-        '        ◜      ┃    ',
-        '               ┗    ',
+        border,
+        '       Bob     ' + Chars.vertical + '    ',
+        '        ' + Chars.spinner.charAt(0) + '      ' + Chars.vertical + '    ',
+        '               ' + Chars.bottomLeft + '    ',
         '                    ' ])
     })
     it('renders checkmark if allPassed', function(){
       runner.set('allPassed', true)
       tab.render()
+      var border = ' ' + ___ + Chars.topRight + '    '
       expect(screen.buffer).to.be.deep.equal([
         '                    ',
         '                    ',
         '                    ',
-        ' ━━━━━━━━━━━━━━┓    ',
-        '       Bob     ┃    ',
-        '       ✔       ┃    ',
-        '               ┗    ',
+        border,
+        '       Bob     ' + Chars.vertical + '    ',
+        '       ' + Chars.success + '       ' + Chars.vertical + '    ',
+        '               ' + Chars.bottomLeft + '    ',
         '                    ' ])
     })
     it('renders no border when deselected', function(){
       tab.set('selected', false)
+      var border = ' ' + ___ + Chars.horizontal + '    '
       expect(screen.buffer).to.be.deep.equal([ 
         '                    ',
         '                    ',
         '                    ',
         '                    ',
         '       Bob          ',
-        '        ◝           ',
-        ' ━━━━━━━━━━━━━━━    ',
+        '        ' + Chars.spinner.charAt(1) + '           ',
+        border,
         '                    ' ])
     })
     /*it('doesnt overwrite the screen boundary', function(){
@@ -99,14 +105,15 @@ describe('RunnerTab', function(){
 
       it('renders failure-x', function(){
           tab.render()
+          var border = ' ' + ___ + Chars.topRight + '    '
           expect(screen.buffer).to.be.deep.equal([
               '                    ',
               '                    ',
               '                    ',
-              ' ━━━━━━━━━━━━━━┓    ',
-              '       Bob     ┃    ',
-              '     0/0 ✘     ┃    ',
-              '               ┗    ',
+              border,
+              '       Bob     ' + Chars.vertical + '    ',
+              '     0/0 ' + Chars.fail + '     ' + Chars.vertical + '    ',
+              '               ' + Chars.bottomLeft + '    ',
               '                    ' ])
       })
 
@@ -141,14 +148,15 @@ describe('RunnerTab', function(){
       results.set('total', 2)
       results.set('pending', 1)
       process.nextTick(function(){
+        var border = ' ' + ___ + Chars.topRight + '    '
         expect(screen.buffer).to.be.deep.equal([
           '                    ',
           '                    ',
           '                    ',
-          ' ━━━━━━━━━━━━━━┓    ',
-          '       Bob     ┃    ',
-          '     1/2 ◞     ┃    ',
-          '               ┗    ',
+          border,
+          '       Bob     ' + Chars.vertical + '    ',
+          '     1/2 ' + Chars.spinner.charAt(2) + '     ' + Chars.vertical + '    ',
+          '               ' + Chars.bottomLeft + '    ',
           '                    ' ])
         done()
       })
@@ -160,14 +168,15 @@ describe('RunnerTab', function(){
         , pending: 1
         , all: true
       })
+      var border = ' ' + ___ + Chars.topRight + '    '
       expect(screen.buffer).to.be.deep.equal([ 
         '                    ',
         '                    ',
         '                    ',
-        ' ━━━━━━━━━━━━━━┓    ',
-        '       Bob     ┃    ',
-        '     1/2 ✔     ┃    ',
-        '               ┗    ',
+        border,
+        '       Bob     ' + Chars.vertical + '    ',
+        '     1/2 ' + Chars.success + '     ' + Chars.vertical + '    ',
+        '               ' + Chars.bottomLeft + '    ',
         '                    ' ])
     })
     context('when there are no pending tests', function(){

--- a/tests/ui/split_log_panel_tests.js
+++ b/tests/ui/split_log_panel_tests.js
@@ -4,6 +4,7 @@ var screen = require('./fake_screen')
 var SplitLogPanel = require('../../lib/dev/ui/split_log_panel')
 var stub = require('bodydouble').stub
 var spy = require('ispy')
+var Chars = require('../../lib/chars')
 
 describe('SplitLogPanel', function(){
 
@@ -56,7 +57,7 @@ describe('SplitLogPanel', function(){
       ])
       results.set('tests', tests)
       results.set('all', true)
-      expect(panel.getResultsDisplayText().unstyled()).to.equal('✔ 1 tests complete.')
+      expect(panel.getResultsDisplayText().unstyled()).to.equal(Chars.success + ' 1 tests complete.')
     })
     it('shows pending tests in yellow when has results, all is true, no tests failed and there are pending tests', function(){
       results.set('total', 1)
@@ -74,7 +75,7 @@ describe('SplitLogPanel', function(){
       var resultText = text.children[0]
       var pendingText = text.children[1]
 
-      expect(resultText.str).to.equal('✔ 1 tests complete (1 pending).')
+      expect(resultText.str).to.equal(Chars.success + ' 1 tests complete (1 pending).')
       expect(resultText.attrs.foreground).to.equal('cyan')
 
       expect(pendingText.str).to.equal('\n\n[PENDING] blah')
@@ -92,7 +93,7 @@ describe('SplitLogPanel', function(){
       ])
       results.set('tests', tests)
       results.set('all', true)
-      expect(panel.getResultsDisplayText().unstyled()).to.match(/blah\n    ✘ failed/)
+      expect(panel.getResultsDisplayText().unstyled()).to.match(/blah\n    [x✘] failed/)
     })
     it('shows the error message', function(){
       results.set('total', 1)
@@ -106,7 +107,7 @@ describe('SplitLogPanel', function(){
       ])
       results.set('tests', tests)
       results.set('all', true)
-      expect(panel.getResultsDisplayText().unstyled()).to.match(/blah\n    ✘ should not be null/)
+      expect(panel.getResultsDisplayText().unstyled()).to.match(/blah\n    [x✘] should not be null/)
     })
     it('shows the stacktrace', function(){
       results.set('total', 1)
@@ -127,7 +128,7 @@ describe('SplitLogPanel', function(){
       ])
       results.set('tests', tests)
       results.set('all', true)
-      expect(panel.getResultsDisplayText().unstyled()).to.equal('blah\n    ✘ should not be null\n        AssertionError: \n            at Module._compile (module.js:437:25)\n            at Object.Module._extensions..js (module.js:467:10)')
+      expect(panel.getResultsDisplayText().unstyled()).to.equal('blah\n    ' + Chars.fail + ' should not be null\n        AssertionError: \n            at Module._compile (module.js:437:25)\n            at Object.Module._extensions..js (module.js:467:10)')
     })
     it('says "Looking good..." if all is false but all passed so far', function(){
       results.set('total', 1)


### PR DESCRIPTION
Windows console doesn't handle unicode symbols, so use the fallback characters in test comparison.

This fixes some of the tests on windows.

I'll work on the others, but some of them are not related to testem itself.
