### PR TITLE
Feed mocha test duration as 'runDuration' to reporter

### DIFF
--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -72,7 +72,7 @@ function mochaAdapter() {
 
     oEmit.apply(this, arguments);
 
-    function testPass() {
+    function testPass(test) {
       var tst = {
         passed: 1,
         failed: 0,
@@ -80,6 +80,7 @@ function mochaAdapter() {
         pending: 0,
         id: id++,
         name: name,
+        runDuration: test.duration,
         items: []
       };
       results.passed++;
@@ -102,6 +103,7 @@ function mochaAdapter() {
         pending: 0,
         id: id++,
         name: name,
+        runDuration: test.duration,
         items: items
       };
       return tst;


### PR DESCRIPTION
So that reporters get `runDuration` from mocha runner.

Similar to qunit https://github.com/testem/testem/commit/191ba59574e4a29b8d50923b02e673990e70b830