### PR TITLE
Testem.hookIntoTestFramework to manually hook into your test framework

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -58,7 +58,7 @@ Common Configuration Options
     debug:                   [Boolean] debug mode (false)
     test_page:               [String]  path to the page to use to run tests
     growl:                   [Boolean] enables growl / native notifications (false)
-    bail_on_uncaught_error:  [Boolean] whether process should exit with error status when there are top level uncaught errors (via `window.onerror`) - in CI mode only
+    bail_on_uncaught_error:  [Boolean] whether process should exit with error status when there are top level uncaught errors (via `window.onerror`) (true)
 
 ### Config-level options:
 

--- a/examples/qunit_lazy/hello.js
+++ b/examples/qunit_lazy/hello.js
@@ -1,0 +1,3 @@
+function hello(name){
+    return "hello " + (name || 'world');
+}

--- a/examples/qunit_lazy/test.html
+++ b/examples/qunit_lazy/test.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+<title>Test'em</title>
+<script src="/testem.js"></script>
+<script src="//code.jquery.com/qunit/qunit-1.20.0.js"></script>
+<script src="hello.js"></script>
+<script src="tests.js"></script>
+<script>
+Testem.hookIntoTestFramework();
+</script>
+<link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.20.0.css"/>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/examples/qunit_lazy/testem.json
+++ b/examples/qunit_lazy/testem.json
@@ -1,0 +1,7 @@
+{
+  "framework": "qunit",
+  "test_page": "test.html",
+  "src_files": [
+    "*.js"
+  ]
+}

--- a/examples/qunit_lazy/tests.js
+++ b/examples/qunit_lazy/tests.js
@@ -1,0 +1,7 @@
+QUnit.test('says hello world', function(assert){
+    assert.equal(hello(), 'hello world', 'should equal hello world');
+});
+
+QUnit.test('says hello to person', function(assert){
+    assert.equal(hello('Bob'), 'hello Bob', 'should equal hello Bob');
+});

--- a/lib/config.js
+++ b/lib/config.js
@@ -156,7 +156,8 @@ Config.prototype.defaults = {
     return scheme + '://' + this.get('host') + ':' + this.get('port') + '/';
   },
   parallel: 1,
-  reporter: 'tap'
+  reporter: 'tap',
+  bail_on_uncaught_error: true
 };
 
 Config.prototype.mergeUrlAndQueryParams = function(urlString, queryParamsObj) {

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -61,12 +61,14 @@ BrowserTestRunner.prototype = {
       });
 
       if (config.get('bail_on_uncaught_error')) {
-        self.reporter.report(browser, {
+        self.onTestResult.call(runner, {
           passed: false,
           name: 'Global error: ' + msg + ' at ' + url + ', line ' + line + '\n',
           logs: [],
           error: {}
         });
+        self.onAllTestResults();
+        self.onEnd.call(runner);
       }
     });
 
@@ -104,7 +106,7 @@ BrowserTestRunner.prototype = {
       }, 1000);
     });
 
-    socket.once('all-test-results', this.onAllTestResults.bind(this));
+    socket.on('all-test-results', this.onAllTestResults.bind(this));
     socket.on('all-test-results', this.onEnd.bind(runner));
 
     var tap = new BrowserTapConsumer(socket);

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -75,10 +75,13 @@ function initTestFrameworkHooks(socket) {
 }
 
 function init() {
-  takeOverConsole();
   interceptWindowOnError();
-  initTestFrameworkHooks(Testem);
+  takeOverConsole();
   setupTestStats();
+  Testem.initTestFrameworkHooks = function() {
+    initTestFrameworkHooks(Testem);
+  };
+  initTestFrameworkHooks(Testem);
 }
 
 function setupTestStats() {
@@ -152,6 +155,8 @@ function emit() {
 }
 
 window.Testem = {
+  // set during init
+  initTestFrameworkHooks: undefined,
   emitConnectionQueue: [],
   useCustomAdapter: function(adapter) {
     adapter(this);

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -80,6 +80,8 @@ function initTestFrameworkHooks(socket) {
     busterAdapter(socket);
     testFrameworkDidInit = true;
   }
+
+  return testFrameworkDidInit;
 }
 
 function init() {
@@ -87,7 +89,10 @@ function init() {
   takeOverConsole();
   setupTestStats();
   Testem.initTestFrameworkHooks = function() {
-    initTestFrameworkHooks(Testem);
+     if (!initTestFrameworkHooks(Testem)) {
+      throw new Error('Testem was unable to detect a test framework, please be sure to have one loaded before invoking Testem.initTestFrameowkrHooks');
+     }
+
   };
   initTestFrameworkHooks(Testem);
 }

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -60,17 +60,25 @@ It also restarts the tests by refreshing the page when instructed by the server 
   }
 })();
 
+var testFrameworkDidInit = false;
 function initTestFrameworkHooks(socket) {
+  if (testFrameworkDidInit) { return; }
+
   if (typeof getJasmineRequireObj === 'function') {
     jasmine2Adapter(socket);
+    testFrameworkDidInit = true;
   } else if (typeof jasmine === 'object') {
     jasmineAdapter(socket);
+    testFrameworkDidInit = true;
   } else if ((typeof mocha).match(/function|object/)) {
     mochaAdapter(socket);
+    testFrameworkDidInit = true;
   } else if (typeof QUnit === 'object') {
     qunitAdapter(socket);
+    testFrameworkDidInit = true;
   } else if (typeof buster !== 'undefined') {
     busterAdapter(socket);
+    testFrameworkDidInit = true;
   }
 }
 

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -61,40 +61,40 @@ It also restarts the tests by refreshing the page when instructed by the server 
 })();
 
 var testFrameworkDidInit = false;
-function initTestFrameworkHooks(socket) {
-  if (testFrameworkDidInit) { return; }
-
-  if (typeof getJasmineRequireObj === 'function') {
-    jasmine2Adapter(socket);
-    testFrameworkDidInit = true;
-  } else if (typeof jasmine === 'object') {
-    jasmineAdapter(socket);
-    testFrameworkDidInit = true;
-  } else if ((typeof mocha).match(/function|object/)) {
-    mochaAdapter(socket);
-    testFrameworkDidInit = true;
-  } else if (typeof QUnit === 'object') {
-    qunitAdapter(socket);
-    testFrameworkDidInit = true;
-  } else if (typeof buster !== 'undefined') {
-    busterAdapter(socket);
-    testFrameworkDidInit = true;
+function hookIntoTestFramework(socket) {
+  if (testFrameworkDidInit) {
+    return;
   }
 
-  return testFrameworkDidInit;
+  var found = true;
+  if (typeof getJasmineRequireObj === 'function') {
+    jasmine2Adapter(socket);
+  } else if (typeof jasmine === 'object') {
+    jasmineAdapter(socket);
+  } else if ((typeof mocha).match(/function|object/)) {
+    mochaAdapter(socket);
+  } else if (typeof QUnit === 'object') {
+    qunitAdapter(socket);
+  } else if (typeof buster !== 'undefined') {
+    busterAdapter(socket);
+  } else {
+    found = false;
+  }
+
+  testFrameworkDidInit = found;
+  return found;
 }
 
 function init() {
   interceptWindowOnError();
   takeOverConsole();
   setupTestStats();
-  Testem.initTestFrameworkHooks = function() {
-     if (!initTestFrameworkHooks(Testem)) {
-      throw new Error('Testem was unable to detect a test framework, please be sure to have one loaded before invoking Testem.initTestFrameowkrHooks');
-     }
-
+  Testem.hookIntoTestFramework = function() {
+    if (!hookIntoTestFramework(Testem)) {
+      throw new Error('Testem was unable to detect a test framework, please load it before invoking Testem.hookIntoTestFramework');
+    }
   };
-  initTestFrameworkHooks(Testem);
+  hookIntoTestFramework(Testem);
 }
 
 function setupTestStats() {

--- a/tests/examples/examples_tests.js
+++ b/tests/examples/examples_tests.js
@@ -37,6 +37,10 @@ describe('examples', function() {
     testExample(path.join('examples/qunit_simple'), done);
   });
 
+  it('runs lazy qunit', function(done) {
+    testExample(path.join('examples/qunit_lazy'), done);
+  });
+
   it('runs routes', function(done) {
     testExample(path.join('examples/routes'), done);
   });


### PR DESCRIPTION
Exposed Testem.hookIntoTestFramework do allow hooking manually into a
test framework. This allows loading `testem.js` as first script to
catch parsing issues when framework and tests are bundled.

Replaces https://github.com/testem/testem/pull/709