### PR TITLE
Adding documentation for `phantomjs_args`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,14 @@ And verify that it's in the list.
 
 If you want to debug tests in PhantomJS, include the `phantomjs_debug_port` option in your testem configuration, referencing an available port number.  Once testem has started PhantomJS, navigate (with a traditional browser) to http://localhost:<port> and attach to one of PhantomJS's browser tabs (probably the second one in the list).  `debugger` statements will now break in the debugging console.
 
+If you want to use any of the [PhantomJS command line options](http://phantomjs.org/api/command-line.html), include the `phantomjs_args` option in your testem configuration. For example:
+
+```javascript
+"phantomjs_args": [
+  "--ignore-ssl-errors=true"  
+]
+```
+
 Preprocessors (CoffeeScript, LESS, Sass, Browserify, etc)
 ---------------------------------------------------------
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -85,6 +85,8 @@ Common Configuration Options
     ignore_missing_launchers: [Boolean] ignore missing launchers in ci mode
     report_file:              [String]  file to write test results to (stdout)
     xunit_intermediate_output [Boolean] print tap output for the xunit reporter (false)
+    phantomjs_debug_port:     [Number]  port used to attach phantomjs debugger
+    phantomjs_args:           [Array]   custom arguments for the phantomjs launcher
 
 
 ### Available hooks:


### PR DESCRIPTION
I was looking for a way to pass custom arguments to PhantomJS, and couldn't find any documentation for it, but did find a reference to `phantomjs_args` in the code. I'd like to propose adding it to the main Readme. Thanks!