### PR TITLE
Added phantomjs_viewport_size config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,10 @@ PhantomJS is a Webkit-based headless browser. It's fast and it's awesome! Testem
 
 And verify that it's in the list.
 
-If you want to debug tests in PhantomJS, include the `phantomjs_debug_port` option in your testem configuration, referencing an available port number.  Once testem has started PhantomJS, navigate (with a traditional browser) to http://localhost:<port> and attach to one of PhantomJS's browser tabs (probably the second one in the list).  `debugger` statements will now break in the debugging console.
+You can set the following PhantomJS specific options in your testem configuration:
+
+- `phantomjs_debug_port`: If you want to debug tests in PhantomJS, include the `phantomjs_debug_port` option in your testem configuration, referencing an available port number.  Once testem has started PhantomJS, navigate (with a traditional browser) to http://localhost:<port> and attach to one of PhantomJS's browser tabs (probably the second one in the list).  `debugger` statements will now break in the debugging console.
+- `phantomjs_viewport_size`: Set this option to a hash containing `width` and `height` to run the PhantomJS browser with a specific viewport size. Example: `phantomjs_viewport_size: {width: 1000, height: 800}`.
 
 Preprocessors (CoffeeScript, LESS, Sass, Browserify, etc)
 ---------------------------------------------------------

--- a/assets/phantom.js
+++ b/assets/phantom.js
@@ -1,3 +1,14 @@
-var page = require('webpage').create();
+//Extract arguments
 var url = phantom.args[0];
+var options = phantom.args[1] ? JSON.parse(phantom.args[1]) : {};
+
+//Create page
+var page = require('webpage').create();
+
+//Set viewportSize?
+if (options.viewportSize) {
+  page.viewportSize = options.viewportSize;
+}
+
+//Open page
 page.open(url);

--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -44,13 +44,21 @@ function setupFirefoxProfile(profileDir, done){
 }
 
 function buildPhantomJsArgs(config) {
-  var options = [path.dirname( __dirname ) + '/assets/phantom.js', this.getUrl()]
+  var options = {}
+  var viewportSize = config.get("phantomjs_viewport_size")
+  if (viewportSize) {
+      if (typeof viewportSize.width !== 'number' || typeof viewportSize.height !== 'number') {
+          throw new Error('Config option `phantomjs_viewport_size` must be a hash containing `width` and `height`. Example: `phantomjs_viewport_size: {width: 1000, height: 800}`')
+      }
+      options.viewportSize = viewportSize
+  }
+  var args = [path.dirname( __dirname ) + '/assets/phantom.js', this.getUrl(), JSON.stringify(options)]
   var debug_port = config.get( "phantomjs_debug_port" )
   if (debug_port) {
-    options.unshift( "--remote-debugg" + "er-autorun=true" )
-    options.unshift( "--remote-debugg" + "er-port=" + debug_port )
+    args.unshift( "--remote-debugg" + "er-autorun=true" )
+    args.unshift( "--remote-debugg" + "er-port=" + debug_port )
   }
-  return options
+  return args
 }
 
 
@@ -59,7 +67,7 @@ function buildPhantomJsArgs(config) {
 //
 // * `name` - the display name of the browser
 // * `exe` - path to the executable to use to launch the browser
-// * `setup(app, done)` - any initial setup needed before launching the executable(this is async, 
+// * `setup(app, done)` - any initial setup needed before launching the executable(this is async,
 //        the second parameter `done()` must be invoked when done).
 // * `supported(cb)` - an async function which tells us whether the browser is supported by the current machine.
 function browsersForPlatform(){
@@ -128,8 +136,8 @@ function browsersForPlatform(){
   }else if (platform === 'darwin'){
     return [
       {
-        name: "Chrome", 
-        exe: "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome", 
+        name: "Chrome",
+        exe: "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
         args: ["--user-data-dir=" + tempDir + "/testem.chrome", "--no-default-browser-check", "--no-first-run"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome', done)
@@ -137,8 +145,8 @@ function browsersForPlatform(){
         supported: browserExeExists
       },
       {
-        name: "Chrome Canary", 
-        exe: "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary", 
+        name: "Chrome Canary",
+        exe: "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary",
         args: ["--user-data-dir=" + tempDir + "/testem.chrome-canary", "--no-default-browser-check", "--no-first-run"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome-canary', done)
@@ -146,7 +154,7 @@ function browsersForPlatform(){
         supported: browserExeExists
       },
       {
-        name: "Firefox", 
+        name: "Firefox",
         exe: "/Applications/Firefox.app/Contents/MacOS/firefox",
         args: ["-profile", tempDir + "/testem.firefox"],
         setup: function(config, done){
@@ -202,7 +210,7 @@ function browsersForPlatform(){
       {
         name: 'Chrome',
         exe: 'google-chrome',
-        args: ["--user-data-dir=" + tempDir + "/testem.chrome", 
+        args: ["--user-data-dir=" + tempDir + "/testem.chrome",
           "--no-default-browser-check", "--no-first-run"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome', done)
@@ -212,7 +220,7 @@ function browsersForPlatform(){
       {
         name: 'Chromium',
         exe: ['chromium', 'chromium-browser'],
-        args: ["--user-data-dir=" + tempDir + "/testem.chromium", 
+        args: ["--user-data-dir=" + tempDir + "/testem.chromium",
           "--no-default-browser-check", "--no-first-run"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chromium', done)

--- a/tests/browser_launcher_tests.js
+++ b/tests/browser_launcher_tests.js
@@ -1,0 +1,53 @@
+var path = require('path')
+var browserLauncher = require('../lib/browser_launcher')
+var Launcher = require('../lib/launcher')
+var Config = require('../lib/config')
+var assert = require('chai').assert
+
+describe('browser_launcher', function(){
+  var originalPlatform = process.platform
+  var browserMap = {}
+
+  before(function(done) {
+    process.platform = 'linux'
+    browserLauncher.getAvailableBrowsers(function(foundBrowsers) {
+        foundBrowsers.forEach(function(browser) {
+            browserMap[browser.name] = browser
+        })
+        done()
+    })
+  })
+
+  after(function() {
+    process.platform = originalPlatform
+  })
+
+  describe('with phantomjs', function() {
+      it('should have phantom.js path and url in args', function() {
+        var config = new Config(null, {port: '7357', url: 'http://blah.com/'})
+        var launcher = new Launcher('whatever', browserMap.PhantomJS, config)
+        var args = launcher.getArgs()
+
+        assert.equal(args[0], path.join(__dirname, '..', 'assets', 'phantom.js'))
+        assert(args[1].match(/^http:\/\/blah\.com\/\d+$/), 'Url should match')
+        assert.equal(args[2], '{}')
+      })
+
+      it('should include viewportSize in args', function() {
+        var config = new Config(null, {phantomjs_viewport_size: {width: 1000, height: 800}})
+        var launcher = new Launcher('whatever', browserMap.PhantomJS, config)
+        var args = launcher.getArgs()
+
+        assert.equal(args[2], '{"viewportSize":{"width":1000,"height":800}}')
+      })
+
+      it('should include debug port in args', function() {
+        var config = new Config(null, {phantomjs_debug_port: 1234})
+        var launcher = new Launcher('whatever', browserMap.PhantomJS, config)
+        var args = launcher.getArgs()
+
+        assert.equal(args[0], '--remote-debugger-port=1234')
+        assert.equal(args[1], '--remote-debugger-autorun=true')
+      })
+  })
+})


### PR DESCRIPTION
We have a test suite that tests a webapp with some drag and drop functionality. For that to work the browser's viewport needs to be a certain size.

This PR makes it possible for users to add `phantomjs_viewport_size` to their `testem.json` and get control over the window's size.

Example:

``` json
{
  "phantomjs_viewport_size": {
    "width": 1000,
    "height": 800
  }
}
```

I added a new test file `tests/browser_launcher_tests.js` that tests the `lib/browser_launcher.js` module. I only added tests concering the PhantomJS command line args. Let me know if you want the tests on a different format.

Questions:
- I added a validation check of the values of `width` and `height`. I'm not sure what your preferred way of warning the user about this is? I just had it throw an exception.
