### PR TITLE
Fixes run afterTests hook for browser tap

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -98,13 +98,14 @@ BrowserTestRunner.prototype = {
     socket.on('disconnect', this.onDisconnect.bind(this));
 
     socket.on('all-test-results', this.onAllTestResults.bind(this));
-    socket.on('all-test-results', this.onEnd.bind(this));
     socket.on('after-tests-complete', this.onAfterTests.bind(this));
 
     var tap = new BrowserTapConsumer(socket);
     tap.on('test-result', this.onTestResult.bind(this));
     tap.on('all-test-results', this.onAllTestResults.bind(this));
-    tap.on('after-tests-complete', this.onAfterTests.bind(this));
+    tap.on('all-test-results', function() {
+      this.socket.emit('tap-all-test-results');
+    }.bind(this));
   },
 
   name: function() {
@@ -151,6 +152,7 @@ BrowserTestRunner.prototype = {
   },
   onAllTestResults: function() {
     log.info('Browser ' + this.name() + ' finished all tests.', this.singleRun);
+    this.onEnd();
   },
   onAfterTests: function() {
     this.finish();

--- a/lib/runners/tap_process_test_runner.js
+++ b/lib/runners/tap_process_test_runner.js
@@ -16,7 +16,7 @@ TapProcessTestRunner.prototype = {
 
     this.tapConsumer = new TapConsumer();
     this.tapConsumer.on('test-result', this.onTestResult.bind(this));
-    this.tapConsumer.on('after-tests-complete', this.onAllTestResults.bind(this));
+    this.tapConsumer.on('all-test-results', this.onAllTestResults.bind(this));
 
     this.launcher.once('processError', this.onProcessError.bind(this));
     this.launcher.start();

--- a/lib/tap_consumer.js
+++ b/lib/tap_consumer.js
@@ -74,11 +74,11 @@ TapConsumer.prototype = {
 
     this.stream.removeAllListeners();
     this.emit('test-result', test);
-    this.emit('after-tests-complete');
+    this.emit('all-test-results');
   },
   onTapEnd: function() {
     this.stream.removeAllListeners();
-    this.emit('after-tests-complete');
+    this.emit('all-test-results');
   }
 };
 

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -101,6 +101,7 @@ function init() {
   };
   hookIntoTestFramework(Testem);
   Testem.on('all-test-results', Testem.runAfterTests);
+  Testem.on('tap-all-test-results', Testem.runAfterTests);
 }
 
 function setupTestStats() {
@@ -280,6 +281,9 @@ window.Testem = {
           break;
         case 'iframe-ready':
           self.iframeReady();
+          break;
+        case 'tap-all-test-results':
+          self.emit('tap-all-test-results');
           break;
       }
     });

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -165,6 +165,9 @@ function initSocket(id) {
     syncConnectStatus();
   });
   socket.on('start-tests', startTests);
+  socket.on('tap-all-test-results', function() {
+    sendMessageToParent('tap-all-test-results');
+  });
 }
 
 window.TestemConnection = {


### PR DESCRIPTION
Tap browser tests are parsed within testem and the `all-test-results`
result was never send back to the client to execute the `afterTests`
hooks