### PR TITLE
Adds config option to attach event listeners to client Testem socket

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -77,12 +77,12 @@ Common Configuration Options
     cwd:                      [Path]    directory to use as root
     parallel:                 [Number]  max number of parallel runners (1)
     routes:                   [Object]  overrides for assets paths
-    fail_on_zero_tests:       [Boolean] whether process should exit with error status when no tests found  
+    fail_on_zero_tests:       [Boolean] whether process should exit with error status when no tests found
     unsafe_file_serving:      [Boolean] allow serving directories that are not in your CWD (false)
     reporter:                 [String]  name of the reporter to be used in ci mode (tap, xunit, dot)
     disable_watching:         [Boolean] disable any file watching
     ignore_missing_launchers: [Boolean] ignore missing launchers in ci mode
-
+    browser_event_listeners:  [Array]   list of eventName / eventListener pairs to attach to browser socket
 
 ### Available hooks:
 

--- a/lib/ci/browser_test_runner.js
+++ b/lib/ci/browser_test_runner.js
@@ -41,6 +41,11 @@ BrowserTestRunner.prototype = {
           })
         })
       }
+      if (config.get('browser_event_listeners')){
+        config.get('browser_event_listeners').forEach(function(listener){
+          socket.on(listener.eventName, listener.eventListener.bind(self))
+        })
+      }
       var tap = new BrowserTapConsumer(socket)
       tap.on('test-result', this.onTestResult.bind(this))
       tap.on('all-test-results', this.onAllTestResults.bind(this))


### PR DESCRIPTION
Can be used with custom reporters to send extra information from the browser.

```
browser_event_listeners: [
  {
    eventName: 'special-browser-event'
    eventListener: function(specialEventData) {
      console.log("This event was probably sent through window.Testem.emit");
      console.log("The browser that sent it was: " + this.browserName);
      console.log(specialEventData);
    }
  }
]
```