### PR TITLE
Stop browser during run when restarting

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -41,7 +41,9 @@ BrowserTestRunner.prototype = {
   },
 
   stop: function(cb) {
-    // TODO: The current run should be stopped here
+    if (this.socket) {
+      this.socket.emit('stop-run');
+    }
     return Bluebird.resolve().asCallback(cb);
   },
 

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -215,6 +215,9 @@ var Testem = {
         case 'tap-all-test-results':
           self.emit('tap-all-test-results');
           break;
+        case 'stop-run':
+          self.emit('after-tests-complete');
+          break;
       }
     });
   },

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -168,6 +168,9 @@ function initSocket(id) {
   socket.on('tap-all-test-results', function() {
     sendMessageToParent('tap-all-test-results');
   });
+  socket.on('stop-run', function() {
+    sendMessageToParent('stop-run');
+  });
 }
 
 init();


### PR DESCRIPTION
Single browser has finished when triggering a new run to prevent
waiting for the previous usually useless run.