### PR TITLE
Attemps to add support for multi-folder routes

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -24,7 +24,7 @@ var Express = require('express')
   , Mustache = require('consolidate').mustache
   , http = require('http')
   //, log = new (require('log'))('info', fs.createWriteStream('testem.log2'))
-        
+
 require('./socket.io.patch')
 
 function Server(config){
@@ -58,7 +58,7 @@ Server.prototype = {
   , createExpress: function(){
     var self = this
     var app = this.express = Express()
-        
+
     this.configureExpress(app)
 
     app.get('/', function(req, res){
@@ -72,7 +72,7 @@ Server.prototype = {
     app.get('/testem.js', function(req, res){
       self.serveTestemClientJs(req, res)
     })
-        
+
     app.get(/^\/(?:[0-9]+)(\/.+)$/, serveStaticFile)
     app.post(/^\/(?:[0-9]+)(\/.+)$/, serveStaticFile)
     app.get(/^(.+)$/, serveStaticFile)
@@ -101,7 +101,7 @@ Server.prototype = {
     var config = this.config
     var framework = config.get('framework') || 'jasmine'
     var css_files = config.get('css_files')
-    var templateFile = { 
+    var templateFile = {
       jasmine: 'jasminerunner'
       , qunit: 'qunitrunner'
       , mocha: 'mocharunner'
@@ -110,7 +110,7 @@ Server.prototype = {
       , custom: 'customrunner'
       , tap: 'taprunner'
     }[framework] + '.mustache'
-    res.render(__dirname + '/../../views/' + templateFile, {    
+    res.render(__dirname + '/../../views/' + templateFile, {
       scripts: files,
       styles: css_files
     })
@@ -123,12 +123,12 @@ Server.prototype = {
     var self = this
     var config = this.config
     var test_page = config.get('test_page')
-          
+
     if (test_page){
       if (test_page[0] === "/") {
         test_page = encodeURIComponent(test_page)
       }
-      var base = req.path === '/' ? 
+      var base = req.path === '/' ?
         req.path : req.path + '/'
       var url = base + test_page
       res.redirect(url)
@@ -176,7 +176,7 @@ Server.prototype = {
       res.write('}());')
       res.end()
     })
-        
+
   }
   , killTheCache: function killTheCache(req, res){
     res.setHeader('Cache-Control', 'No-cache')
@@ -188,54 +188,92 @@ Server.prototype = {
     var config = this.config
     var routes = config.get('routes') || config.get('route') || {}
     var bestMatchLength = 0
-    var bestMatch = null
+    var bestMatches = []
     for (var prefix in routes){
       if (uri.substring(0, prefix.length) === prefix){
         if (bestMatchLength < prefix.length){
-          bestMatch = routes[prefix] + '/' + uri.substring(prefix.length)
-          bestMatchLength = prefix.length
+            if (util.isArray(routes[prefix])) {
+                // All possible fileSystem paths for the file
+                bestMatches = (routes[prefix].map(function (fsPath) {
+                    return fsPath + '/' + uri.substring(prefix.length);
+                }));
+            } else {
+                bestMatches = [routes[prefix] + "/" + uri.substring(prefix.length)];
+            }
+            bestMatchLength = prefix.length
         }
       }
     }
-    return {
-      routed: !!bestMatch
-      , uri: bestMatch || uri.substring(1)
+
+      var routed = (bestMatches.length > 0);
+      var uris = (routed ? bestMatches : [uri.substring(1)]);
+
+      return {
+       routed: routed
+      , uris: uris
     }
   }
+  , findFile : function (uris, config, cb) {
+      // Find the fist file that exits
+      var filePaths = uris.map(function (uri) {
+          var resolved =  path.resolve(config.resolvePath(uri));
+          return resolved;
+      });
+
+      async.detect(filePaths, fs.exists, function (filePath) {
+          if (!filePath) {
+              filePath = filePaths[0];
+          }
+          var ext = path.extname(filePath)
+          var isPathPermitted = filePath.indexOf(config.cwd()) !== -1
+          cb(filePath, ext, isPathPermitted);
+
+      });
+
+
+  }
   , serveStaticFile: function(uri, req, res){
+
     var self = this
     var config = this.config
+
+      // Interpret this as a *list* of possible uris
     var routeRes = this.route(uri)
-    uri = routeRes.uri
+    uris = routeRes.uris
+
     var wasRouted = routeRes.routed
     this.killTheCache(req, res)
     var allowUnsafeDirs = config.get('unsafe_file_serving')
-    var filePath = path.resolve(config.resolvePath(uri))
-    var ext = path.extname(filePath)
-    var isPathPermitted = filePath.indexOf(config.cwd()) !== -1
-    if (!wasRouted && !allowUnsafeDirs && !isPathPermitted) {
-      res.status(403)
-      res.write('403 Forbidden')
-      res.end()
-    } else if (ext === '.mustache') {
-      config.getTemplateData(function(err, data){
-        res.render(filePath, data)
-        self.emit('file-requested', filePath)
-      })
-    } else {
-      fs.stat(filePath, function(err, stat){
-        self.emit('file-requested', filePath)
-        if (err) return res.sendfile(filePath)    
-        if (stat.isDirectory()){
-          fs.readdir(filePath, function(err, files){
-            var dirListingPage = __dirname + '/../../views/directorylisting.mustache'
-            res.render(dirListingPage, {files: files})
-          })
-        }else{
-          res.sendfile(filePath)
-        }
-      })   
-    }
+
+      this.findFile(uris, config, function (filePath, ext, isPathPermitted) {
+
+          if (!wasRouted && !allowUnsafeDirs && !isPathPermitted) {
+              res.status(403)
+              res.write('403 Forbidden')
+              res.end()
+          } else if (ext === '.mustache') {
+              config.getTemplateData(function(err, data){
+                  res.render(filePath, data)
+                  self.emit('file-requested', filePath)
+              })
+          } else {
+
+              fs.stat(filePath, function(err, stat){
+                  self.emit('file-requested', filePath)
+                  if (err) return res.sendfile(filePath)
+                  if (stat.isDirectory()){
+                      fs.readdir(filePath, function(err, files){
+                          var dirListingPage = __dirname + '/../../views/directorylisting.mustache'
+                          res.render(dirListingPage, {files: files})
+                      })
+                  } else {
+                      res.sendfile(filePath)
+                  }
+              })
+          }
+
+      });
+
   }
   , onClientConnected: function(client){
     var self = this

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -52,7 +52,7 @@ describe('Server', function(){
       //expect(window.document.title).to.equal('Test\'em')
       var scripts = document.getElementsByTagName('script')
       var srcs = Array.prototype.map.call(scripts, function(s){ return s.src })
-      /*expect(srcs).to.deep.equal([ 
+      /*expect(srcs).to.deep.equal([
         '/testem/jasmine.js',
         '/testem.js',
         '/testem/jasmine-html.js',
@@ -113,6 +113,10 @@ describe('Server', function(){
     })
   }
 
+    function assertUrlReturnsTestFileContents(url, file, done){
+        assertUrlReturnsFileContents(url, path.join(__dirname, file), done);
+    }
+
   it('lists directories', function(done){
       request(baseUrl + 'data', function(err, req, text){
           expect(text).to.match(/<a href=\"blah.txt\">blah.txt<\/a>/)
@@ -120,27 +124,40 @@ describe('Server', function(){
       })
   })
 
-  //describe('routes', function(){
-  //    beforeEach(function(){
-  //        config.set('routes', {
-  //            '/index.html': 'web/tests.html'
-  //            , '/www': 'web'
-  //            , '/': 'web/tests.html'
-  //            , '/config.js': path.join(__dirname, '../lib/config.js')
-  //        })
-  //    })
-  //    it('routes file path', function(done){
-  //        assertUrlReturnsFileContents(baseUrl + 'index.html', 'web/tests.html', done)
-  //    })
-  //    it('routes dir path', function(done){
-  //        assertUrlReturnsFileContents(baseUrl + 'www/hello.js', 'web/hello.js', done)
-  //    })
-  //    it('route base path', function(done){
-  //        assertUrlReturnsFileContents(baseUrl, 'web/tests.html', done)
-  //    })
-  //    it('can route files in parent directory', function(done){
-  //        assertUrlReturnsFileContents(baseUrl + 'config.js', '../lib/config.js', done)
-  //    })
-  //})
-    
+  describe('routes', function(){
+     beforeEach(function(){
+         config.set('routes', {
+             '/index.html': 'web/tests.html'
+             , '/www': 'web'
+             , '/': 'web/tests.html'
+             , '/config.js': path.join(__dirname, '../lib/config.js')
+             ,'/many' : ['web/many1', 'web/many2']
+         })
+     })
+     it('routes file path', function(done){
+         assertUrlReturnsTestFileContents(baseUrl + 'index.html', 'web/tests.html', done)
+     })
+     it('routes dir path', function(done){
+         assertUrlReturnsTestFileContents(baseUrl + 'www/hello.js', 'web/hello.js', done)
+     })
+     it('route base path', function(done){
+         assertUrlReturnsTestFileContents(baseUrl, 'web/tests.html', done)
+     })
+     it('can route files in parent directory', function(done){
+         assertUrlReturnsTestFileContents(baseUrl + 'config.js', '../lib/config.js', done)
+     })
+     it('can route files from different folder locations (case 1)', function (done) {
+         assertUrlReturnsTestFileContents(baseUrl + 'many/many1.html', 'web/many1/many1.html', done)
+     });
+     it('can route files from different folder locations (case 2)', function (done) {
+         assertUrlReturnsTestFileContents(baseUrl + 'many/many2.html', 'web/many2/many2.html', done)
+     })
+     it ("does not fail on missing file", function (done) {
+         request(baseUrl + 'many/many3.html', function (err, req, text) {
+             expect(err).to.equal(null);
+             done();
+         })
+     });
+  })
+
 })

--- a/tests/web/many1/many1.html
+++ b/tests/web/many1/many1.html
@@ -1,0 +1,1 @@
+This file is in many1 folder, should be served as /many/many1.html

--- a/tests/web/many2/many2.html
+++ b/tests/web/many2/many2.html
@@ -1,0 +1,1 @@
+This file is in many2 folder, should be served as /many/many2.html


### PR DESCRIPTION
Hi

 I'm trying to test pages that use requirejs. For some reason, in
 development mode, all my static js client-side files are not under
 the same folder hierarchy ; however I want to serve both hierarchy
 under the same prefix.

 For example, If I have :

```
+ root
  + public
    + js
      + foo.js
  + deps
    + commons
      + js
        + bar.js
```

I want to be able to serve :
- File /root/public/js/foo.js as URL '/public/js/foo.js'
- File /root/deps/commonsjs/bar.js as URL '/public/js/bar.js'

I though using 'routes' would do the trick, but unfortunately you can
only use one path.

So I tried to allow specifying routes like this :

```
{
  routes : {
    'public' : ['public', "deps/commons"]
  }
}
```

The idea being that if a url matches a route, the first file that can
be located in any of the folders passed in the list is returned.

I managed to implement something, but unfortunately, serving the files
becomes incredibly slow with this ; so there must be something very
inefficient somewhere, that I can not find.

I added a server tests, everything passes fine (I had to uncomment the
other 'routes' tests, though.)

So this PR is more about asking for help than anything :)
- is there a built-in way to deal with my case ?
- do you have any idea why my patch makes thing so slow ?

Thanks !
