### PR TITLE
[FEATURE] Browser Flags (resolves #808)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,23 @@ This will display something like the following
 
 This displays the current list of launchers that are available. Launchers can launch either a browser or a custom process &mdash; as shown in the "Type" column. Custom launchers can be defined to launch custom processes. The "CI" column indicates the launchers which will be automatically launch in CI-mode. Similarly, the "Dev" column those that will automatically launch in dev-mode.
 
+Customizing Browser Arguments
+-----------------------------
+
+Testem passes its own list of arguments to some of the browsers it launches. You can add your own custom arguments to these lists by including the `browser_args` option in your Testem configuration. For example:
+
+```javascript
+"browser_args": {
+  "Chrome": [
+    "--auto-open-devtools-for-tabs"
+  ]
+}
+```
+
+You can supply arguments to any number of browsers Testem has available by using the launcher name as a key in `browser_args`. Values may be an array of string arguments or, if only one, a single string.
+
+Read [more details](docs/browser_args.md) about the browser argument options.
+
 Running Tests in Node and Custom Process Launchers
 --------------------------------------------------
 

--- a/docs/browser_args.md
+++ b/docs/browser_args.md
@@ -1,0 +1,104 @@
+Custom Browser Arguments with Testem
+====================================
+
+This document details the usage of the `browser_args` configuration option. Testem has the ability to automatically launch browsers or processes for you. Some of Testem's built-in launchers already supply a list of arguments to their respective browsers. You can add your own arguments to those lists for each browser.
+
+An Example
+----------
+
+Here's an example `testem.js` file
+
+```javascript
+module.exports = {
+  "framework": "qunit",
+  "test_page": "tests/index.html",
+  "launch_in_dev": [
+    "Chrome"
+  ],
+  "browser_args": {
+    "Chrome": [
+      "--auto-open-devtools-for-tabs"
+    ]
+  }
+};
+```
+
+In this example the `--auto-open-devtools-for-tabs` argument will be added to the list of arguments Testem supplies to the Chrome browser when it launches.
+
+Conventions
+-----------
+
+* The `browser_args` option is an object, i.e., a hash
+* The keys are launcher names, e.g., "Chrome" and they don't need to be capitalized
+* The values can be either:
+  * An array of strings (if you need to add many arguments)
+  * A single string (if you only need to add one argument)
+
+    ```javascript
+    "browser_args": {
+      "Chrome": [
+        "--auto-open-devtools-for-tabs"
+      ]
+    }
+
+    // OR
+
+    "browser_args": {
+      "chrome": "--auto-open-devtools-for-tabs"
+     }
+    ```
+
+Launchers
+---------
+
+Below is a list of built-in launchers. Use the names of the launchers as keys in the `browser_args` hash. The key names do not need to be capitalized.
+
+Note: This guide doesn't go into depth about the numerous command line arguments supported by each browser. It's a good idea to make sure the arguments you want to use work on the command line _before_ including them in the `browser_args` options.
+
+* Chrome
+* Chrome Canary
+* Chromium
+* Firefox
+* IE
+* Opera
+* PhantomJS
+* Safari
+
+Logging
+-------
+
+Using browser arguments can be tricky. It can be hard to know if the options you've supplied are working correctly. Testem will log warning messages whenever it encounters a problem with any of the `browser_args` options. You will need to use the `debug` configuration option in order to read the log.
+
+Read [more details](docs/config_file.md) about the config options including `debug`.
+
+Potential warnings:
+
+* `browser_args` is defined but isn't an object
+* One or more of the keys in the hash doesn't match the name of a built-in launcher, e.g., "Crome" vs. "Chrome"
+* One or more of the values in the hash wasn't an array or a string
+* One or more of the values in the hash is an empty array or an empty string
+* One of the values in the hash is an array but contains non-string or empty string values
+* One or more of the values in the hash duplicates an argument for a given browser
+
+PhantomJS Args
+--------------
+
+Prior to the availability of the `browser_args` configuration option, Testem allowed for a `phantomjs_args` option. This option is still available; however, it has the same purpose as `browser_args`.
+
+These two example options are essentially the same:
+
+```javascript
+"phantom_args": [
+  "--remote-debugger-port=1234"
+],
+"browser_args": [
+  "PhantomJS": "--remote-debugger-port=1234"
+]
+```
+
+While it may be strange to include both, this is not invalid.
+
+Note:
+
+* If the two options contain different flags, they will be combined
+* If the two options produce duplicates, they will be deduped

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -90,6 +90,7 @@ Common Configuration Options
     user_data_dir:               [String]  directory to initialize the browser user data directories (default a temporary directory)
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
+    browser_args:                [Object]  hash of browsers (keys) and their custom aruments (values)
 
 ### Available hooks:
 

--- a/lib/utils/browser-args.js
+++ b/lib/utils/browser-args.js
@@ -71,7 +71,7 @@ module.exports = {
           return self.dedupeBrowserArgs(browserName,
             browserArgs.concat(patchArgs.apply(this, arguments)));
         };
-      } else if (patchArgs == null) {
+      } else if (patchArgs === undefined) {
         validation.knownBrowser.args = function() {
           return browserArgs;
         };

--- a/lib/utils/browser-args.js
+++ b/lib/utils/browser-args.js
@@ -1,0 +1,145 @@
+'use strict';
+
+var capitalize = require('./capitalize');
+var log = require('npmlog');
+
+function Validation() {
+  this.knownBrowser = null;
+  this.messages = [];
+  this.valid = true;
+}
+
+function warn(message) {
+  log.warn('', message);
+}
+
+module.exports = {
+  addCustomArgs: function(knownBrowsers, config) {
+    if (!knownBrowsers || !config) { return; }
+
+    var browserArgs = config.get('browser_args');
+    var browserName;
+
+    if (browserArgs && typeof browserArgs === 'object') {
+      for (browserName in browserArgs) {
+        if (browserArgs.hasOwnProperty(browserName)) {
+          this.parseArgs(capitalize(browserName), browserArgs[browserName], knownBrowsers);
+        }
+      }
+    } else if (browserArgs !== undefined) {
+      warn('Type error: browser_args should be an object');
+    }
+
+    return knownBrowsers;
+  },
+  createValidation: function() {
+    return new Validation();
+  },
+  dedupeBrowserArgs: function(browserName, browserArgs) {
+    if (!browserName || !(browserArgs instanceof Array)) { return; }
+
+    var argHash = {};
+
+    browserArgs.forEach(function(arg) {
+      if (arg in argHash) {
+        warn('Removed duplicate arg for ' + browserName + ': ' + arg);
+      } else {
+        argHash[arg] = null;
+      }
+    });
+
+    return Object.keys(argHash);
+  },
+  parseArgs: function(browserName, browserArgs, knownBrowsers) {
+    if (!browserName || !browserArgs || !knownBrowsers) { return; }
+
+    var patchArgs;
+    var self = this;
+    var validation = this.validate(browserName, browserArgs, knownBrowsers);
+
+    if (validation.valid) {
+      if (typeof browserArgs === 'string') {
+        browserArgs = [browserArgs];
+      }
+
+      patchArgs = validation.knownBrowser.args;
+
+      if (patchArgs instanceof Array) {
+        validation.knownBrowser.args = browserArgs.concat(validation.knownBrowser.args);
+      } else if (typeof patchArgs === 'function') {
+        validation.knownBrowser.args = function() {
+          return self.dedupeBrowserArgs(browserName,
+            browserArgs.concat(patchArgs.apply(this, arguments)));
+        };
+      } else if (patchArgs == null) {
+        validation.knownBrowser.args = function() {
+          return browserArgs;
+        };
+      }
+    } else {
+      validation.messages.forEach(function(message) {
+        warn(message);
+      });
+    }
+  },
+  validate: function(browserName, browserArgs, knownBrowsers) {
+    if (!browserName || !browserArgs || !(knownBrowsers instanceof Array) ||
+      !knownBrowsers.length) { return; }
+
+    var i;
+    var len = knownBrowsers.length;
+    var validation = this.createValidation();
+
+    this.validateBrowserArgs(browserName, browserArgs, validation);
+
+    for (i = 0; i < len; i++) {
+      if (knownBrowsers[i].name === browserName) {
+        validation.knownBrowser = knownBrowsers[i];
+        break;
+      }
+    }
+
+    if (!validation.knownBrowser) {
+      validation.messages.push('Could not find "' + browserName + '" in known browsers');
+    }
+
+    validation.valid = !validation.messages.length;
+
+    return validation;
+  },
+  validateBrowserArgs: function(browserName, browserArgs, validation) {
+    if (!browserName || !validation) { return; }
+
+    var arg;
+    var i;
+    var len;
+
+    if (typeof browserArgs !== 'string' && !(browserArgs instanceof Array)) {
+      validation.messages.push('Type error: ' + browserName +
+        '\'s "args" property should be a string or an array');
+    } else if (typeof browserArgs === 'string' && !browserArgs.trim()) {
+      validation.messages.push('Bad value: ' + browserName +
+        '\'s "args" property should not be empty');
+    } else if (browserArgs instanceof Array) {
+      len = browserArgs.length;
+
+      if (len) {
+        for (i = 0; i < len; i++) {
+          arg = browserArgs[i];
+
+          if (typeof arg !== 'string') {
+            validation.messages.push('Bad value: ' + browserName +
+              '\'s "args" may only contain strings');
+            break;
+          } else if (!arg.trim()) {
+            validation.messages.push('Bad value: ' + browserName +
+              '\'s "args" may not contain empty strings');
+            break;
+          }
+        }
+      } else {
+        validation.messages.push('Bad value: ' + browserName + '\'s "args" property should not be empty');
+      }
+    }
+  }
+};

--- a/lib/utils/capitalize.js
+++ b/lib/utils/capitalize.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function(str) {
+  if (typeof str !== 'string') { return; }
+
+  // Special case for PhantomJS
+  if (str.toLowerCase() === 'phantomjs') {
+    return 'PhantomJS';
+  }
+
+  return str.replace(/\w+/g, function(word) {
+    return word.replace(/^[a-z]/, function(firstCharacter) {
+      return firstCharacter.toUpperCase();
+    });
+  });
+};

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var browserArgs = require('./browser-args');
 var path = require('path');
 var fs = require('fs');
 
@@ -160,7 +161,7 @@ function knownBrowsers(platform, config) {
     ]);
   }
 
-  return browsers;
+  return browserArgs.addCustomArgs(browsers, config);
 }
 
 module.exports = knownBrowsers;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "backbone": "^1.1.2",
-    "bluebird": "^3.4.0",
+    "bluebird": ">=3.4.0 <=3.4.5",
     "charm": "^1.0.0",
     "commander": "^2.6.0",
     "consolidate": "^0.14.0",

--- a/tests/utils/browser-args_tests.js
+++ b/tests/utils/browser-args_tests.js
@@ -70,7 +70,7 @@ describe('browserArgs', function() {
         };
 
         browserArgs.addCustomArgs(knownBrowsers, config);
-        
+
         expect(knownBrowsers[0].args()).to.deep.equal([ '--fake' ].concat(defaultArgs));
 
         // Resets known browsers value
@@ -129,7 +129,7 @@ describe('browserArgs', function() {
         var defaultArgs = createKnownBrowsers()[0].args();
 
         browserArgs.parseArgs('Chrome', '--fake', knownBrowsers);
-        
+
         expect(knownBrowsers[0].args()).to.deep.equal([ '--fake' ].concat(defaultArgs));
       });
 
@@ -139,7 +139,7 @@ describe('browserArgs', function() {
         var defaultArgs = createKnownBrowsers()[0].args();
 
         browserArgs.parseArgs('Chrome', [ '--fake' ], knownBrowsers);
-        
+
         expect(knownBrowsers[0].args()).to.deep.equal([ '--fake' ].concat(defaultArgs));
       });
 
@@ -149,7 +149,7 @@ describe('browserArgs', function() {
         var defaultArgs = createKnownBrowsers()[1].args;
 
         browserArgs.parseArgs('Firefox', '--fake', knownBrowsers);
-        
+
         expect(knownBrowsers[1].args).to.deep.equal([ '--fake' ].concat(defaultArgs));
       });
 
@@ -159,7 +159,7 @@ describe('browserArgs', function() {
         var defaultArgs = createKnownBrowsers()[1].args;
 
         browserArgs.parseArgs('Firefox', [ '--fake' ], knownBrowsers);
-        
+
         expect(knownBrowsers[1].args).to.deep.equal([ '--fake' ].concat(defaultArgs));
       });
     });

--- a/tests/utils/browser-args_tests.js
+++ b/tests/utils/browser-args_tests.js
@@ -1,0 +1,281 @@
+'use strict';
+
+var browserArgs = require('../../lib/utils/browser-args');
+var expect = require('chai').expect;
+var log = require('npmlog');
+
+var EventEmitter = require('events').EventEmitter;
+var fakeStream = new EventEmitter();
+
+fakeStream.write = function() {};
+log.stream = fakeStream;
+
+function createKnownBrowsers() {
+  return [{
+    name: 'Chrome',
+    args: function() {
+      return [
+        '--testem',
+        'http://localhost/'
+      ];
+    }
+  }, {
+    name: 'Firefox',
+    args: [
+      '--testem',
+      'http://localhost/'
+    ]
+  }];
+}
+
+describe('browserArgs', function() {
+  var config = {
+    get: function() {
+      return this.browser_args;
+    }
+  };
+  var knownBrowsers;
+
+  describe('methods', function() {
+    describe('addCustomArgs', function() {
+      afterEach(function() {
+        delete config.browser_args;
+      });
+
+      it('ignores no input', function() {
+        expect(browserArgs.addCustomArgs()).to.equal(undefined);
+      });
+
+      it('warns if browser_args is not an object', function(done) {
+        config.browser_args = 'invalid';
+
+        log.once('log.warn', function(warning) {
+          expect(warning.message).to.equal('Type error: browser_args should be an object');
+          done();
+        });
+
+        browserArgs.addCustomArgs(createKnownBrowsers(), config);
+      });
+
+      // NOTE: knownBrowsers[0] is Chrome
+      it('adds args to browser regardless of key capitalization', function() {
+        // Get Chrome's default args
+        var defaultArgs = createKnownBrowsers()[0].args();
+
+        knownBrowsers = createKnownBrowsers();
+
+        // NOTE: Chrome is not capitalized here
+        config.browser_args = {
+          chrome: '--fake'
+        };
+
+        browserArgs.addCustomArgs(knownBrowsers, config);
+        
+        expect(knownBrowsers[0].args()).to.deep.equal([ '--fake' ].concat(defaultArgs));
+
+        // Resets known browsers value
+        knownBrowsers = createKnownBrowsers();
+      });
+    });
+
+    describe('createValidation', function() {
+      it('creates an instance of Validation', function() {
+        var validation = browserArgs.createValidation();
+
+        expect(validation).to.have.property('knownBrowser', null);
+        expect(validation.messages).to.deep.equal([]);
+        expect(validation).to.have.property('valid', true);
+      });
+    });
+
+    describe('dedupeBrowserArgs', function() {
+      it('ignores no input', function() {
+        expect(browserArgs.dedupeBrowserArgs()).to.equal(undefined);
+      });
+
+      it('dedupes args', function(done) {
+        var args;
+
+        log.once('log.warn', function(warning) {
+          expect(warning.message).to.equal('Removed duplicate arg for Chrome: -b');
+          done();
+        });
+
+        args = browserArgs.dedupeBrowserArgs('Chrome', [ '-a', '-b', '-b' ]);
+
+        expect(args).to.deep.equal([ '-a', '-b' ]);
+      });
+
+      it('returns in tact args if no dupes', function() {
+        var argsIn = [ '-a', '-b', '-c' ];
+        var argsOut = browserArgs.dedupeBrowserArgs('Chrome', argsIn);
+
+        expect(argsOut).to.deep.equal(argsIn);
+      });
+    });
+
+    describe('parseArgs', function() {
+      beforeEach(function() {
+        knownBrowsers = createKnownBrowsers();
+      });
+
+      afterEach(function() {
+        knownBrowsers = createKnownBrowsers();
+      });
+
+      // NOTE: knownBrowsers[0] is Chrome
+      it('adds string args to browser with args method', function() {
+        // Get Chrome's default args
+        var defaultArgs = createKnownBrowsers()[0].args();
+
+        browserArgs.parseArgs('Chrome', '--fake', knownBrowsers);
+        
+        expect(knownBrowsers[0].args()).to.deep.equal([ '--fake' ].concat(defaultArgs));
+      });
+
+      // NOTE: knownBrowsers[0] is Chrome
+      it('adds array args to browser with args method', function() {
+        // Get Chrome's default args
+        var defaultArgs = createKnownBrowsers()[0].args();
+
+        browserArgs.parseArgs('Chrome', [ '--fake' ], knownBrowsers);
+        
+        expect(knownBrowsers[0].args()).to.deep.equal([ '--fake' ].concat(defaultArgs));
+      });
+
+      // NOTE: knownBrowsers[1] is Firefox
+      it('adds string args to browser with args array', function() {
+        // Get Firefox's default args
+        var defaultArgs = createKnownBrowsers()[1].args;
+
+        browserArgs.parseArgs('Firefox', '--fake', knownBrowsers);
+        
+        expect(knownBrowsers[1].args).to.deep.equal([ '--fake' ].concat(defaultArgs));
+      });
+
+      // NOTE: knownBrowsers[1] is Firefox
+      it('adds array args to browser with args array', function() {
+        // Get Firefox's default args
+        var defaultArgs = createKnownBrowsers()[1].args;
+
+        browserArgs.parseArgs('Firefox', [ '--fake' ], knownBrowsers);
+        
+        expect(knownBrowsers[1].args).to.deep.equal([ '--fake' ].concat(defaultArgs));
+      });
+    });
+
+    describe('validate', function() {
+      it('ignores invalid arguments', function() {
+        var badInputs = [
+          [],
+          [ 'Chrome' ],
+          [ 'Chrome', '--flag' ],
+          [ 'Chrome', '--flag', 'invalid' ]
+        ];
+
+        badInputs.forEach(function(inputValues) {
+          expect(browserArgs.validate.apply(browserArgs, inputValues)).to.equal(undefined);
+        });
+      });
+
+      it('returns a validation object', function() {
+        var validation = browserArgs.validate('Fake', '--flag', knownBrowsers);
+
+        expect(validation).to.have.property('knownBrowser', null);
+        expect(validation.messages).to.be.an.instanceof(Array);
+        expect(validation).to.have.property('valid', false);
+      });
+
+      it('warns if unknown browser in args', function() {
+        var validation = browserArgs.validate('Fake', '--flag', knownBrowsers);
+
+        expect(validation.messages[0]).to.equal('Could not find "Fake" in known browsers');
+      });
+    });
+
+    describe('validateBrowserArgs', function() {
+      var validation;
+
+      beforeEach(function() {
+        validation = browserArgs.createValidation();
+      });
+
+      it('ignores invalid arguments', function() {
+        var badInputs = [
+          [],
+          [ 'Chrome' ],
+          [ 'Chrome', '--flag' ]
+        ];
+
+        badInputs.forEach(function(inputs) {
+          expect(browserArgs.validateBrowserArgs.apply(browserArgs, inputs)).equal(undefined);
+        });
+      });
+
+      it('warns if args value not a string or array', function() {
+        browserArgs.validateBrowserArgs('Chrome', 0, validation);
+
+        expect(validation.messages[0]).to.equal('Type error: Chrome\'s "args" property should be a string or an array');
+      });
+
+      it('warns if string arg is empty', function() {
+        browserArgs.validateBrowserArgs('Chrome', '', validation);
+
+        expect(validation.messages[0]).to.equal('Bad value: Chrome\'s "args" property should not be empty');
+      });
+
+      it('warns if array arg is empty', function() {
+        browserArgs.validateBrowserArgs('Chrome', [], validation);
+
+        expect(validation.messages[0]).to.equal('Bad value: Chrome\'s "args" property should not be empty');
+      });
+
+      it('warns if array arg contains non-string values', function() {
+        browserArgs.validateBrowserArgs('Chrome', [ 0 ], validation);
+
+        expect(validation.messages[0]).to.equal('Bad value: Chrome\'s "args" may only contain strings');
+      });
+
+      it('warns if array arg contains empty strings', function() {
+        browserArgs.validateBrowserArgs('Chrome', [ ' ' ], validation);
+
+        expect(validation.messages[0]).to.equal('Bad value: Chrome\'s "args" may not contain empty strings');
+      });
+    });
+  });
+
+  describe('multiple warnings', function() {
+    afterEach(function() {
+      delete config.browser_args;
+    });
+
+    it('can log multiple validation warnings', function(done) {
+      var count = 1;
+      var warnHandler = function(warning) {
+        if (count === 1) {
+          expect(warning.message).to.equal('Could not find "Fake" in known browsers');
+        }
+
+        if (count === 2) {
+          expect(warning.message).to.equal('Bad value: Chrome\'s "args" may only contain strings');
+          log.removeListener('log.warn', warnHandler);
+          done();
+        }
+
+        count++;
+      };
+
+      config.browser_args = {
+        'Fake': '--testem',
+        'Chrome': [
+          '--testem',
+          12345
+        ]
+      };
+
+      log.on('log.warn', warnHandler);
+
+      browserArgs.addCustomArgs(knownBrowsers, config);
+    });
+  });
+});

--- a/tests/utils/capitalize_tests.js
+++ b/tests/utils/capitalize_tests.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var capitalize = require('../../lib/utils/capitalize');
+var expect = require('chai').expect;
+
+describe('capitalize', function() {
+  it('capitalizes the first letter of a string', function() {
+    expect(capitalize('lowercase')).to.equal('Lowercase');
+  });
+
+  it('capitalizes the fist letter of each word in a string', function() {
+    expect(capitalize('chrome canary')).to.equal('Chrome Canary');
+  });
+
+  it('capitalizes phantomjs correctly', function() {
+    expect(capitalize('phantomjs')).to.equal('PhantomJS');
+  });
+
+  it('ignores non-string arguments', function() {
+    var badInputs = [ 0, [], {}, NaN, null, undefined ];
+
+    badInputs.forEach(function(input) {
+      expect(capitalize(input)).to.equal(undefined);
+    });
+  });
+});

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -20,7 +20,7 @@ function addBrowserArgsToConfig(config, browserName) {
       args[browserName] = '--testem';
       return args;
     }
-  }
+  };
 }
 
 function createConfig() {
@@ -65,7 +65,7 @@ describe('knownBrowsers', function() {
     describe('Firefox', function() {
       var browsers;
       var firefox;
-      
+
       function setup(browserName) {
         if (browserName) {
           addBrowserArgsToConfig(config, browserName);
@@ -122,7 +122,7 @@ describe('knownBrowsers', function() {
     describe('Chrome', function() {
       var browsers;
       var chrome;
-     
+
       function setup(browserName) {
         if (browserName) {
           addBrowserArgsToConfig(config, browserName);
@@ -194,7 +194,7 @@ describe('knownBrowsers', function() {
     describe('Safari', function() {
       var browsers;
       var safari;
-     
+
       function setup(browserName) {
         if (browserName) {
           addBrowserArgsToConfig(config, browserName);
@@ -250,7 +250,7 @@ describe('knownBrowsers', function() {
     describe('Opera', function() {
       var browsers;
       var opera;
-     
+
       function setup(browserName) {
         if (browserName) {
           addBrowserArgsToConfig(config, browserName);
@@ -297,7 +297,7 @@ describe('knownBrowsers', function() {
       var browsers;
       var phantomJS;
       var scriptPath;
-     
+
       function setup(browserName) {
         if (browserName) {
           addBrowserArgsToConfig(config, browserName);
@@ -367,7 +367,8 @@ describe('knownBrowsers', function() {
           ]);
         });
 
-        it('constructs correct args with phantomjs_debug_port and browser_args', function() {        config.get = function(name) {
+        it('constructs correct args with phantomjs_debug_port and browser_args', function() {
+          config.get = function(name) {
             if (name === 'phantomjs_debug_port') {
               return '1234';
             } else if (name === 'browser_args') {
@@ -409,7 +410,7 @@ describe('knownBrowsers', function() {
     describe('Internet Explorer', function() {
       var browsers;
       var internetExplorer;
-     
+
       function setup(browserName) {
         if (browserName) {
           addBrowserArgsToConfig(config, browserName);

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -12,6 +12,34 @@ var file = require('chai-files').file;
 
 var knownBrowsers = require('../../lib/utils/known-browsers');
 
+function addBrowserArgsToConfig(config, browserName) {
+  config.get = function(name) {
+    var args = {};
+
+    if (name === 'browser_args') {
+      args[browserName] = '--testem';
+      return args;
+    }
+  }
+}
+
+function createConfig() {
+  return {
+    getHomeDir: function() {
+      return 'home/dir';
+    },
+    get: function() {
+      return;
+    }
+  };
+}
+
+function findBrowser(browsers, browserName) {
+  return find(browsers, function(browser) {
+    return browser.name === browserName;
+  });
+}
+
 describe('knownBrowsers', function() {
   var browserTmpDir;
   var url = 'http://localhost:7357';
@@ -26,14 +54,7 @@ describe('knownBrowsers', function() {
   var config;
 
   beforeEach(function() {
-    config = {
-      getHomeDir: function() {
-        return 'home/dir';
-      },
-      get: function() {
-        return;
-      }
-    };
+    config = createConfig();
 
     return tmpDirAsync().then(function(path) {
       browserTmpDir = path;
@@ -42,14 +63,22 @@ describe('knownBrowsers', function() {
 
   describe('Any platform', function() {
     describe('Firefox', function() {
+      var browsers;
       var firefox;
+      
+      function setup(browserName) {
+        if (browserName) {
+          addBrowserArgsToConfig(config, browserName);
+        } else {
+          config = createConfig();
+        }
+
+        browsers = knownBrowsers('any', config);
+        firefox = findBrowser(browsers, 'Firefox');
+      }
 
       beforeEach(function() {
-        var browsers = knownBrowsers('any', config);
-
-        firefox = find(browsers, function(browser) {
-          return browser.name === 'Firefox';
-        });
+        setup();
       });
 
       it('exists', function() {
@@ -72,17 +101,41 @@ describe('knownBrowsers', function() {
           done();
         });
       });
+
+      describe('browser_args', function() {
+        beforeEach(function() {
+          setup('Firefox');
+        });
+
+        afterEach(function() {
+          setup();
+        });
+
+        it('constructs correct args with browser_args', function() {
+          expect(firefox.args.call(launcher, config, url)).to.deep.eq([
+            '--testem', '-profile', browserTmpDir, url
+          ]);
+        });
+      });
     });
 
     describe('Chrome', function() {
+      var browsers;
       var chrome;
+     
+      function setup(browserName) {
+        if (browserName) {
+          addBrowserArgsToConfig(config, browserName);
+        } else {
+          config = createConfig();
+        }
+
+        browsers = knownBrowsers('any', config);
+        chrome = findBrowser(browsers, 'Chrome');
+      }
 
       beforeEach(function() {
-        var browsers = knownBrowsers('any', config);
-
-        chrome = find(browsers, function(browser) {
-          return browser.name === 'Chrome';
-        });
+        setup();
       });
 
       it('exists', function() {
@@ -112,17 +165,49 @@ describe('knownBrowsers', function() {
           '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
         ]);
       });
+
+      describe('browser_args', function() {
+        beforeEach(function() {
+          setup('Chrome');
+        });
+
+        afterEach(function() {
+          setup();
+        });
+
+        it('constructs correct args with browser_args', function() {
+          expect(chrome.args.call(launcher, config, url)).to.deep.eq([
+            '--testem',
+            '--user-data-dir=' + browserTmpDir,
+            '--no-default-browser-check',
+            '--no-first-run',
+            '--ignore-certificate-errors',
+            '--test-type',
+            '--disable-renderer-backgrounding',
+            '--disable-background-timer-throttling',
+            url
+          ]);
+        });
+      });
     });
 
     describe('Safari', function() {
+      var browsers;
       var safari;
+     
+      function setup(browserName) {
+        if (browserName) {
+          addBrowserArgsToConfig(config, browserName);
+        } else {
+          config = createConfig();
+        }
+
+        browsers = knownBrowsers('any', config);
+        safari = findBrowser(browsers, 'Safari');
+      }
 
       beforeEach(function() {
-        var browsers = knownBrowsers('any', config);
-
-        safari = find(browsers, function(browser) {
-          return browser.name === 'Safari';
-        });
+        setup();
       });
 
       it('exists', function() {
@@ -144,17 +229,41 @@ describe('knownBrowsers', function() {
           done();
         });
       });
+
+      describe('browser_args', function() {
+        beforeEach(function() {
+          setup('Safari');
+        });
+
+        afterEach(function() {
+          setup();
+        });
+
+        it('constructs correct args with browser_args', function() {
+          expect(safari.args.call(launcher, config, url)).to.deep.eq([
+            '--testem', path.join(browserTmpDir, 'start.html')
+          ]);
+        });
+      });
     });
 
     describe('Opera', function() {
+      var browsers;
       var opera;
+     
+      function setup(browserName) {
+        if (browserName) {
+          addBrowserArgsToConfig(config, browserName);
+        } else {
+          config = createConfig();
+        }
+
+        browsers = knownBrowsers('any', config);
+        opera = findBrowser(browsers, 'Opera');
+      }
 
       beforeEach(function() {
-        var browsers = knownBrowsers('any', config);
-
-        opera = find(browsers, function(browser) {
-          return browser.name === 'Opera';
-        });
+        setup();
       });
 
       it('exists', function() {
@@ -166,17 +275,42 @@ describe('knownBrowsers', function() {
           '--user-data-dir=' + browserTmpDir, '-pd', browserTmpDir, url
         ]);
       });
+
+      describe('browser_args', function() {
+        beforeEach(function() {
+          setup('Opera');
+        });
+
+        afterEach(function() {
+          setup();
+        });
+
+        it('constructs correct args with browser_args', function() {
+          expect(opera.args.call(launcher, config, url)).to.deep.eq([
+            '--testem', '--user-data-dir=' + browserTmpDir, '-pd', browserTmpDir, url
+          ]);
+        });
+      });
     });
 
     describe('PhantomJS', function() {
-      var phantomJS, scriptPath;
+      var browsers;
+      var phantomJS;
+      var scriptPath;
+     
+      function setup(browserName) {
+        if (browserName) {
+          addBrowserArgsToConfig(config, browserName);
+        } else {
+          config = createConfig();
+        }
+
+        browsers = knownBrowsers('any', config);
+        phantomJS = findBrowser(browsers, 'PhantomJS');
+      }
 
       beforeEach(function() {
-        var browsers = knownBrowsers('any', config);
-
-        phantomJS = find(browsers, function(browser) {
-          return browser.name === 'PhantomJS';
-        });
+        setup();
         scriptPath = path.resolve(__dirname, '../../assets/phantom.js');
       });
 
@@ -196,6 +330,7 @@ describe('knownBrowsers', function() {
             return '1234';
           }
         };
+
         expect(phantomJS.args.call(launcher, config, url)).to.deep.eq([
           '--remote-debugger-port=1234',
           '--remote-debugger-autorun=true',
@@ -215,23 +350,99 @@ describe('knownBrowsers', function() {
           'arg1', 'arg2', scriptPath, url
         ]);
       });
+
+      describe('browser_args', function() {
+        beforeEach(function() {
+          setup('PhantomJS');
+          scriptPath = path.resolve(__dirname, '../../assets/phantom.js');
+        });
+
+        afterEach(function() {
+          setup();
+        });
+
+        it('constructs correct args and browser_args', function() {
+          expect(phantomJS.args.call(launcher, config, url)).to.deep.eq([
+            '--testem', scriptPath, url
+          ]);
+        });
+
+        it('constructs correct args with phantomjs_debug_port and browser_args', function() {        config.get = function(name) {
+            if (name === 'phantomjs_debug_port') {
+              return '1234';
+            } else if (name === 'browser_args') {
+              return {
+                PhantomJS: '--testem'
+              };
+            }
+          };
+
+          expect(phantomJS.args.call(launcher, config, url)).to.deep.eq([
+            '--testem',
+            '--remote-debugger-port=1234',
+            '--remote-debugger-autorun=true',
+            scriptPath,
+            url
+          ]);
+        });
+
+        it('constructs correct args with phantomjs_args and browser_args', function() {
+          config.get = function(name) {
+            if (name === 'phantomjs_args') {
+              return ['arg1', 'arg2'];
+            } else if (name === 'browser_args') {
+              return {
+                PhantomJS: '--testem'
+              };
+            }
+          };
+
+          expect(phantomJS.args.call(launcher, config, url)).to.deep.eq([
+            '--testem', 'arg1', 'arg2', scriptPath, url
+          ]);
+        });
+      });
     });
   });
 
   describe('Windows', function() {
     describe('Internet Explorer', function() {
+      var browsers;
       var internetExplorer;
+     
+      function setup(browserName) {
+        if (browserName) {
+          addBrowserArgsToConfig(config, browserName);
+        } else {
+          config = createConfig();
+        }
+
+        browsers = knownBrowsers('win32', config);
+        internetExplorer = findBrowser(browsers, 'IE');
+      }
 
       beforeEach(function() {
-        var browsers = knownBrowsers('win32', config);
-
-        internetExplorer = find(browsers, function(browser) {
-          return browser.name === 'IE';
-        });
+        setup();
       });
 
       it('exists', function() {
         expect(internetExplorer).to.exist();
+      });
+
+      describe('browser_args', function() {
+        beforeEach(function() {
+          setup('IE');
+        });
+
+        afterEach(function() {
+          setup();
+        });
+
+        it('constructs correct args with browser_args', function() {
+          expect(internetExplorer.args.call(launcher, config, url)).to.deep.eq([
+            '--testem'
+          ]);
+        });
       });
     });
   });


### PR DESCRIPTION
Note: One test fails with Bluebird `3.4.6`. The test is in `/tests/ci/dev_tests.js` and the one that fails is `dev mode app > in interactive mode > allows to restart a run`.