### PR TITLE
Remove the default progoption of reporter

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -33,7 +33,7 @@ program
   .option('-T, --timeout [sec]', 'timeout a browser after [sec] seconds', null)
   .option('-P, --parallel [num]', 'number of browsers to run in parallel, defaults to 1', Number)
   .option('-b, --bail_on_uncaught_error', 'Bail on any uncaught errors')
-  .option('-R, --reporter [reporter]', 'Test reporter to use [tap|dot|xunit|teamcity]', 'tap')
+  .option('-R, --reporter [reporter]', 'Test reporter to use [tap|dot|xunit|teamcity]')
   .action(act(function(env) {
     env.__proto__ = program;
     progOptions = env;


### PR DESCRIPTION
Remove the default progOption of reporter, to make the custom reporter work.

It will not affect the default value of reporter, cause the Config will get the default value "tap" when there are no progOption and fileOption of reporter.