### PR TITLE
Fix IE exe path

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -70,7 +70,7 @@ function browsersForPlatform(config, cb) {
     cb([
       {
         name: 'IE',
-        exe: ':\\Program Files\\Internet Explorer\\iexplore.exe',
+        exe: 'C:\\Program Files\\Internet Explorer\\iexplore.exe',
         supported: browserExeExists
       },
       {


### PR DESCRIPTION
Looks like someone accidentally removed `C` in https://github.com/testem/testem/commit/4a85195f2cd0305a11d677a177fc177f1b98b143#diff-f6055c71cdaa57eff4423a9403d5b00bR74.