### PR TITLE
added ability to specify xunit output file

### DIFF
--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -10,6 +10,8 @@ var HookRunner = require('../hook_runner')
 var log = require('npmlog')
 var cleanExit = require('../clean_exit')
 var isa = require('../isa')
+var fs = require('fs')
+var wStream = null;
 
 function App(config, finalizer){
   this.exited = false
@@ -20,6 +22,7 @@ function App(config, finalizer){
   this.hookRunners = {}
   this.results = []
   this.reporter = this.initReporter(this.config.get('reporter'))
+  this.outFile = this.createWStream(this.config.get('out_file'))
   if (!this.reporter){
     console.error('Test reporter `' + reporter + '` not found.')
     this.cleanExit(1)
@@ -132,7 +135,7 @@ App.prototype = {
         }
       })
     }
-    this.reporter.finish()
+    this.reporter.finish(this.outFile)
     this.emit('tests-finish')
     this.stopHookRunners()
     this.stopServer(this.exit.bind(this))
@@ -159,6 +162,12 @@ App.prototype = {
     if (this.reporter.total === 0 && this.config.get('fail_on_zero_tests'))
       return 1
     return 0
+  },
+
+  createWStream: function(outFileName) {
+    if(outFileName) {
+      return fs.createWriteStream(outFileName);
+    }
   },
 
   exit: function(){

--- a/lib/ci/test_reporters/xunit_reporter.js
+++ b/lib/ci/test_reporters/xunit_reporter.js
@@ -22,11 +22,14 @@ XUnitReporter.prototype = {
     this.total++
     if (data.passed) this.pass++
   },
-  finish: function(){
+  finish: function(writeStream){
     if (this.silent) return
     this.endTime = new Date()
     this.out.write(this.summaryDisplay())
     this.out.write('\n')
+    if(writeStream) {
+      writeStream.write(this.summaryDisplay())
+    }
   },
   summaryDisplay: function(){
     return '<testsuite name="Testem Tests" tests="' + this.total +

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -12,6 +12,11 @@ var Process = require('did_it_work')
 describe('ci mode app', function(){
 
   beforeEach(function(done){
+    fs.exists('test-output.xml', function(exists) {
+     if(exists) {
+       fs.unlinkSync('test-output.xml');
+     }
+    });
     fs.unlink('tests/fixtures/tape/public/bundle.js', function(){
       done()
     })
@@ -74,6 +79,18 @@ describe('ci mode app', function(){
     })
     var app = new App(config)
     assert.strictEqual(app.reporter, fakeReporter)
+  })
+  
+  it('allow passing in out_file from config', function() {
+    var outFile = 'test-output.xml';
+    assert.equal(fs.existsSync(outFile),false)
+    var config = new Config('ci', {
+      'out_file': outFile 
+    });
+    var app = new App(config);
+    console.log('app in test:', app)
+    assert.strictEqual(app.outFile.path, outFile);
+    assert.equal(fs.existsSync(outFile),true);
   })
 
   it('wrapUp reports error to reporter', function(){


### PR DESCRIPTION
- necessary to add to the testem config a key output_file : file-name.xml
- for now only for the xunit ci reporter
- test checks for output file presence
