### PR TITLE
Avdv fix filter predicate for errors

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -83,7 +83,7 @@ BrowserTestRunner.prototype = {
   onTestResult: function(result) {
     var errItems = (result.items || [])
       .filter(function(item) {
-        return !item.passed || item.failed;
+        return !item.passed;
       });
 
     this.reporter.report(this.browser, {

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -83,7 +83,7 @@ BrowserTestRunner.prototype = {
   onTestResult: function(result) {
     var errItems = (result.items || [])
       .filter(function(item) {
-        return !item.passed || result.failed;
+        return !item.passed || item.failed;
       });
 
     this.reporter.report(this.browser, {

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -118,6 +118,20 @@ describe('browser test runner', function() {
         return r.result.passed;
       })).to.be.true();
     });
+
+    it('reports the first failed item as error', function() {
+      var failedItem = { name: 'failed', failed: 1 };
+
+      runner.onTestResult({
+        failed: 1,
+        skipped: false,
+        name: 'failed test',
+        runDuration: 20,
+        items: [{ name: 'passed', passed: 1 }, failedItem]
+      });
+
+      expect(reporter.results[0].result.error).to.eq(failedItem);
+    });
   });
 
   describe('finish', function() {


### PR DESCRIPTION
`item.passed` is already a boolean and no a number as in suite / group
reports

Fixes https://github.com/testem/testem/pull/750