### PR TITLE
Fix running Chrome browser on Windows via Jenkins

### DIFF
--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -26,6 +26,7 @@ function chromeArgs(browserTmpDir, url) {
     '--no-first-run',
     '--ignore-certificate-errors',
     '--test-type',
+    '--no-sandbox',
     '--disable-renderer-backgrounding',
     '--disable-background-timer-throttling',
     url

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -96,6 +96,7 @@ describe('knownBrowsers', function() {
           '--no-first-run',
           '--ignore-certificate-errors',
           '--test-type',
+          '--no-sandbox',
           '--disable-renderer-backgrounding',
           '--disable-background-timer-throttling',
           url


### PR DESCRIPTION
Chrome browser tests fail when running testem from Jenkins on Windows Server 2012. This patch adds the '--no-sandbox' flag to the Chrome command line arguments and allows Jenkins to run testem & Chrome.

Prior to applying this patch I'd receive the following output when trying to run from Jenkins.
```
Browser "C:\Program Files (x86)\Google\Chrome\Application\Chrome.exe --user-data-dir=C:\Users\Jenkins\AppData\Local\Temp\testem-5983 --no-default-browser-check --no-first-run --ignore-certificate-errors --test-type --disable-renderer-backgrounding --disable-background-timer-throttling http://localhost:7357/5983" failed to connect. testem.js not loaded?
```

Here is a link to people discussing the same issue with chrome driver for selenium
[https://bugs.chromium.org/p/chromedriver/issues/detail?id=46#c8](https://bugs.chromium.org/p/chromedriver/issues/detail?id=46#c8)