### PR TITLE
Prevent multiple calls to callback error

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -103,7 +103,7 @@ BrowserTestRunner.prototype = {
       }, 1000);
     });
 
-    socket.on('all-test-results', this.onAllTestResults.bind(this));
+    socket.once('all-test-results', this.onAllTestResults.bind(this));
     socket.on('all-test-results', this.onEnd.bind(runner));
 
     var tap = new BrowserTapConsumer(socket);


### PR DESCRIPTION
This is a regression caused by https://github.com/testem/testem/commit/79e75d850942804e197d4bb676b9cbc5c4026b53

It appears that removing the `socket.once` allows multiple calls to the same callback, which is bad.