### PR TITLE
Disable timer throttling and renderer throttling in Chrome launchers by default.

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -96,7 +96,16 @@ function browsersForPlatform(config, cb) {
           'C:\\Program Files (x86)\\Google\\Chrome\\Application\\Chrome.exe'
         ],
         args: function(config, url) {
-          return ['--user-data-dir=' + getUserDataDir('chrome', this.id, platform), '--no-default-browser-check', '--no-first-run', '--ignore-certificate-errors', '--test-type', url];
+          return [
+            '--user-data-dir=' + getUserDataDir('chrome', this.id, platform),
+            '--no-default-browser-check',
+            '--no-first-run',
+            '--ignore-certificate-errors',
+            '--test-type',
+            '--disable-renderer-backgrounding',
+            '--disable-background-timer-throttling',
+            url
+          ];
         },
         setup: function(config, done) {
           rimraf(getUserDataDir('chrome', this.id, platform), done);
@@ -143,7 +152,16 @@ function browsersForPlatform(config, cb) {
           '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'
         ],
         args: function(config, url) {
-          return ['--user-data-dir=' + getUserDataDir('chrome', this.id), '--no-default-browser-check', '--no-first-run', '--ignore-certificate-errors', '--test-type', url];
+          return [
+            '--user-data-dir=' + getUserDataDir('chrome', this.id),
+            '--no-default-browser-check',
+            '--no-first-run',
+            '--ignore-certificate-errors',
+            '--test-type',
+            '--disable-renderer-backgrounding',
+            '--disable-background-timer-throttling',
+            url
+          ];
         },
         setup: function(config, done) {
           rimraf(getUserDataDir('chrome', this.id), done);
@@ -157,7 +175,16 @@ function browsersForPlatform(config, cb) {
           '/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary'
         ],
         args: function(config, url) {
-          return ['--user-data-dir=' + getUserDataDir('chrome-canary', this.id), '--no-default-browser-check', '--no-first-run', '--ignore-certificate-errors', '--test-type', url];
+          return [
+            '--user-data-dir=' + getUserDataDir('chrome-canary', this.id),
+            '--no-default-browser-check',
+            '--no-first-run',
+            '--ignore-certificate-errors',
+            '--test-type',
+            '--disable-renderer-backgrounding',
+            '--disable-background-timer-throttling',
+            url
+          ];
         },
         setup: function(config, done) {
           rimraf(getUserDataDir('chrome-canary', this.id), done);
@@ -232,7 +259,15 @@ function browsersForPlatform(config, cb) {
         name: 'Chrome',
         exe: 'google-chrome',
         args: function(config, url) {
-          return ['--user-data-dir=' + getUserDataDir('chrome', this.id), '--no-default-browser-check', '--no-first-run', '--ignore-certificate-errors', url];
+          return [
+            '--user-data-dir=' + getUserDataDir('chrome', this.id),
+            '--no-default-browser-check',
+            '--no-first-run',
+            '--ignore-certificate-errors',
+            '--disable-renderer-backgrounding',
+            '--disable-background-timer-throttling',
+            url
+          ];
         },
         setup: function(config, done) {
           rimraf(getUserDataDir('chrome', this.id), done);
@@ -243,7 +278,15 @@ function browsersForPlatform(config, cb) {
         name: 'Chromium',
         exe: ['chromium', 'chromium-browser'],
         args: function(config, url) {
-          return ['--user-data-dir=' + getUserDataDir('chromium', this.id), '--no-default-browser-check', '--no-first-run', '--ignore-certificate-errors', url];
+          return [
+            '--user-data-dir=' + getUserDataDir('chromium', this.id),
+            '--no-default-browser-check',
+            '--no-first-run',
+            '--ignore-certificate-errors',
+            '--disable-renderer-backgrounding',
+            '--disable-background-timer-throttling',
+            url
+          ];
         },
         setup: function(config, done) {
           rimraf(getUserDataDir('chromium', this.id), done);


### PR DESCRIPTION
Since [around 2012](https://bugs.webkit.org/show_bug.cgi?id=98474), WebKit and other browsers have throttled timers (like `setTimeout`) to only a max of once per second _in inactive tabs_.

For some test suites, this may never be an issue. But, for example, in a very large Ember test suite
with >1000 acceptance tests and much custom code, it manifested as often flaky and non-deterministic
test timeouts, even in headless CI environments with Chrome in xvfb.

This has caused much much testing pain that might manifest as the not-obviously-related error:
`Error: timeout of 10000ms exceeded. Ensure the done() callback is being called in this test.`

Also see things like:
> Command line option to allow background windows to run unthrottled.
> This is for tools like Karma/Jasmine and other testing tools that run continuously
> in the background.  The launched browser running the tests can be minimized as all test
> output goes to the console. However when the window is minimized the throttling takes effect
> and makes testing impossible.
- https://bugs.chromium.org/p/chromium/issues/detail?id=485425

**Chrome 49 stable** finally supports both of these flags which turn :cry: in to :grinning:. I've also confirmed it's safe to pass them to older Chrome versions where they are not supported:
- `--disable-background-timer-throttling`
- `--disable-renderer-backgrounding`

I strongly believe they should be passed in the default Chrome launcher configurations, to avoid unnecessarily slowing tests down.

Thoughts?