### PR TITLE
cancel existing timeouts

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -29,6 +29,7 @@ function App(config, finalizer) {
   this.results = [];
   this.runnerIndex = 0;
   this.runners = [];
+  this.timeoutID = undefined;
 
   this.reportFileName = this.config.get('report_file');
   this.reportFileStream = this.initReportFileStream(this.reportFileName);
@@ -164,10 +165,8 @@ App.prototype = {
 
     log.info('Stopping ' + this.config.appMode);
 
-    if (this.timeoutID) {
-      clearTimeout(this.timeoutID);
-      this.timeoutID = null;
-    }
+    this.cancelExistingTimeout();
+
     if (err) {
       this.reporter.report(null, {
         passed: false,
@@ -324,15 +323,22 @@ App.prototype = {
 
     return new (this.getRunnerFactory(launcher))(launcher, reporter, this.runnerIndex++, singleRun);
   },
+
   startClock: function(callback) {
     var self = this;
     var timeout = this.config.get('timeout');
     if (timeout) {
+      this.cancelExistingTimeout();
       this.timeoutID = setTimeout(function() {
         self.wrapUp(new Error('Timed out after ' + timeout + 's'));
       }, timeout * 1000);
     }
     callback(null);
+  },
+
+  cancelExistingTimeout: function() {
+    clearTimeout(this.timeoutID);
+    this.timeoutID = null;
   },
 
   singleRun: function(callback) {


### PR DESCRIPTION
* this prevents us from leaking existing timeouts
* this prevents leaked timeouts from spuriously triggering irrelevant timeout exceptions after restarts


- [ ] get feedback
- [x] add tests