### PR TITLE
Make tests without checks pass again

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -87,7 +87,7 @@ BrowserTestRunner.prototype = {
       });
 
     this.reporter.report(this.browser, {
-      passed: result.passed && !result.failed && !result.skipped,
+      passed: (result.passed !== false) && !result.failed && !result.skipped,
       name: result.name,
       skipped: result.skipped,
       runDuration: result.runDuration,

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -106,6 +106,19 @@ describe('browser test runner', function() {
       expect(reporter.skipped).to.equal(1);
     });
 
+    it('counts a test as passed when no failures occurred', function() {
+      runner.onTestResult({
+        name: 'no checks',
+        items: [],
+        failed: 0,
+        passed: 0,
+        skipped: false,
+        total: 0,
+        runDuration: 20
+      });
+      expect(reporter.pass).to.equal(1);
+    });
+
     it('counts a test as passed if it has no failures and has not been skipped', function() {
       runner.onTestResult({
         passed: true,


### PR DESCRIPTION
Tests which report their result with a numerical `passed` status would
fail when this value is falsy, i.e. "0". This is a regression which was
introduced in commit abb0fdc.

Make this work again even if the value is a number and add a test case.

Fixes #749