### PR TITLE
Make test run stopping depend on process cleanup.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -111,19 +111,16 @@ App.prototype = {
     });
   },
 
-  stopCurrentRun: function(cb) {
+  stopCurrentRun: function() {
     if (this.stopping || !this.currentRun) {
       return Bluebird.resolve();
     }
     this.stopping = true;
 
     var self = this;
-
-    this.cleanUpProcessLaunchers();
-
-    return this.currentRun.finally(function() {
+    return Bluebird.all([ this.cleanUpProcessLaunchers(), this.currentRun ]).finally(function() {
       self.stopping = false;
-    }).asCallback(cb);
+    });
   },
 
   runTests: function(err, cb) {
@@ -404,13 +401,13 @@ App.prototype = {
     return null;
   },
 
-  cleanUpProcessLaunchers: function(callback) {
+  cleanUpProcessLaunchers: function() {
     var processRunners = this.runners.filter(function(runner) {
       return runner.launcher.isProcess();
     });
     return Bluebird.each(processRunners, function(runner) {
       return runner.stop();
-    }).asCallback(callback);
+    });
   },
 
   cleanUpLaunchers: function(callback) {


### PR DESCRIPTION
Tries to fix #902.

Manual testing using a sample small app suggests that this change fixes the crash. Logically, I think it is correct that the stopping flag is only reset after the launcher processes have a chance to clean up. I removed the node style callbacks from the two methods I touched, since they are not currently needed.

I spent several minutes trying to figure out a clean way to write a test that fails before and passes after, but could not come up with anything that doesn't use timing, which always makes me uncomfortable. I'm open to suggestions on how to write an automated regression test for this; in the meantime, would love to see this merged if the change makes sense.