### PR TITLE
Fix dot test reporter outputting F for passed tests

### DIFF
--- a/lib/reporters/dot_reporter.js
+++ b/lib/reporters/dot_reporter.js
@@ -38,7 +38,7 @@ DotReporter.prototype = {
       this.out.write('.');
     } else if (result.skipped) {
       this.out.write('*');
-    } {
+    } else {
       this.out.write('F');
     }
   },

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -140,7 +140,7 @@ describe('test reporters', function() {
         });
         reporter.finish();
         var output = stream.read().toString();
-        assert.match(output, /  \./);
+        assert.match(output, /  \.\n\n/);
         assert.match(output, /1 tests complete \([0-9]+ ms\)/);
       });
     });


### PR DESCRIPTION
the dot test reporter was outputting F's `.F.F.F.F.F.F` regardless