### PR TITLE
Change teamcity reporter to remove reference to mocha

### DIFF
--- a/lib/reporters/teamcity_reporter.js
+++ b/lib/reporters/teamcity_reporter.js
@@ -26,7 +26,7 @@ TeamcityReporter.prototype = {
     }
     this.endTime = new Date();
     this.out.write('\n\n');
-    this.out.write('##teamcity[testSuiteFinished name=\'mocha.suite\' duration=\'' + this._duration() + '\']\n');
+    this.out.write('##teamcity[testSuiteFinished name=\'testem.suite\' duration=\'' + this._duration() + '\']\n');
     this.out.write('\n\n');
   },
   _display: function(prefix, result) {

--- a/testem.js
+++ b/testem.js
@@ -33,7 +33,7 @@ program
   .option('-T, --timeout [sec]', 'timeout a browser after [sec] seconds', null)
   .option('-P, --parallel [num]', 'number of browsers to run in parallel, defaults to 1', Number)
   .option('-b, --bail_on_uncaught_error', 'Bail on any uncaught errors')
-  .option('-R, --reporter [reporter]', 'Test reporter to use [tap|dot|xunit]', 'tap')
+  .option('-R, --reporter [reporter]', 'Test reporter to use [tap|dot|xunit|teamcity]', 'tap')
   .action(act(function(env) {
     env.__proto__ = program;
     progOptions = env;

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -403,7 +403,7 @@ describe('test reporters', function() {
       reporter.finish();
       var output = stream.read().toString();
 
-      assert.match(output, /##teamcity\[testSuiteFinished name='mocha\.suite' duration='(\d+(\.\d+)?)'\]/);
+      assert.match(output, /##teamcity\[testSuiteFinished name='testem\.suite' duration='(\d+(\.\d+)?)'\]/);
       assert.match(output, /##teamcity\[testStarted name='phantomjs - it does <cool> "cool" \|'cool\|' stuff']/);
       assert.match(output, /##teamcity\[testIgnored name='phantomjs - it skips stuff' message='pending']/);
     });


### PR DESCRIPTION
I was using this reporter with jasmine and wondered why it referenced mocha. Thought having it read "testem" would be more appropriate.