### PR TITLE
Asynchronously detect + setup the testFramework

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -75,10 +75,13 @@ function initTestFrameworkHooks(socket) {
 }
 
 function init() {
-  takeOverConsole();
   interceptWindowOnError();
-  initTestFrameworkHooks(Testem);
+  takeOverConsole();
   setupTestStats();
+  Testem.initTestFrameworkHooks = function() {
+    initTestFrameworkHooks(Testem);
+  };
+  initTestFrameworkHooks(Testem);
 }
 
 function setupTestStats() {
@@ -152,6 +155,8 @@ function emit() {
 }
 
 window.Testem = {
+  // set during init
+  initTestFrameworkHooks: undefined,
   emitConnectionQueue: [],
   useCustomAdapter: function(adapter) {
     adapter(this);

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -80,6 +80,8 @@ function initTestFrameworkHooks(socket) {
     busterAdapter(socket);
     testFrameworkDidInit = true;
   }
+
+  return testFrameworkDidInit;
 }
 
 function init() {
@@ -87,7 +89,10 @@ function init() {
   takeOverConsole();
   setupTestStats();
   Testem.initTestFrameworkHooks = function() {
-    initTestFrameworkHooks(Testem);
+     if (!initTestFrameworkHooks(Testem)) {
+      throw new Error('Testem was unable to detect a test framework, please be sure to have one loaded before invoking Testem.initTestFrameowkrHooks');
+     }
+
   };
   initTestFrameworkHooks(Testem);
 }

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -60,17 +60,25 @@ It also restarts the tests by refreshing the page when instructed by the server 
   }
 })();
 
+var testFrameworkDidInit = false;
 function initTestFrameworkHooks(socket) {
+  if (testFrameworkDidInit) { return; }
+
   if (typeof getJasmineRequireObj === 'function') {
     jasmine2Adapter(socket);
+    testFrameworkDidInit = true;
   } else if (typeof jasmine === 'object') {
     jasmineAdapter(socket);
+    testFrameworkDidInit = true;
   } else if ((typeof mocha).match(/function|object/)) {
     mochaAdapter(socket);
+    testFrameworkDidInit = true;
   } else if (typeof QUnit === 'object') {
     qunitAdapter(socket);
+    testFrameworkDidInit = true;
   } else if (typeof buster !== 'undefined') {
     busterAdapter(socket);
+    testFrameworkDidInit = true;
   }
 }
 


### PR DESCRIPTION
allows:

* testem.js to be loaded as soon as possible
* allowing testem to catch all errors
  * as the test framework itself can fail to load
* much better user experience in failure scenarios