### PR TITLE
Fix mocha adapter not reporting all test results

### DIFF
--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -18,6 +18,7 @@ function mochaAdapter(socket){
 	var id = 1
 	var Runner
 	var ended = false
+	var waiting = 0
 	
 	try{
 		Runner = mocha.Runner || Mocha.Runner
@@ -39,11 +40,15 @@ function mochaAdapter(socket){
 		if (evt === 'start'){
 			emit('tests-start')
 		}else if (evt === 'end'){
-			emit('all-test-results', results)
+			if (waiting === 0) {
+				emit('all-test-results', results)
+			}
 			ended = true
 		}else if (evt === 'test end'){
 			var name = getFullName(test)
+			waiting++
 			setTimeout(function(){
+				waiting--
 				if (test.state === 'passed'){
 					testPass(test)
 				}else if (test.state === 'failed'){
@@ -51,7 +56,7 @@ function mochaAdapter(socket){
 				}else if (test.pending){
 					testPending(test)
 				}
-				if (ended){
+				if (ended && waiting === 0){
 					emit('all-test-results', results)
 				}
 			}, 0)


### PR DESCRIPTION
I'm using testem with mocha, and noticed that sometimes `testem ci` outputs a report with lack of some test results. (ex. Although the spec has 100 tests, testem's report only contains 90 results)

This is because, by commit 6c890dc, reporting test result is delayed by `setTimeout` asynchronously, which may cause inconsistent order of event emitting, such as `test-result` event after `all-test-results` event.

This PR fixes the inconsistency and always emitting `all-test-results` event after all of `test-result` events have been fired, so that reporters can finalize their report properly.
