### PR TITLE
fix teamcity reporter - handle undefined errors

### DIFF
--- a/lib/reporters/teamcity_reporter.js
+++ b/lib/reporters/teamcity_reporter.js
@@ -38,7 +38,9 @@ TeamcityReporter.prototype = {
     if (result.skipped) {
       this.out.write('##teamcity[testIgnored name=\'' + this._namify(prefix, result) + '\' message=\'pending\']\n');
     } else if (!result.passed) {
-      this.out.write('##teamcity[testFailed name=\'' + this._namify(prefix, result) + '\' message=\'' + escape(result.error.message) + '\' details=\'' + escape(result.error.stack) + '\']\n');
+      var message = (result.error && result.error.message) || '';
+      var stack = (result.error && result.error.stack) || '';
+      this.out.write('##teamcity[testFailed name=\'' + this._namify(prefix, result) + '\' message=\'' + escape(message) + '\' details=\'' + escape(stack) + '\']\n');
     }
     this.out.write('##teamcity[testFinished name=\'' + this._namify(prefix, result) + '\']\n');
 

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -402,12 +402,40 @@ describe('test reporters', function() {
         name: 'it skips stuff',
         skipped: true
       });
+
+      reporter.report('phantomjs', {
+        name: 'it handles failures',
+        passed: false,
+        error: {
+          passed: false,
+          message: 'foo',
+          stack: 'bar'
+        }
+      });
+
+      reporter.report('phantomjs', {
+        name: 'it handles undefined errors',
+        passed: false,
+        skipped: undefined,
+        error: undefined,
+        pending: undefined
+      });
+
       reporter.finish();
       var output = stream.read().toString();
 
       assert.match(output, /##teamcity\[testSuiteFinished name='testem\.suite' duration='(\d+(\.\d+)?)'\]/);
       assert.match(output, /##teamcity\[testStarted name='phantomjs - it does <cool> "cool" \|'cool\|' stuff']/);
+      assert.match(output, /##teamcity\[testFinished name='phantomjs - it does <cool> "cool" \|'cool\|' stuff']/);
+      assert.match(output, /##teamcity\[testStarted name='phantomjs - it skips stuff']/);
       assert.match(output, /##teamcity\[testIgnored name='phantomjs - it skips stuff' message='pending']/);
+      assert.match(output, /##teamcity\[testFinished name='phantomjs - it skips stuff']/);
+      assert.match(output, /##teamcity\[testStarted name='phantomjs - it handles failures']/);
+      assert.match(output, /##teamcity\[testFailed name='phantomjs - it handles failures' message='foo' details='bar']/);
+      assert.match(output, /##teamcity\[testFinished name='phantomjs - it handles failures']/);
+      assert.match(output, /##teamcity\[testStarted name='phantomjs - it handles undefined errors']/);
+      assert.match(output, /##teamcity\[testFailed name='phantomjs - it handles undefined errors' message='' details='']/);
+      assert.match(output, /##teamcity\[testFinished name='phantomjs - it handles undefined errors']/);
     });
   });
 });


### PR DESCRIPTION
When there's a global error the reporter breaks the process and exits.
This PR just adds a validation to prevent throwing an error within the reporter when the test error is undefined.

Currently you will get something like this:
```
TypeError: Cannot read property 'message' of undefined
      at Object.TeamcityReporter._display (lib/reporters/teamcity_reporter.js:41:124)
      at Object.TeamcityReporter.report (lib/reporters/teamcity_reporter.js:17:10)
      at Context.<anonymous> (tests/ci/reporter_tests.js:406:16)
npm ERR! Test failed.  See above for more details.
Process exited with code 1
```

The actual result looks something like this and the error is **undefined**:
```
{ passed: false,
  name: 'Global error: ReferenceError: Can\'t find variable: XYZ at http://localhost:7357/668/tests/index.html?hidepassed=&_split=24&_partition=11, line 38\n',
  skipped: undefined,
  runDuration: undefined,
  logs:
   [ { type: 'error',
       text: 'ReferenceError: Can\'t find variable: XYZ at http://localhost:7357/668/tests/index.html?hidepassed=&_split=24&_partition=11, line 38\n' } ],
  error: undefined,
  launcherId: '668',
  failed: 1,
  pending: undefined,
  items: undefined }
```
