### PR TITLE
Properly handle flags in query params

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -187,7 +187,9 @@ Config.prototype.mergeUrlAndQueryParams = function(urlString, queryParamsObj) {
     outputQueryParams[param] = queryParamsObj[param];
   });
   urlObj.query = outputQueryParams;
-  urlObj.search = querystring.stringify(outputQueryParams);
+  urlObj.search = querystring.stringify(outputQueryParams)
+                    .replace(/\=&/g, '&')
+                    .replace(/=$/, '');
   urlObj.path = urlObj.pathname + urlObj.search;
   return url.format(urlObj);
 };

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -156,11 +156,12 @@ describe('Config', function() {
         test_page: 'http://my-url/path/',
         query_params: {
           library: 'testem',
-          language: 'javascript'
+          language: 'javascript',
+          flag: ''
         }
       });
       config.read(function() {
-        expect(config.get('test_page')[0]).to.equal('http://my-url/path/?library=testem&language=javascript');
+        expect(config.get('test_page')[0]).to.equal('http://my-url/path/?library=testem&language=javascript&flag');
         done();
       });
     });
@@ -182,10 +183,10 @@ describe('Config', function() {
     it('handles string query param argument', function(done) {
       var config = new Config('dev', {
         test_page: 'http://my-url/path/?language=python&os=mac',
-        query_params: '?language=english&library=british'
+        query_params: '?language=english&speak&library=british&flag'
       });
       config.read(function() {
-        expect(config.get('test_page')[0]).to.equal('http://my-url/path/?language=english&os=mac&library=british');
+        expect(config.get('test_page')[0]).to.equal('http://my-url/path/?language=english&os=mac&speak&library=british&flag');
         done();
       });
     });


### PR DESCRIPTION
Currently, if you pass a "flag" as a query parameter (e.g., a key without a value), then the resultant URL contains an unnecessary equal sign. In other words:

```js
var qs = require('querystring');
qs.stringify(qs.parse('foo&bar')) // => 'foo=&bar='
```

This is troublesome for query parsing implementations that I've worked with as the intent is unclear. Additionally, it results in unexpected behavior as a passed in query string may not be properly reflected in the browser.

Unfortunately, it doesn't look like this will be [supported by Node itself](https://github.com/nodejs/node/issues/7330) in the near future as the standard they've adopted does not define a behavior for it. So, I've implemented a simple solution within the Config code and modified the appropriate tests to cover this case.