### PR TITLE
escape XML entities in test names e.g. <tags> to not break XUnitReporter...

### DIFF
--- a/lib/ci/test_reporters/xunit_reporter.js
+++ b/lib/ci/test_reporters/xunit_reporter.js
@@ -1,4 +1,6 @@
 var strutils = require('../../strutils')
+var xmlescape = require('xml-escape');
+
 
 function XUnitReporter(silent, out){
   this.out = out || process.stdout
@@ -39,7 +41,7 @@ XUnitReporter.prototype = {
     var launcher = result.launcher
     result = result.result
     var error = result.error
-    var testname = result.name.replace(/\"|\&/g, '')
+    var testname = xmlescape(result.name);
     if (error){
       return '  <testcase name="' +
         launcher + ' ' + testname + '">' +

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "consolidate": "~0.8.0",
     "did_it_work": "~0.0.5",
     "fireworm": "~0.6.0",
-    "npmlog": "~0.0.6"
+    "npmlog": "~0.0.6",
+    "xml-escape": "~1.0.0"
   },
   "files": [
     "lib",

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -74,18 +74,18 @@ describe('test reporters', function(){
   })
 
   describe('xunit reporter', function(){
-    it('writes out results', function(){
+    it('writes out and XML escapes results', function(){
       var stream = BufferStream()
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
-        name: 'it does stuff',
+        name: 'it does <cool> \"cool\" \'cool\' stuff',
         passed: 1,
         total: 1,
         failed: 0
       })
       reporter.finish()
       assert.match(stream.string, /<testsuite name="Testem Tests" tests="1" failures="0" timestamp="(.+)" time="([0-9]+)">/)
-      assert.match(stream.string, /<testcase name="phantomjs it does stuff"\/>/)
+      assert.match(stream.string, /<testcase name="phantomjs it does &lt;cool&gt; &quot;cool&quot; &apos;cool&apos; stuff"\/>/)
     })
     it('outputs errors', function(){
       var stream = BufferStream()


### PR DESCRIPTION
Our test: 

``` javascript
describe("<title> should display the basic title info", function() { ....
```

ran using Testem via Lineman. 

``` xml
 <testcase name="PhantomJS 1.9 title directive <title> should display the basic title info should define a payload."/>
```

However, this is invalid XML - the angle brackets <> are bad. Our Jenkins build failed due to invalid XML parsing. 

```
Caused by: org.dom4j.DocumentException: Error on line 6 of document file:///home/jenkins/slave1/workspace/metasearch-app-ui/target/test-reports/metasearch-app-ui-xunit.xml : 
   The value of attribute "name" associated with an element type "null" must not contain the '<' character. 
  Nested exception: The value of attribute "name" associated with an element type "null" must not contain 
      the '<' character.
    at org.dom4j.io.SAXReader.read(SAXReader.java:482)
    at org.dom4j.io.SAXReader.read(SAXReader.java:264)
    at hudson.tasks.junit.SuiteResult.parse(SuiteResult.java:112)
    at hudson.tasks.junit.TestResult.parse(TestResult.java:227)
    ... 15 more
Caused by: org.xml.sax.SAXParseException: The value of attribute "name" associated with an element type "null" must not contain the '<' character.
```

The fix uses the [npm module xml-escape](https://www.npmjs.org/package/xml-escape) which is similar to every other snippet out there but packaged in npm and modifies one test. I also check for all the possible XML entities.
