### PR TITLE
Pass on associated stacktrace from qunit log callback

### DIFF
--- a/public/testem/qunit_adapter.js
+++ b/public/testem/qunit_adapter.js
@@ -55,7 +55,7 @@ function qunitAdapter() {
         passed: params.result,
         line: lineNumber(e),
         file: sourceFile(e),
-        stack: stacktrace(e),
+        stack: stacktrace(e) || params.source,
         message: message(e)
       });
     } else {
@@ -69,6 +69,7 @@ function qunitAdapter() {
           passed: params.result,
           actual: params.actual,
           expected: params.expected,
+          stack: params.source,
           message: params.message
         });
       }


### PR DESCRIPTION
The [QUnit.log callback](http://api.qunitjs.com/QUnit.log/) will potentially pass a stacktrace. This should pass it along if it is available.

NB: I did not see a facility to test the QUnit adapter.