### PR TITLE
Bug Fix: Fixes issue #406 that was introduced in commit 86f308844e

### DIFF
--- a/lib/ci/test_reporters/tap_reporter.js
+++ b/lib/ci/test_reporters/tap_reporter.js
@@ -29,7 +29,11 @@ TapReporter.prototype = {
       .map(function(key){
         return key + ': >\n' + strutils.indent(String(err[key]))
       })
-    var testLogs = ["Log: >"].concat(logs.map(function(log){return strutils.indent(String(log))}))
+    if(logs){
+        var testLogs = ["Log: >"].concat(logs.map(function(log){return strutils.indent(String(log))}))
+    } else {
+        var testLogs = []
+    }
     return strutils.indent([
       '---',
       strutils.indent(failed.concat(testLogs).join('\n')),


### PR DESCRIPTION
An error was being generated when using the `tap_reporter` with a work flow
that did not go through the `browser_test_runner`. This commit provides
a check which safely allows the logging functionality introduced in the
previous commit to work with all work flows.
