### PR TITLE
[Bugfix #924] prevent unnecessary waits on shutdown

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -13,6 +13,9 @@ function BrowserTestRunner(launcher, reporter, index, singleRun) {
   this.id = this.launcher.id;
   this.singleRun = singleRun;
   this.logs = [];
+
+  this.pendingTimer = undefined;
+  this.onProcessExitTimer = undefined;
 }
 
 BrowserTestRunner.prototype = {
@@ -200,6 +203,9 @@ BrowserTestRunner.prototype = {
   },
   onDisconnect: function() {
     var self = this;
+
+    if (this.finished) { return; }
+
     this.pending = true;
     this.pendingTimer = setTimeout(function() {
       if (self.finished) {
@@ -219,9 +225,10 @@ BrowserTestRunner.prototype = {
     }, this.launcher.config.get('browser_disconnect_timeout') * 1000);
   },
   onProcessExit: function(code) {
-    var self = this;
+    if (this.finished) { return; }
 
-    setTimeout(function() {
+    var self = this;
+    this.onProcessExitTimer = setTimeout(function() {
       if (self.finished) {
         return;
       }
@@ -240,9 +247,11 @@ BrowserTestRunner.prototype = {
     }, 1000);
   },
   finish: function() {
-    if (this.finished) {
-      return;
-    }
+    if (this.finished) { return; }
+
+    clearTimeout(this.pendingTimer);
+    clearTimeout(this.onProcessExitTimer);
+
     this.finished = true;
     if (!this.singleRun) {
       if (this.onFinish) {


### PR DESCRIPTION
* don’t schedule “cleanup” tasks if already finished
* store setTimeout cookies, and cancel when finished

----

[Bugfix #924] 