### PR TITLE
Use dbus-launch only on Linux Chrome browsers

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -254,21 +254,16 @@ function browsersForPlatform(config, cb) {
     };
     dbus.supported(function(dbusAvailable) {
       if (dbusAvailable) {
-        // Make sure the original browser was supported.
-        async.filter(browsers, function(browser, cb) {
-          browser.supported(cb);
-        }, function(available) {
-          available.forEach(function(browser) {
-            if (browser.name !== 'PhantomJS') {
-              browser.args.unshift('--exit-with-session', browser.exe);
-              browser.exe = dbus.exe;
-            }
-          });
-          cb(available);
+        // Only add dbus-launch on Chrome browsers.
+        var chromeBrowsers = ['Chrome', 'Chromium'];
+        browsers.forEach(function(browser) {
+          if (chromeBrowsers.indexOf(browser.name) !== -1) {
+            browser.args.unshift('--exit-with-session', browser.exe);
+            browser.exe = dbus.exe;
+          }
         });
-      } else {
-        cb(browsers);
       }
+      cb(browsers);
     });
   } else if (platform === 'sunos') {
     cb([


### PR DESCRIPTION
It seems that dbus-launch doesn't play nicely with Firefox. To be on the safe side, I've now limited dbus-launch to Linux Chrome browsers.