### PR TITLE
Fix multiple content-type proxying.

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -150,7 +150,7 @@ Server.prototype = {
     acceptCheck = acceptCheck.concat(opts.onlyContentTypes)
     acceptCheck.push('text')
     accepts = req.accepts(acceptCheck);
-    if (accepts.indexOf(opts.onlyContentTypes) !== -1) {
+    if (opts.onlyContentTypes.indexOf(accepts) !== -1) {
       return true;
     }
     return false;

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -33,7 +33,7 @@ describe('Server', function(){
           },
           '/api3': {
             target: 'http://localhost:13374',
-            onlyContentTypes: ['json']
+            onlyContentTypes: ['json', 'xml']
           },
         }
       })


### PR DESCRIPTION
I tried using the example for proxying multiple content types in README.md and it wasn't working. Looks like there was a small mix-up in the implementation.