### PR TITLE
Chrome: include option --ignore-certificate-errors

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -92,7 +92,7 @@ function browsersForPlatform(){
           "C:\\Program Files\\Google\\Chrome\\Application\\Chrome.exe",
           "C:\\Program Files (x86)\\Google\\Chrome\\Application\\Chrome.exe"
         ],
-        args: ["--user-data-dir=" + tempDir + "\\testem.chrome", "--no-default-browser-check", "--no-first-run"],
+        args: ["--user-data-dir=" + tempDir + "\\testem.chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
         setup: function(config, done){
           rimraf(tempDir + '\\testem.chrome', done)
         },
@@ -130,7 +130,7 @@ function browsersForPlatform(){
       {
         name: "Chrome", 
         exe: "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome", 
-        args: ["--user-data-dir=" + tempDir + "/testem.chrome", "--no-default-browser-check", "--no-first-run"],
+        args: ["--user-data-dir=" + tempDir + "/testem.chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome', done)
         },
@@ -139,7 +139,7 @@ function browsersForPlatform(){
       {
         name: "Chrome Canary", 
         exe: "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary", 
-        args: ["--user-data-dir=" + tempDir + "/testem.chrome-canary", "--no-default-browser-check", "--no-first-run"],
+        args: ["--user-data-dir=" + tempDir + "/testem.chrome-canary", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome-canary', done)
         },
@@ -203,7 +203,7 @@ function browsersForPlatform(){
         name: 'Chrome',
         exe: 'google-chrome',
         args: ["--user-data-dir=" + tempDir + "/testem.chrome", 
-          "--no-default-browser-check", "--no-first-run"],
+          "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome', done)
         },
@@ -213,7 +213,7 @@ function browsersForPlatform(){
         name: 'Chromium',
         exe: ['chromium', 'chromium-browser'],
         args: ["--user-data-dir=" + tempDir + "/testem.chromium", 
-          "--no-default-browser-check", "--no-first-run"],
+          "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chromium', done)
         },

--- a/play/launcher.js
+++ b/play/launcher.js
@@ -9,7 +9,7 @@ var spawn = require('child_process').spawn
 
 var browsers = [
   ["PhantomJS", "/usr/local/bin/phantomjs"],
-  ["Chrome", "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome", ["--user-data-dir=/tmp/chrome", "--no-default-browser-check", "--no-first-run"]],
+  ["Chrome", "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome", ["--user-data-dir=/tmp/chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"]],
   ["Safari", "/Applications/Safari.app/Contents/MacOS/Safari"],
   ["Firefox", "/Applications/Firefox.app/Contents/MacOS/firefox"]
 ]


### PR DESCRIPTION
This option will allow us to perform integration tests using Testem, as our server requires https.
