### PR TITLE
this function always fails o failed tests with numerical comparisons

### DIFF
--- a/lib/strutils.js
+++ b/lib/strutils.js
@@ -7,6 +7,7 @@ function pad(str, l, s, t){
 }
 
 function indent(text){
+  text = "" + text;
   return text.split('\n').map(function(line){
     return '    ' + line
   }).join('\n')


### PR DESCRIPTION
if you had in a test:

equals(myArray.length, 3);

and myArray.length was not 3 (a fail).. it would pass a NUMBER into strutils which errors out since the number has no method split on it.
