### PR TITLE
Basic support for interceptors = code coverage?

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -3,6 +3,7 @@ var Config = require('./config')
 var Backbone = require('backbone')
 var EventEmitter = require('events').EventEmitter
 var fs = require('fs')
+var util = require('util')
 
 /*
   CLI-level options:
@@ -67,7 +68,10 @@ var EventLogger = Backbone.Model.extend({
   startTests: function() {}
 } )
 
-function Api(){}
+function Api(){
+  EventEmitter.call(this)
+}
+util.inherits(Api, EventEmitter)
 
 Api.prototype.setup = function(mode, dependency, finalizer){
   var self = this
@@ -77,6 +81,7 @@ Api.prototype.setup = function(mode, dependency, finalizer){
   log.info("Test'em starting...")
   config.read(function() {
     self.app = new App(config, finalizer)
+    self.emit("before_start")
     self.app.start()
   })
 }

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -268,7 +268,15 @@ function emit(){
     Testem.emit.apply(Testem, arguments)
 }
 
-window.Testem = {
+function extend(host, properties){
+    host = host || {}
+    for (var name in properties){
+        if (!host[name]) host[name] = properties[name]
+    }
+    return host
+}
+
+window.Testem = extend(window.Testem, {
     useCustomAdapter: function(adapter){
         adapter(socket)
     }
@@ -293,7 +301,7 @@ window.Testem = {
         this.evtHandlers[evt].push(callback)
     }
     , handleConsoleMessage: function(){}
-}
+})
 
 var JSON = window.JSON || JSON2()
 


### PR DESCRIPTION
This allows to define a custom `Testem` object that overrides the default one.
By doing so it's possible to define additional methods or modify testem behavior.

The extend allows to create a `Testem` object before `testem.js` is loaded.

I kept this change as light and generic as possible, but the idea behind is to support code coverage (or at least go in that direction).

I'm the author of `node-coverage` and my tool (as well as istanbul) creates a JSON object that should be sent to a server to be stored on disk after the tests are done and before the browser is closed.

With this small change on testem I can include the following script in my test page

``` js
Testem.evtHandlers = {
    "all-test-results": [function () {
        sendCoverage()
    }]
}
```

This works both for `node-coverage` and `istanbul`.

The `extend` is needed in my setup because I don't have much control on the order of loading scripts, so I can't guarantee that the extra script gets loaded after `testem.js` and thus call `Testem.on()`.

The changes on `api.js` allow to do the following

``` js
testem.on("before_start", function () {
   testem.app.server.on("server-start", function () {
      testem.app.server.express.put('/save-report', function (req, res, next) {
          storeReportSomehow(req.body);
          res.end("OK");
      });
   })
});
```

that basically means adding a middleware onto express server.

I thought about other ways to add middlewares, like defining them in the config or providing a hook, but it's more specific and requires few changes more.

What do you think?
