### PR TITLE
Pin socket.io version to 1.4.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "npmlog": "^3.0.0",
     "printf": "^0.2.3",
     "rimraf": "^2.4.4",
-    "socket.io": "^1.4.1",
+    "socket.io": "1.4.7",
     "styled_string": "0.0.1",
     "tap-parser": "^1.1.3",
     "xmldom": "^0.1.19"


### PR DESCRIPTION
What appears to be a change in a downstream dependency of socket.io version 1.4.8 breaks IE <= 9.

This issue is tracked downstream in socketio/engine.io#407. We can use the Greenkeeper PR #907 to track unpinning this dependency once everything is resolved.

