### PR TITLE
Allow custom user data directories

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -87,6 +87,7 @@ Common Configuration Options
     xunit_intermediate_output [Boolean] print tap output for the xunit reporter (false)
     phantomjs_debug_port:     [Number]  port used to attach phantomjs debugger
     phantomjs_args:           [Array]   custom arguments for the phantomjs launcher
+    user_data_dir:            [String]  directory to initialize the browser user data directories (default a temporary directory)
 
 
 ### Available hooks:

--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -18,9 +18,6 @@ var findableByWhichOrModule = fileutils.findableByWhichOrModule;
 var findableByWhereOrModule = fileutils.findableByWhereOrModule;
 var os = require('os');
 
-var tempDir = os.tmpdir();
-var userHomeDir = process.env.HOME || process.env.USERPROFILE;
-
 function setupFirefoxProfile(profileDir, done) {
   rimraf(profileDir, function() {
     // using prefs.js to suppress the check default browser popup
@@ -59,8 +56,14 @@ function buildPhantomJsArgs(config) {
 // * `setup(app, done)` - any initial setup needed before launching the executable(this is async,
 //        the second parameter `done()` must be invoked when done).
 // * `supported(cb)` - an async function which tells us whether the browser is supported by the current machine.
-function browsersForPlatform(cb) {
+function browsersForPlatform(config, cb) {
   var platform = process.platform;
+  var tempDir = os.tmpdir();
+  var userHomeDir = process.env.HOME || process.env.USERPROFILE;
+  if (config.get('user_data_dir')) {
+    tempDir = path.resolve(config.cwd(), config.get('user_data_dir'));
+    userHomeDir = tempDir;
+  }
 
   if (platform === 'win32') {
     cb([
@@ -291,8 +294,8 @@ function browsersForPlatform(cb) {
 }
 
 // Returns the avaliable browsers on the current machine.
-function getAvailableBrowsers(cb) {
-  browsersForPlatform(function(browsers) {
+function getAvailableBrowsers(config, cb) {
+  browsersForPlatform(config, function(browsers) {
     browsers.forEach(function(b) {
       b.protocol = 'browser';
     });

--- a/lib/config.js
+++ b/lib/config.js
@@ -228,7 +228,7 @@ Config.prototype.isCwdMode = function() {
 
 Config.prototype.getAvailableLaunchers = function(cb) {
   var self = this;
-  browser_launcher.getAvailableBrowsers(function(availableBrowsers) {
+  browser_launcher.getAvailableBrowsers(self, function(availableBrowsers) {
     var availableLaunchers = {};
     availableBrowsers.forEach(function(browser) {
       var newLauncher = new Launcher(browser.name, browser, self);

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -223,7 +223,7 @@ describe('Config', function() {
   it('should getLaunchers should call getAvailable browsers', function(done) {
     stub(config, 'getWantedLaunchers', function(n, cb) {return cb(null, n);});
     var getAvailableBrowsers = browserLauncher.getAvailableBrowsers;
-    browserLauncher.getAvailableBrowsers = function(cb) {
+    browserLauncher.getAvailableBrowsers = function(config, cb) {
       cb([
       {name: 'Chrome', exe: 'chrome.exe'},
       {name: 'Firefox'}
@@ -239,6 +239,20 @@ describe('Config', function() {
     });
   });
 
+  it('should customize user_data_dir when provided', function(done) {
+    var config = new Config();
+    stub(config, 'getWantedLaunchers', function(n, cb) {return cb(null, n);});
+    config.set('user_data_dir', 'customDirectory');
+    config.getLaunchers(function(err, launchers) {
+      var correctFlag = config.cwd() + '/customDirectory/testem.firefox';
+      if (process.platform === 'win32') {
+        correctFlag = config.cwd() + '\\customDirectory\\testem.firefox';
+      }
+      expect(launchers.firefox.settings.args).to.include(correctFlag);
+      done();
+    });
+  });
+
   it('should install custom launchers', function(done) {
     stub(config, 'getWantedLaunchers', function(n, cb) {return cb(null, n);});
     config.config = {
@@ -249,7 +263,7 @@ describe('Config', function() {
       }
     };
     var getAvailableBrowsers = browserLauncher.getAvailableBrowsers;
-    browserLauncher.getAvailableBrowsers = function(cb) {cb([]);};
+    browserLauncher.getAvailableBrowsers = function(config, cb) {cb([]);};
     config.getLaunchers(function(err, launchers) {
       expect(launchers.node.name).to.equal('Node');
       expect(launchers.node.settings.command).to.equal('node tests.js');


### PR DESCRIPTION
This allows users to specify a directory for the browser user data profiles. Default behavior is the same as before.

Not sure how to test this.