### PR TITLE
Handle different which exit codes

### DIFF
--- a/lib/fileutils.js
+++ b/lib/fileutils.js
@@ -19,21 +19,13 @@ exports.fileExists = fileExists;
 var executableExists = function(exe, options) {
   var cmd = isWin ? 'where' : 'which';
 
-  return new Bluebird.Promise(function(resolve, reject) {
+  return new Bluebird.Promise(function(resolve) {
     var test = childProcess.spawn(cmd, [exe], options);
     test.on('error', function(error) {
       log.error('Error spawning "' + cmd + exe + '"', error);
     });
     test.on('close', function(exitCode) {
-      if (exitCode === 0) {
-        return resolve(true);
-      }
-
-      if (exitCode === 1) {
-        return resolve(false);
-      }
-
-      return reject(exitCode);
+      return resolve(exitCode === 0);
     });
   });
 };

--- a/tests/fileutils_tests.js
+++ b/tests/fileutils_tests.js
@@ -1,13 +1,26 @@
 'use strict';
 
 var path = require('path');
+var childProcess = require('child_process');
+var EventEmitter = require('events').EventEmitter;
 
 var expect = require('chai').expect;
+var sinon = require('sinon');
 
 var fileutils = require('../lib/fileutils');
 var addToPATH = require('../lib/add-to-PATH');
 
 describe('fileutils', function() {
+  var sandbox;
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
   describe('fileExists', function() {
     it('returns true for an existing file', function() {
       return fileutils.fileExists(__filename).then(function(result) {
@@ -46,6 +59,21 @@ describe('fileutils', function() {
     });
 
     it('returns false for an not existing executable', function() {
+      return fileutils.executableExists('not-found').then(function(result) {
+        expect(result).to.be.false();
+      });
+    });
+
+    it('returns false for not existing executables with a custom which', function() {
+      var process = new EventEmitter();
+
+      sandbox.stub(childProcess, 'spawn', function() {
+        setTimeout(function() {
+          process.emit('close', 127);
+        })
+        return process;
+      });
+
       return fileutils.executableExists('not-found').then(function(result) {
         expect(result).to.be.false();
       });


### PR DESCRIPTION
In some environments, which is returning with error codes different from `1` when the executable wasn’t found.

Fixes https://github.com/testem/testem/issues/886