### PR TITLE
Configure middlewares

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -61,6 +61,11 @@ Server.prototype = {
         
     this.configureExpress(app)
 
+    // Add normal middlewares at the beginning
+    includeMiddlewares(function (middleware) {
+      return middleware.length <= 3
+    })
+
     app.get('/', function(req, res){
       self.serveHomePage(req, res)
     })
@@ -78,8 +83,20 @@ Server.prototype = {
     app.get(/^(.+)$/, serveStaticFile)
     app.post(/^(.+)$/, serveStaticFile)
 
+    // Add error handlers at the end to catch all errors
+    includeMiddlewares(function (middleware) {
+      return middleware.length === 4
+    })
+
     function serveStaticFile(req, res){
       self.serveStaticFile(req.params[0], req, res)
+    }
+
+    function includeMiddlewares(filter){
+      var middlewares = self.config.get('middlewares')
+      if (middlewares) middlewares.filter(filter).forEach(function (middleware) {
+        app.use(middleware)
+      })
     }
   }
   , configureExpress: function(app){
@@ -111,7 +128,7 @@ Server.prototype = {
       , custom: 'customrunner'
       , tap: 'taprunner'
     }[framework] + '.mustache'
-    res.render(__dirname + '/../../views/' + templateFile, {    
+    res.render(__dirname + '/../../views/' + templateFile, {
       scripts: files,
       styles: css_files
     })
@@ -226,7 +243,7 @@ Server.prototype = {
     } else {
       fs.stat(filePath, function(err, stat){
         self.emit('file-requested', filePath)
-        if (err) return res.sendfile(filePath)    
+        if (err) return res.sendfile(filePath)
         if (stat.isDirectory()){
           fs.readdir(filePath, function(err, files){
             var dirListingPage = __dirname + '/../../views/directorylisting.mustache'

--- a/tests/server_middleware_error.js
+++ b/tests/server_middleware_error.js
@@ -1,0 +1,58 @@
+var Server = require('../lib/server')
+var Config = require('../lib/config')
+var EventEmitter = require('events').EventEmitter
+var Backbone = require('backbone')
+var request = require('request')
+var jsdom = require('jsdom')
+var fs = require('fs')
+var path = require('path')
+var expect = require('chai').expect
+
+describe('Server', function(){
+  var server, runners, app, socketClient, config
+  var orgSetTimeout, baseUrl, port
+  before(function(done){
+  port = 73571
+  config = new Config('dev', {
+    port: port,
+    src_files: [
+      'web/hello.js',
+      {src:'web/hello_tst.js', attrs: ['data-foo="true"', 'data-bar']}
+    ],
+    cwd: 'tests',
+    middlewares: [function(err, req, res, next){
+      if (err.code === "ENOENT" && err.path.match(/missing$/)) {
+        res.send('hijacking errors')
+      } else {
+        next(err)
+      }
+    }]
+  })
+  baseUrl = 'http://localhost:' + port + '/'
+  runners = new Backbone.Collection
+
+  server = new Server(config)
+  server.start()
+  server.server.addListener('connection', function(stream){
+    stream.setTimeout(100) // don't tolerate idleness in tests
+  })
+  server.once('server-start', function(){
+    done()
+  })
+  socketClient = new EventEmitter
+  })
+  after(function(done){
+    server.stop(function(){
+      done()
+    })
+  })
+
+  it('handles errors', function(done){
+    request(baseUrl + 'im/sure/the_path/is/missing', function(err, req, text){
+      expect(req.statusCode).to.equal(200)
+      expect(text).to.match(/hijacking errors/)
+      done()
+    })
+  })
+
+})


### PR DESCRIPTION
So, I'm back with another pull request that would help #337, #333 and #294

With this it's now possible to specify extra middlewares to add onto testem server from the configuration.

There are two types of middlewares
1. plain middlewares, `function (req, res) {}` or `function (req, res, next) {}`. These are added before any other testem middleware (for greater extensibility)
2. [error handlers](http://expressjs.com/guide.html#error-handling) `function (err, req, res, next) {}` which are added last to catch all errors

Passing middlewares is only possible when using testem as module, I have no idea on how to deal with the command line...
