### PR TITLE
Fix filter predicate for error items

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -83,7 +83,7 @@ BrowserTestRunner.prototype = {
   onTestResult: function(result) {
     var errItems = (result.items || [])
       .filter(function(item) {
-        return !item.passed || result.failed;
+        return !item.passed || item.failed;
       });
 
     this.reporter.report(this.browser, {


### PR DESCRIPTION
If the value of `result.failed` would be true, no items would have been
filtered from `result.items`.

Change that logic to only keep those items which failed or didn't pass.