### PR TITLE
fixes #338. created a spec that proves the bug if html element is return...

### DIFF
--- a/maxstackjasminebug/README.md
+++ b/maxstackjasminebug/README.md
@@ -1,0 +1,8 @@
+If a matcher is added to jasmine which has a HTMLElement as part of the message return, testem blows up. 
+This works fine if you run jasmine normally in the browser. 
+Something to do with the terminal output mechanism i guess. 
+
+the stack explodes from an infinite recursion in a str(key, holder) function. 
+
+to reproduce run:
+node testem.js -f maxstackjasminebug/testem.json

--- a/maxstackjasminebug/bugSpec.js
+++ b/maxstackjasminebug/bugSpec.js
@@ -1,0 +1,22 @@
+describe('Bug', function() {
+    beforeEach(function() {
+        this.addMatchers({
+          notToBlowUpStack : function () {
+            this.message = function () {
+              return [
+                this.actual,
+                "Expected not to blow up."
+              ];
+            };
+            return false;
+          }
+        });
+    });
+    it('should handle custom matcher with html element in message return', function() {
+        expect(document.createElement('div')).notToBlowUpStack();
+    });
+    it('should handle custom matcher with null in message return', function() {
+        expect(null).notToBlowUpStack();
+    });
+});
+

--- a/maxstackjasminebug/testem.json
+++ b/maxstackjasminebug/testem.json
@@ -1,0 +1,9 @@
+{
+    "framework": "jasmine",
+    "src_files": [
+        "maxstackjasminebug/bugSpec.js"
+    ], 
+    "launch_in_dev": [
+        "PhantomJS"
+    ]
+}

--- a/public/testem/jasmine_adapter.js
+++ b/public/testem/jasmine_adapter.js
@@ -44,7 +44,7 @@ function jasmineAdapter(socket){
                 test.failed++
             test.items.push({    
                 passed: passed,
-                message: item.message,
+                message: String(item.message),
                 stack: item.trace.stack ? item.trace.stack : undefined
             })
         }


### PR DESCRIPTION
...ed from matcher message. added a spec with null return in matcher message as well. implemented the fix in jasmine_adapter.js. the bugSpec.js fails as it should, and does not blow the stack.
