### PR TITLE
Update cli help to say milliseconds

### DIFF
--- a/play/cmdr.js
+++ b/play/cmdr.js
@@ -23,7 +23,7 @@ program
 program
     .command('ci')
     .description('Continuous integration mode')
-    .option('-t, --timeout [sec]', 'timeout a browser after [sec] seconds', null)
+    .option('-t, --timeout [ms]', 'timeout a browser after [ms] milliseconds', null)
     .action(function(e){
         env = e
         console.log(env.skip)


### PR DESCRIPTION
Because it is definitely not seconds:

```
$ testem ci --timeout=5
not ok 1 Error
    ---
        message: >
            Timed out after 5ms
    ...
```
