### PR TITLE
Fixed launching of locally installed phantomjs

### DIFF
--- a/lib/env-with-local-path.js
+++ b/lib/env-with-local-path.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var _ = require('lodash');
+var path = require('path');
+var PATH = 'PATH';
+
+// windows calls it's path 'Path' usually, but this is not guaranteed.
+if (process.platform === 'win32') {
+  PATH = 'Path';
+  Object.keys(process.env).forEach(function(e) {
+    if (e.match(/^PATH$/i)) {
+      PATH = e;
+    }
+  });
+}
+
+var modulesPath = path.join(process.cwd(), 'node_modules', '.bin');
+
+module.exports = function envWithLocalPath() {
+  var env = _.clone(process.env);
+  env[PATH] = [modulesPath, env[PATH]].join(process.platform === 'win32' ? ';' : ':');
+
+  return env;
+};

--- a/lib/fileutils.js
+++ b/lib/fileutils.js
@@ -3,19 +3,8 @@ var path = require('path');
 var exec = require('child_process').exec;
 var async = require('async');
 var fileExists = fs.exists || path.exists;
-var _ = require('lodash');
 
-var PATH = 'PATH';
-
-// windows calls it's path 'Path' usually, but this is not guaranteed.
-if (process.platform === 'win32') {
-  PATH = 'Path';
-  Object.keys(process.env).forEach(function(e) {
-    if (e.match(/^PATH$/i)) {
-      PATH = e;
-    }
-  });
-}
+var envWithLocalPath = require('./env-with-local-path');
 
 exports.fileExists = fileExists;
 
@@ -56,13 +45,4 @@ function which(exe, cb) {
   exec('which ' + exe, { env: envWithLocalPath() }, function(err, exePath) {
     cb(!!exePath);
   });
-}
-
-var modulesPath = path.join(process.cwd(), 'node_modules', '.bin');
-
-function envWithLocalPath() {
-  var env = _.clone(process.env);
-  env[PATH] = [modulesPath, env[PATH]].join(process.platform === 'win32' ? ';' : ':');
-
-  return env;
 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -5,6 +5,7 @@ var log = require('npmlog');
 var fileutils = require('./fileutils');
 var async = require('async');
 var template = require('./strutils').template;
+var envWithLocalPath = require('./env-with-local-path');
 
 function Launcher(name, settings, config) {
   this.name = name;
@@ -54,10 +55,14 @@ Launcher.prototype = {
   doLaunch: function(cb) {
     var settings = this.settings;
     var self = this;
-    var options = {};
+    var options = {
+      env: envWithLocalPath()
+    };
+
     if (settings.cwd) {
       options.cwd = settings.cwd;
     }
+
     if (settings.exe) {
       var spawn = function spawn(exe, useCrossSpawn) {
         var args = self.getArgs();

--- a/tests/launcher_tests.js
+++ b/tests/launcher_tests.js
@@ -104,6 +104,18 @@ describe('Launcher', function() {
         done();
       });
     });
+
+    it('adds the local node modules to the path', function(done) {
+      settings.command = 'node -e "console.log(process.env.PATH)"';
+      config = new Config();
+      launcher.start();
+      launcher.on('processExit', function(code, stdout) {
+        expect(code).to.eq(0);
+        expect(stdout).to.contain(path.join(process.cwd(), 'node_modules', '.bin'));
+        done();
+      });
+    });
+
     it('sends SIGKILL when SIGTERM is ignored', function(done) {
       settings.command = 'node ' + path.join(__dirname, 'fixtures/processes/ignore_sigterm.js');
       launcher.start();

--- a/tests/runners/tap_process_test_runner_tests.js
+++ b/tests/runners/tap_process_test_runner_tests.js
@@ -359,8 +359,6 @@ describe('tap process test runner', function() {
       var runner = new TapProcessTestRunner(launcher, reporter);
 
       runner.start(function() {
-        console.trace(reporter);
-
         var total = reporter.total;
         var pass = reporter.pass;
         expect(pass).to.equal(0);


### PR DESCRIPTION
While the installed browser detection already added the node modules of the current
folder to the `PATH`. The launcher itself didn’t and could only start globally
installed instances.

Fixes https://github.com/testem/testem/issues/868