### PR TITLE
Changed runAfterTests shift to use the same object as the conditional 

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -234,7 +234,7 @@ var Testem = {
   },
   runAfterTests: function() {
     if (Testem.afterTestsQueue.length) {
-      var afterTestsCallback = this.afterTestsQueue.shift();
+      var afterTestsCallback = Testem.afterTestsQueue.shift();
 
       if (typeof afterTestsCallback !== 'function') {
         throw Error('Callback not a function');


### PR DESCRIPTION
Without this change, you have to do `callback.apply(Testem)` in your `.afterTests` to prevent `this` from being undefined.
