### PR TITLE
Cleanup when stopping runners

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -412,18 +412,17 @@ App.prototype = {
   },
 
   cleanUpProcessLaunchers: function(callback) {
-    var processLaunchers = this.launchers().filter(function(launcher) {
-      return launcher.isProcess();
+    var processRunners = this.runners.filter(function(runner) {
+      return runner.launcher.isProcess();
     });
-    async.forEach(processLaunchers, function(launcher, done) {
-      launcher.kill('SIGTERM', done);
+    async.each(processRunners, function(runner, next) {
+      runner.stop(next);
     }, callback);
   },
 
   cleanUpLaunchers: function(callback) {
-    var launchers = this.launchers();
-    async.forEach(launchers, function(launcher, done) {
-      launcher.kill('SIGTERM', done);
+    async.each(this.runners, function(runner, next) {
+      runner.stop(next);
     }, callback);
   },
 

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -31,6 +31,11 @@ BrowserTestRunner.prototype = {
     }
   },
 
+  stop: function(cb) {
+    this.launcher.removeListener('processExit', this.onProcessExit.bind(this));
+    this.launcher.kill(null, cb);
+  },
+
   setupStartTimer: function() {
     var self = this;
     this.startTimer = setTimeout(function() {

--- a/lib/runners/process_test_runner.js
+++ b/lib/runners/process_test_runner.js
@@ -15,6 +15,12 @@ ProcessTestRunner.prototype = {
     this.launcher.once('processError', this.onProcessError.bind(this));
   },
 
+  stop: function(cb) {
+    this.launcher.removeListener('processExit', this.onProcessExit.bind(this));
+    this.launcher.removeListener('processError', this.onProcessError.bind(this));
+    this.launcher.kill(null, cb);
+  },
+
   onProcessExit: function(code, stdout, stderr) {
     this.finish(null, code, stdout, stderr);
   },

--- a/lib/runners/tap_process_test_runner.js
+++ b/lib/runners/tap_process_test_runner.js
@@ -22,22 +22,26 @@ TapProcessTestRunner.prototype = {
     this.launcher.start();
     this.launcher.process.stdout.pipe(this.tapConsumer.stream);
   },
+  stop: function(cb) {
+    this.launcher.removeListener('processError', this.onProcessError.bind(this));
+    this.launcher.kill(null, cb);
+  },
   onTestResult: function(test) {
     test.launcherId = this.launcherId;
     this.reporter.report(this.launcher.name, test);
   },
   onAllTestResults: function() {
-    this.wrapUp();
+    setTimeout(function() { // Workaround Node 0.10 finishing stdout before receiving process error
+      this.wrapUp();
+    }.bind(this), 100);
   },
   wrapUp: function() {
     if (this.finished) {
       return;
     }
     this.finished = true;
-    this.launcher.kill(null, function() {
-      this.onEnd();
-      this.onFinish();
-    }.bind(this));
+    this.onEnd();
+    this.onFinish();
   },
   name: function() {
     return this.launcher.name;

--- a/lib/tap_consumer.js
+++ b/lib/tap_consumer.js
@@ -72,6 +72,7 @@ TapConsumer.prototype = {
       }
     };
 
+    this.stream.removeAllListeners();
     this.emit('test-result', test);
     this.emit('all-test-results');
   },

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -292,22 +292,19 @@ describe('ci mode app', function() {
       if (err) {
         return done(err);
       }
-      assert(app.runners[0].launcher.kill.called, 'launcher with process and kill should be called');
+      assert(app.runners[0].stop.called, 'launcher with process and kill should be called');
       done();
     });
     app.runners = [
       {
-        launcher: {
-          process: true,
-          kill: sandbox.stub().callsArg(1)
-        }
+        stop: sandbox.stub().callsArg(0)
       }
     ];
 
     var cb = spy();
     app.cleanUpLaunchers(cb);
     assert(cb.called, 'cleanUpLaunchers calls its given callback');
-    assert(app.runners[0].launcher.kill.called, 'launcher with process and kill should be called');
+    assert(app.runners[0].stop.called, 'launcher with process and kill should be called');
     app.exit();
   });
 

--- a/tests/runners/tap_process_test_runner_tests.js
+++ b/tests/runners/tap_process_test_runner_tests.js
@@ -359,6 +359,8 @@ describe('tap process test runner', function() {
       var runner = new TapProcessTestRunner(launcher, reporter);
 
       runner.start(function() {
+        console.trace(reporter);
+
         var total = reporter.total;
         var pass = reporter.pass;
         expect(pass).to.equal(0);


### PR DESCRIPTION
Prevent double exit calls and event listener leaking.

Fixes https://github.com/testem/testem/issues/812