### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,9 +431,11 @@ Testem.afterTests(
     }
 });
 
-//Synchronously
+// Synchronously.
 Testem.afterTests(doStuff);
 ```
+
+NOTE: You must call the `callback()` argument or your tests will hang.
 
 
 Custom Routes


### PR DESCRIPTION
I found out the hard way that you must accept all three arguments to any afterTests method and call the `callback()` method, otherwise tests will hang. It would be nice if this behavior didn't exist, but a comment is at least called for.