### PR TITLE
Proof-of-concept for top-level errors in CI mode

### DIFF
--- a/lib/ci/browser_test_runner.js
+++ b/lib/ci/browser_test_runner.js
@@ -21,6 +21,14 @@ BrowserTestRunner.prototype = {
       socket.on('test-result', this.onTestResult.bind(this))
       socket.on('log', function(log){this.logs.push(log)}.bind(this))
       socket.once('all-test-results', this.onAllTestResults.bind(this))
+      socket.on('top-level-error', function(msg,url,line){
+        self.reporter.report(self.browserName, {
+          passed: false,
+          name: 'Global error: ' + msg + ' at ' + url + ', line ' + line + '\n',
+          logs: [],
+          error: {}
+        })
+      }.bind(this))      
       var tap = new BrowserTapConsumer(socket)
       tap.on('test-result', this.onTestResult.bind(this))
       tap.on('all-test-results', this.onAllTestResults.bind(this))


### PR DESCRIPTION
As discussed in  stefanpenner/ember-cli#2142 and stefanpenner/ember-cli#2205 , if something goes very wrong in CI mode, tests just don't run instead of reporting the error(s).

As I'm not really familiar with this codebase yet, here's a small proof-of-concept on what I'd like to achieve.. If this approach is ok for you, I'll add test(s) to this PR so it can get merged.
