### PR TITLE
add configuration for cdata

### DIFF
--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -4,6 +4,7 @@ var XmlDom = require('xmldom');
 function XUnitReporter(silent, out, config) {
   this.out = out || process.stdout;
   this.printIntermediateOutput = config.get('xunit_intermediate_output');
+  this.includeStackTraces = config.get('xunit_include_stack') || true;
   this.silent = silent;
   this.stoppedOnError = null;
   this.id = 1;
@@ -73,7 +74,7 @@ XUnitReporter.prototype = {
       var failureNode = document.createElement('failure');
       failureNode.setAttribute('name', result.name);
       failureNode.setAttribute('message', error.message);
-      if (error.stack) {
+      if (error.stack && this.includeStackTraces) {
         var cdata = document.createCDATASection(error.stack);
         failureNode.appendChild(cdata);
       }

--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -4,7 +4,7 @@ var XmlDom = require('xmldom');
 function XUnitReporter(silent, out, config) {
   this.out = out || process.stdout;
   this.printIntermediateOutput = config.get('xunit_intermediate_output');
-  this.includeStackTraces = config.get('xunit_include_stack') || true;
+  this.excludeStackTraces = config.get('xunit_exclude_stack');
   this.silent = silent;
   this.stoppedOnError = null;
   this.id = 1;
@@ -74,7 +74,7 @@ XUnitReporter.prototype = {
       var failureNode = document.createElement('failure');
       failureNode.setAttribute('name', result.name);
       failureNode.setAttribute('message', error.message);
-      if (error.stack && this.includeStackTraces) {
+      if (error.stack && !this.excludeStackTraces) {
         var cdata = document.createCDATASection(error.stack);
         failureNode.appendChild(cdata);
       }

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -260,13 +260,36 @@ describe('test reporters', function() {
         name: 'it didnt work',
         passed: false,
         error: {
-          message: (new Error('it crapped out')).stack
+          message: 'it crapped out',
+          stack: (new Error('it crapped out')).stack
         }
       });
       reporter.finish();
       var output = stream.read().toString();
-      assert.match(output, /it didnt work"/);
-      assert.match(output, /it crapped out/);
+      assert.match(output, /it didnt work/);
+      assert.match(output, /CDATA\[Error: it crapped out/);
+
+      assertXmlIsValid(output);
+    });
+
+    it('outputs errors without stack traces', function() {
+      var config = new Config('ci', {
+        xunit_intermediate_output: false,
+        xunit_exclude_stack: true
+      });
+      var reporter = new XUnitReporter(false, stream, config);
+      reporter.report('phantomjs', {
+        name: 'it didnt work',
+        passed: false,
+        error: {
+          message: 'it crapped out',
+          stack: (new Error('it crapped out')).stack
+        }
+      });
+      reporter.finish();
+      var output = stream.read().toString();
+      assert.match(output, /it didnt work/);
+      assert.notMatch(output, /CDATA\[Error: it crapped out/);
 
       assertXmlIsValid(output);
     });


### PR DESCRIPTION
This PR adds the ability to configure whether or not to include the cdata stack tracs that might not be parsed by some readers.