### PR TITLE
Configurable start timeout

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -89,7 +89,7 @@ Common Configuration Options
     phantomjs_args:              [Array]   custom arguments for the phantomjs launcher
     user_data_dir:               [String]  directory to initialize the browser user data directories (default a temporary directory)
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
-
+    browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
 
 ### Available hooks:
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -159,6 +159,7 @@ Config.prototype.defaults = {
   parallel: 1,
   reporter: 'tap',
   bail_on_uncaught_error: true,
+  browser_start_timeout: 30,
   browser_disconnect_timeout: 10
 };
 

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -14,6 +14,10 @@ function BrowserTestRunner(launcher, reporter, index, singleRun) {
 
 BrowserTestRunner.prototype = {
   start: function(onFinish) {
+    if (this.pending) {
+      return;
+    }
+
     this.onFinish = onFinish;
     this.finished = false;
     this.pending = true;
@@ -23,7 +27,24 @@ BrowserTestRunner.prototype = {
     } else {
       this.launcher.on('processExit', this.onProcessExit.bind(this));
       this.launcher.start();
+      this.setupStartTimer();
     }
+  },
+
+  setupStartTimer: function() {
+    var self = this;
+    this.startTimer = setTimeout(function() {
+      if (self.finished || !self.pending) {
+        return;
+      }
+
+      var result = {
+        failed: 1,
+        name: 'Browser ' + self.launcher.commandLine() + ' failed to connect. testem.js not loaded?'
+      };
+      self.onTestResult.call(self, result);
+      self.finish();
+    }, this.launcher.config.get('browser_start_timeout') * 1000);
   },
 
   tryAttach: function(browser, id, socket) {
@@ -33,8 +54,11 @@ BrowserTestRunner.prototype = {
 
     log.info('tryAttach', browser, id);
 
-    if (this.pending) {
-      clearTimeout(this.pending);
+    if (this.startTimer) {
+      clearTimeout(this.startTimer);
+    }
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
     }
 
     this.pending = false;
@@ -144,7 +168,8 @@ BrowserTestRunner.prototype = {
   },
   onDisconnect: function() {
     var self = this;
-    this.pending = setTimeout(function() {
+    this.pending = true;
+    this.pendingTimer = setTimeout(function() {
       if (self.finished) {
         return;
       }

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -464,6 +464,12 @@ describe('Config', function() {
       expect(config.get('browser_disconnect_timeout')).to.eq(10);
     });
   });
+
+  describe('browser_start_timeout', function() {
+    it('defaults to 30 seconds', function() {
+      expect(config.get('browser_start_timeout')).to.eq(30);
+    });
+  });
 });
 
 function mockTopLevelProgOptions() {


### PR DESCRIPTION
Adds a configurable start timeout (30s default) and fixes an issue when
re-running the test before is connected