### PR TITLE
Revert "Revert change to use `<error>` instead of `<failure>` for XUnitReporter."

### DIFF
--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -71,7 +71,7 @@ XUnitReporter.prototype = {
 
     var error = result.error;
     if (error) {
-      var errorNode = document.createElement('failure');
+      var errorNode = document.createElement('error');
       errorNode.setAttribute('message', error.message);
       if (error.stack && !this.excludeStackTraces) {
         var cdata = document.createCDATASection(error.stack);

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -267,7 +267,7 @@ describe('test reporters', function() {
       reporter.finish();
       var output = stream.read().toString();
       assert.match(output, /it didnt work/);
-      assert.match(output, /<failure message=\"it crapped out\">/);
+      assert.match(output, /<error message=\"it crapped out\">/);
       assert.match(output, /CDATA\[Error: it crapped out/);
 
       assertXmlIsValid(output);
@@ -290,7 +290,7 @@ describe('test reporters', function() {
       reporter.finish();
       var output = stream.read().toString();
       assert.match(output, /it didnt work/);
-      assert.match(output, /<failure message=\"it crapped out\"\/>/);
+      assert.match(output, /<error message=\"it crapped out\"\/>/);
       assert.notMatch(output, /CDATA\[Error: it crapped out/);
 
       assertXmlIsValid(output);


### PR DESCRIPTION
Reverts testem/testem#816

Should be correct, right @rwjblue @jreading?

Fixes https://github.com/testem/testem/issues/815