### PR TITLE
Prevent double-callbacks on finish

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -5,8 +5,6 @@ var util = require('util');
 function BrowserTestRunner(launcher, reporter, index, singleRun) {
   this.launcher = launcher;
   this.reporter = reporter;
-  this.finished = false;
-  this.pending = true;
   this.running = false;
   this.index = index;
   this.id = this.launcher.id;
@@ -16,9 +14,10 @@ function BrowserTestRunner(launcher, reporter, index, singleRun) {
 BrowserTestRunner.prototype = {
   start: function(onFinish) {
     this.onFinish = onFinish;
+    this.finished = false;
+    this.pending = true;
 
     if (this.socket) {
-      this.pending = true;
       this.socket.emit('start-tests');
     } else {
       this.launcher.on('processExit', this.onProcessExit.bind(this));
@@ -176,6 +175,9 @@ BrowserTestRunner.prototype = {
     }, 1000);
   },
   finish: function() {
+    if (this.finished) {
+      return;
+    }
     this.finished = true;
     if (!this.singleRun) {
       if (this.onFinish) {

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -107,4 +107,21 @@ describe('browser test runner', function() {
       })).to.be.true();
     });
   });
+
+  describe('finish', function() {
+    var runner;
+
+    beforeEach(function() {
+      var reporter = new TapReporter();
+      var config = new Config('ci', { reporter: reporter });
+      var launcher = new Launcher('ci', { protocol: 'browser' }, config);
+      runner = new BrowserTestRunner(launcher, reporter);
+    });
+
+    it('ignores multiple finish calls', function(done) {
+      runner.start(done);
+      runner.finish();
+      runner.finish();
+    });
+  });
 });


### PR DESCRIPTION
In some cases all test results are transmitted multiple times, this
shouldn’t make testem crash

Related https://github.com/ember-cli/ember-cli/issues/5300