### PR TITLE
Add middleware configuration

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -59,9 +59,10 @@ Server.prototype = {
   , createExpress: function(){
     var self = this
     var app = this.express = Express()
-        
+
     this.configureExpress(app)
 
+    this.injectMiddleware(app)
 
     this.configureProxy(app)
 
@@ -99,6 +100,14 @@ Server.prototype = {
       })
       app.use(Express.static(__dirname + '/../../public'))
     })
+  }
+  , injectMiddleware: function(app) {
+    var middlewares = this.config.get('middleware')
+    if (middlewares) {
+      middlewares.forEach(function(middleware) {
+        middleware(app);
+      })
+    }
   }
   , configureProxy: function(app) {
     var proxies = this.config.get('proxies');


### PR DESCRIPTION
Testem servers can have custom middleware layers injected prior to the
proxy server.

Meant to be used by consuming applications instantiating their own
custom testem instances:

```
testem.startCI({
  middleware: [
    middlewareOne,
    middlewareTwo
  ]
});
```
