### PR TITLE
Ensure failed tests are reported with XUnitReporter.

### DIFF
--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -71,18 +71,21 @@ XUnitReporter.prototype = {
 
     var error = result.error;
     if (error) {
-      var failureNode = document.createElement('failure');
-      failureNode.setAttribute('message', error.message);
+      var errorNode = document.createElement('error');
+      errorNode.setAttribute('message', error.message);
       if (error.stack && !this.excludeStackTraces) {
         var cdata = document.createCDATASection(error.stack);
-        failureNode.appendChild(cdata);
+        errorNode.appendChild(cdata);
       }
-      resultNode.appendChild(failureNode);
-    }
-    if (result.skipped) {
+      resultNode.appendChild(errorNode);
+    } else if (result.skipped) {
       var skippedNode = document.createElement('skipped');
       resultNode.appendChild(skippedNode);
+    } else if (!result.passed) {
+      var failureNode = document.createElement('failure');
+      resultNode.appendChild(failureNode);
     }
+
     return resultNode;
   },
   failures: function() {

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -267,7 +267,7 @@ describe('test reporters', function() {
       reporter.finish();
       var output = stream.read().toString();
       assert.match(output, /it didnt work/);
-      assert.match(output, /<failure message=\"it crapped out\">/);
+      assert.match(output, /<error message=\"it crapped out\">/);
       assert.match(output, /CDATA\[Error: it crapped out/);
 
       assertXmlIsValid(output);
@@ -290,7 +290,7 @@ describe('test reporters', function() {
       reporter.finish();
       var output = stream.read().toString();
       assert.match(output, /it didnt work/);
-      assert.match(output, /<failure message=\"it crapped out\"\/>/);
+      assert.match(output, /<error message=\"it crapped out\"\/>/);
       assert.notMatch(output, /CDATA\[Error: it crapped out/);
 
       assertXmlIsValid(output);
@@ -306,6 +306,33 @@ describe('test reporters', function() {
       reporter.finish();
       var output = stream.read().toString();
       assert.match(output, /<skipped\/>/);
+
+      assertXmlIsValid(output);
+    });
+
+    it('skipped tests are not considered failures', function() {
+      var reporter = new XUnitReporter(false, stream, config);
+      reporter.report('phantomjs', {
+        name: 'it didnt work',
+        passed: false,
+        skipped: true
+      });
+      reporter.finish();
+      var output = stream.read().toString();
+      assert.notMatch(output, /<failure/);
+
+      assertXmlIsValid(output);
+    });
+
+    it('outputs failed tests', function() {
+      var reporter = new XUnitReporter(false, stream, config);
+      reporter.report('phantomjs', {
+        name: 'it didnt work',
+        passed: false
+      });
+      reporter.finish();
+      var output = stream.read().toString();
+      assert.match(output, /<failure/);
 
       assertXmlIsValid(output);
     });


### PR DESCRIPTION
Prior to this, the `passed` flag for each test result was not actually
used to flag a given test as failed (we only checked `error`).

While reviewing the quasi-official implementation in the JUnit exporter
for `ant`, I noticed that error information should not be in `<failure>`
elements but they should be in `<error>` elements.

Implementation here:

* https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/taskdefs/optional/junit/XMLJUnitResultFormatter.java
* https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/taskdefs/optional/junit/XMLConstants.java