### PR TITLE
Exit only when report file stream ended to avoid partial file

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -24,13 +24,6 @@ function App(config, finalizer) {
   this.config = config;
   this.stdoutStream = config.get('stdout_stream') || process.stdout;
   this.server = new Server(this.config);
-  this.cleanExit = function(err) {
-    var exitCode = 0;
-    if (err) {
-      exitCode = 1;
-    }
-    (finalizer || cleanExit)(exitCode, err);
-  };
   this.Process = Process;
   this.hookRunners = {};
   this.results = [];
@@ -45,6 +38,25 @@ function App(config, finalizer) {
       'Test reporter `' + this.config.get('reporter') + '` not found.'
     ));
   }
+
+  this.cleanExit = function(err) {
+    var exit = function() {
+      var exitCode = 0;
+      if (err) {
+        exitCode = 1;
+      }
+      (finalizer || cleanExit)(exitCode, err);
+    };
+
+    if (this.reportFile) {
+      // Exit only when report file stream ended
+      this.reportFile.fileStream.on('finish', exit);
+      this.reportFile.fileStream.on('close', exit);
+      this.reportFile.fileStream.on('error', exit);
+    } else {
+      exit();
+    }
+  };
 }
 
 App.prototype = {
@@ -161,6 +173,12 @@ App.prototype = {
       });
     }
     this.reporter.finish();
+
+    // Close the file report stream
+    if (this.reportFile) {
+      this.reportFile.stream.end();
+    }
+
     this.emit('tests-finish');
     this.stopHookRunners();
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -40,12 +40,14 @@ function App(config, finalizer) {
   }
 
   this.cleanExit = function(err) {
+    var alreadyExit = false;
     var exit = function() {
-      var exitCode = 0;
-      if (err) {
-        exitCode = 1;
+      if (!alreadyExit) {
+        alreadyExit = true;
+
+        var exitCode = err ? 1 : 0;
+        (finalizer || cleanExit)(exitCode, err);
       }
-      (finalizer || cleanExit)(exitCode, err);
     };
 
     if (this.reportFile) {

--- a/lib/report_file.js
+++ b/lib/report_file.js
@@ -17,8 +17,12 @@ function ReportFile(reportFile, out) {
     fileStream.write(data);
   });
 
+  var alreadyEnded = false;
   function finish(data) {
-    fileStream.end(data);
+    if (!alreadyEnded) {
+      fileStream.end(data);
+      alreadyEnded = true;
+    }
   }
 
   this.outputStream.on('finish', finish);

--- a/lib/report_file.js
+++ b/lib/report_file.js
@@ -17,10 +17,13 @@ function ReportFile(reportFile, out) {
     fileStream.write(data);
   });
 
-  this.outputStream.on('end', function(data) {
-    out.end(data);
+  function finish(data) {
     fileStream.end(data);
-  });
+  }
+
+  this.outputStream.on('finish', finish);
+  this.outputStream.on('close', finish);
+  this.outputStream.on('error', finish);
 
   this.fileStream = fileStream;
   this.stream = this.outputStream;

--- a/tests/ci/report_file_tests.js
+++ b/tests/ci/report_file_tests.js
@@ -55,8 +55,9 @@ describe('report file output', function() {
     });
     var app = new App(config, function() {
       expect(app.reportFileName).to.eq(filename);
-      app.reportFile.fileStream.on('finish', done);
-      app.reportFileStream.end();
+
+      // fileStream already closed
+      done();
     });
     app.exit();
   });

--- a/tests/ci/report_file_tests.js
+++ b/tests/ci/report_file_tests.js
@@ -54,6 +54,7 @@ describe('report file output', function() {
       report_file: filename
     });
     var app = new App(config, function() {
+      console.log('entering app finalizer callback');
       expect(app.reportFileName).to.eq(filename);
 
       // fileStream already closed


### PR DESCRIPTION
The process was closed before the file report stream and so the report file was not completed.
The result with Jenkins TAP plugin is:
```
org.tap4j.parser.ParserException: Error parsing TAP Stream: Missing TAP Plan.
```