### PR TITLE
Fix debug log

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -44,6 +44,10 @@ function Config(appMode, progOptions, config) {
     this.progOptions.parallel = -1;
   }
 
+  if (this.progOptions.debug === true) {
+    this.progOptions.debug = 'testem.log';
+  }
+
   if (appMode === 'ci') {
     this.progOptions.disable_watching = true;
     this.progOptions.single_run = true;

--- a/testem.js
+++ b/testem.js
@@ -15,7 +15,7 @@ program
   .option('--host [hostname]', 'host name - defaults to localhost', String)
   .option('-l, --launch [list]', 'list of launchers to launch(comma separated)')
   .option('-s, --skip [list]', 'list of launchers to skip(comma separated)')
-  .option('-d, --debug [file]', 'output debug to debug log - defaults to testem.log', 'testem.log')
+  .option('-d, --debug [file]', 'output debug to debug log - defaults to testem.log')
   .option('-t, --test_page [page]', 'the html page to drive the tests')
   .option('-g, --growl', 'turn on growl / native notifications');
 

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -495,6 +495,33 @@ describe('Config', function() {
       expect(config.get('browser_start_timeout')).to.eq(30);
     });
   });
+
+  describe('debug', function() {
+    describe('when unset', function() {
+      it('is not defined', function() {
+        var config = new Config('dev', {});
+        expect(config.get('debug')).not.to.exist();
+      });
+    });
+
+    describe('when set', function() {
+      it('defaults to testem.log', function() {
+        var config = new Config('dev', {
+          debug: true
+        });
+        expect(config.get('debug')).to.eq('testem.log');
+      });
+    });
+
+    describe('when set and file name specified', function() {
+      it('uses the provided file name', function() {
+        var config = new Config('dev', {
+          debug: 'debug.log'
+        });
+        expect(config.get('debug')).to.eq('debug.log');
+      });
+    });
+  });
 });
 
 function mockTopLevelProgOptions() {


### PR DESCRIPTION
The configurable debug log path merged in https://github.com/testem/testem/pull/974
introduced a regression that logs are always written.

Write logs only to testem.log when -d is set.