### PR TITLE
Testem with Phantom hangs on windows

### DIFF
--- a/lib/clean_exit.js
+++ b/lib/clean_exit.js
@@ -1,21 +1,7 @@
 function exit(code) {
-  // Workaround for this node core bug <https://github.com/joyent/node/issues/3584>
-  // Instead of using `process.exit(?code)`, use this instead.
-  //
-  // Wait for stdout and stderr to "drain" before exiting
-  var draining = 0
-  var onDrain = function() {
-    if (!draining--) process.exit(code)
-  }
-  if (process.stdout.bufferSize) {
-    draining++
-    process.stdout.once('drain', onDrain)
-  }
-  if (process.stderr.bufferSize) {
-    draining++
-    process.stderr.once('drain', onDrain)
-  }
-  if (!draining) process.exit(code)
+
+  var exit = require('exit');
+  exit(code);
 }
 
 module.exports = exit

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "consolidate": "~0.8.0",
     "did_it_work": "~0.0.5",
     "fireworm": "~0.5.0",
-    "npmlog": "~0.0.6"
+    "npmlog": "~0.0.6",
+	"exit": "0.1.2"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Running testem with phantom hangs on windows. Replacing the clean_exit.js exit-function to use node-exit lib fixed the hang.

This change was based on the windows_tests-branch.
