### PR TITLE
Store a reference to setTimeout when loading mocha adapter

### DIFF
--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -35,6 +35,10 @@ function mochaAdapter(socket){
 		return name.replace(/^ /, '')
 	}
 
+	/* Store a reference to the global setTimeout function, in case it's
+	 * manipulated by test helpers */
+	var _setTimeout = setTimeout
+
 	var oEmit = Runner.prototype.emit
 	Runner.prototype.emit = function(evt, test, err){
 		if (evt === 'start'){
@@ -47,7 +51,7 @@ function mochaAdapter(socket){
 		}else if (evt === 'test end'){
 			var name = getFullName(test)
 			waiting++
-			setTimeout(function(){
+			_setTimeout(function(){
 				waiting--
 				if (test.state === 'passed'){
 					testPass(test)


### PR DESCRIPTION
Fixes a problem where the test execution hangs, if a test helper (e.g.
sinon.useFakeTimers), has swapped out the global timeout function.
