### PR TITLE
Clean timeout

### DIFF
--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -105,7 +105,7 @@ App.prototype = {
     var self = this
     var timeout = this.config.get('timeout')
     if (timeout){
-      setTimeout(function(){
+      this.timeoutID = setTimeout(function(){
         self.wrapUp(new Error('Timed out after ' + timeout + 'ms'))
       }, timeout)
     }
@@ -119,6 +119,10 @@ App.prototype = {
     }, callback)
   },
   wrapUp: function(err){
+    if (this.timeoutID) {
+      clearTimeout(this.timeoutID)
+      this.timeoutID = null
+    }
     if (err){
       this.reporter.report(null, {
         passed: false,


### PR DESCRIPTION
Clear the test timeout, this is needed when multiple `testem` are used as a module, otherwise the timeout is called even after a previous test ended.
