### PR TITLE
Wrap Linux browser launches with dbus-launch when possible

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -59,11 +59,11 @@ function buildPhantomJsArgs(config) {
 // * `setup(app, done)` - any initial setup needed before launching the executable(this is async,
 //        the second parameter `done()` must be invoked when done).
 // * `supported(cb)` - an async function which tells us whether the browser is supported by the current machine.
-function browsersForPlatform() {
+function browsersForPlatform(cb) {
   var platform = process.platform;
 
   if (platform === 'win32') {
-    return [
+    cb([
       {
         name: 'IE',
         exe: ':\\Program Files\\Internet Explorer\\iexplore.exe',
@@ -122,9 +122,9 @@ function browsersForPlatform() {
         args: buildPhantomJsArgs,
         supported: findableByWhereOrModule
       }
-    ];
+    ]);
   } else if (platform === 'darwin') {
-    return [
+    cb([
       {
         name: 'Chrome',
         exe: [
@@ -194,9 +194,9 @@ function browsersForPlatform() {
         args: buildPhantomJsArgs,
         supported: findableByWhichOrModule
       }
-    ];
+    ]);
   } else if (platform === 'linux') {
-    return [
+    var browsers = [
       {
         name: 'Firefox',
         exe: 'firefox',
@@ -239,39 +239,68 @@ function browsersForPlatform() {
         supported: findableByWhichOrModule
       }
     ];
+
+    // If dbus-launch is present, wrap google-chrome launch
+    // to prevent a race condition in Google Chrome
+    // Discussion here: https://github.com/angular/protractor/issues/2419
+    // Adds a second set of wrapper browsers that will override the previous set of browsers
+    // if dbus-launch is available.
+    var dbus = {
+      exe: 'dbus-launch',
+      supported: findableByWhich
+    };
+    dbus.supported(function(dbusAvailable) {
+      if (dbusAvailable) {
+        // Make sure the original browser was supported.
+        async.filter(browsers, function(browser, cb) {
+          browser.supported(cb);
+        }, function(available) {
+          available.forEach(function(browser) {
+            if (browser.name !== 'PhantomJS') {
+              browser.args.unshift('--exit-with-session', browser.exe);
+              browser.exe = dbus.exe;
+            }
+          });
+          cb(available);
+        });
+      } else {
+        cb(browsers);
+      }
+    });
   } else if (platform === 'sunos') {
-    return [
+    cb([
         {
           name: 'PhantomJS',
           exe: 'phantomjs',
           args: buildPhantomJsArgs,
           supported: findableByWhichOrModule
         }
-      ];
+      ]);
   } else if (platform === 'freebsd') {
-    return [
+    cb([
         {
           name: 'PhantomJS',
           exe: 'phantomjs',
           args: buildPhantomJsArgs,
           supported: findableByWhichOrModule
         }
-      ];
+      ]);
   } else {
-    return [];
+    cb([]);
   }
 }
 
 // Returns the avaliable browsers on the current machine.
 function getAvailableBrowsers(cb) {
-  var browsers = browsersForPlatform();
-  browsers.forEach(function(b) {
-    b.protocol = 'browser';
-  });
-  async.filter(browsers, function(browser, cb) {
-    browser.supported(cb);
-  }, function(available) {
-    cb(available);
+  browsersForPlatform(function(browsers) {
+    browsers.forEach(function(b) {
+      b.protocol = 'browser';
+    });
+    async.filter(browsers, function(browser, cb) {
+      browser.supported(cb);
+    }, function(available) {
+      cb(available);
+    });
   });
 }
 


### PR DESCRIPTION
I noticed that Chrome sometimes fails to start properly on Linux VMs. Recently, a solution has been found here: https://github.com/angular/protractor/issues/2419 that solves the issue (I've confirmed that by running tests repeatedly and getting no Chrome hangs). I implemented their solution here. This first checks whether the requisite executable is installed before wrapping the browsers, so this shouldn't cause any regressions.