### PR TITLE
Option to specify custom phantomjs launcher file

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ If you want to use any of the [PhantomJS command line options](http://phantomjs.
 ]
 ```
 
+You can also customize the phantomjs launcher file by specifying the `phantomjs_launcher` option.
+In this launcher you can change options like the `viewPortSize`. See `assets/phantom.js` for the default launcher.
+
 Preprocessors (CoffeeScript, LESS, Sass, Browserify, etc)
 ---------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ If you want to use any of the [PhantomJS command line options](http://phantomjs.
 ]
 ```
 
-You can also customize the phantomjs launcher file by specifying the `phantomjs_launcher` option.
+You can also customize the phantomjs launcher file by specifying the `phantomjs_launch_script` option.
 In this launcher you can change options like the `viewPortSize`. See `assets/phantom.js` for the default launcher.
 
 Preprocessors (CoffeeScript, LESS, Sass, Browserify, etc)

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -86,7 +86,7 @@ Common Configuration Options
     report_file:                 [String]  file to write test results to (stdout)
     xunit_intermediate_output    [Boolean] print tap output for the xunit reporter (false)
     phantomjs_debug_port:        [Number]  port used to attach phantomjs debugger
-    phantomjs_launch_script:     [String]  path of custom phantomjs launcher file
+    phantomjs_launch_script:     [String]  path of custom phantomjs launch script
     phantomjs_args:              [Array]   custom arguments for the phantomjs launcher
     user_data_dir:               [String]  directory to initialize the browser user data directories (default a temporary directory)
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -86,7 +86,7 @@ Common Configuration Options
     report_file:                 [String]  file to write test results to (stdout)
     xunit_intermediate_output    [Boolean] print tap output for the xunit reporter (false)
     phantomjs_debug_port:        [Number]  port used to attach phantomjs debugger
-    phantomjs_launch_script:          [String]  path of custom phantomjs launcher file
+    phantomjs_launch_script:     [String]  path of custom phantomjs launcher file
     phantomjs_args:              [Array]   custom arguments for the phantomjs launcher
     user_data_dir:               [String]  directory to initialize the browser user data directories (default a temporary directory)
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -86,6 +86,7 @@ Common Configuration Options
     report_file:                 [String]  file to write test results to (stdout)
     xunit_intermediate_output    [Boolean] print tap output for the xunit reporter (false)
     phantomjs_debug_port:        [Number]  port used to attach phantomjs debugger
+    phantomjs_launcher:          [String]  path of custom phantomjs launcher file
     phantomjs_args:              [Array]   custom arguments for the phantomjs launcher
     user_data_dir:               [String]  directory to initialize the browser user data directories (default a temporary directory)
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -86,7 +86,7 @@ Common Configuration Options
     report_file:                 [String]  file to write test results to (stdout)
     xunit_intermediate_output    [Boolean] print tap output for the xunit reporter (false)
     phantomjs_debug_port:        [Number]  port used to attach phantomjs debugger
-    phantomjs_launcher:          [String]  path of custom phantomjs launcher file
+    phantomjs_launch_script:          [String]  path of custom phantomjs launcher file
     phantomjs_args:              [Array]   custom arguments for the phantomjs launcher
     user_data_dir:               [String]  directory to initialize the browser user data directories (default a temporary directory)
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -137,7 +137,12 @@ function knownBrowsers(platform, config) {
       name: 'PhantomJS',
       possibleExe: 'phantomjs',
       args: function() {
-        var options = [path.resolve(__dirname, '../../assets/phantom.js'), this.getUrl()];
+        var launcher = config.get('phantomjs_launcher');
+        if (!launcher) {
+          launcher = path.resolve(__dirname, '../../assets/phantom.js');
+        }
+        console.log(launcher);
+        var options = [launcher, this.getUrl()];
         var debug_port = config.get('phantomjs_debug_port');
         if (debug_port) {
           options.unshift('--remote-debugger-autorun=true');

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -137,12 +137,11 @@ function knownBrowsers(platform, config) {
       name: 'PhantomJS',
       possibleExe: 'phantomjs',
       args: function() {
-        var launcher = config.get('phantomjs_launcher');
-        if (!launcher) {
-          launcher = path.resolve(__dirname, '../../assets/phantom.js');
+        var launch_script = config.get('phantomjs_launch_script');
+        if (!launch_script) {
+          launch_script = path.resolve(__dirname, '../../assets/phantom.js');
         }
-        console.log(launcher);
-        var options = [launcher, this.getUrl()];
+        var options = [launch_script, this.getUrl()];
         var debug_port = config.get('phantomjs_debug_port');
         if (debug_port) {
           options.unshift('--remote-debugger-autorun=true');

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -402,6 +402,20 @@ describe('knownBrowsers', function() {
             '--testem', 'arg1', 'arg2', scriptPath, url
           ]);
         });
+
+        it('constructs correct args with custom launch script', function() {
+          var customScriptPath = './custom_phantom.js';
+
+          config.get = function(name) {
+            if (name === 'phantomjs_launch_script') {
+              return customScriptPath;
+            }
+          };
+
+          expect(phantomJS.args.call(launcher, config, url)).to.deep.eq([
+            '--testem', customScriptPath, url
+          ]);
+        });
       });
     });
   });


### PR DESCRIPTION
Also discussed in #876 sometimes you want to be able to override the phantomjs viewPortSize option. As far as I know this is not possible using command line arguments and the `browser_args` option.

If there is any better option than this please let me know ;-)