### PR TITLE
Pass on `skipped` info to the reporter

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -126,6 +126,7 @@ BrowserTestRunner.prototype = {
     this.reporter.report(this.browserName, {
       passed: !result.failed && !result.skipped,
       name: result.name,
+      skipped: result.skipped,
       runDuration: result.runDuration,
       logs: this.logs,
       error: errItems[0],

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -95,6 +95,16 @@ describe('browser test runner', function() {
       })).to.be.true();
     });
 
+    it('counts a test as skipped if it is skipped', function() {
+      runner.onTestResult({
+        failed: 0,
+        skipped: true,
+        name: 'skipped test',
+        runDuration: 20,
+      });
+      expect(reporter.skipped).to.equal(1);
+    });
+
     it('counts a test as passed if it has no failures and has not been skipped', function() {
       runner.onTestResult({
         failed: 0,


### PR DESCRIPTION
When a test was skipped, make sure to pass that information to the
reporter so it is properly counted.

Fixes #737