### PR TITLE
Use path.resolve in Config#resolvePath

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -55,7 +55,7 @@ Config.prototype.resolvePath = function(filepath){
     return filepath
   }
 
-  return path.join(this.cwd(), filepath)
+  return path.resolve(this.cwd(), filepath)
 }
 
 Config.prototype.reverseResolvePath = function(filepath){


### PR DESCRIPTION
This fixes resolving absolute paths in Windows. `path.join` does not respect Window's drive prefixes, `c:\`, resolve does. On windows it fixes the 14th Config test that reads as `read js config file gets properties from config file` since it's `file` config value is resolved from an absolute path.
