### PR TITLE
Update config_file.md

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -63,6 +63,7 @@ Common Configuration Options
     routes:                 [Hash]    overrides for assets paths
     fail_on_zero_tests:     [Boolean] whether process should exit with error status when no tests found  
     unsafe_file_serving:    [Boolean] allow serving directories that are not in your CWD (false)
+    reporter:               [String]  name of the reporter to be used in ci mode (tap, xunit, dot)
     
 
 ### Available hooks:


### PR DESCRIPTION
Recently I've struggled a bit how to add a xunit reporter to an ember-cli project, because ember-cli is running testem internally and there was no simple option to specify the `testem ci -R xunit`
