### PR TITLE
Namespace log events with console- prefix

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -90,10 +90,10 @@ BrowserTestRunner.prototype = {
       }.bind(this);
     }.bind(this);
 
-    socket.on('error', handleMessage('error'));
-    socket.on('info', handleMessage('info'));
-    socket.on('warn', handleMessage('warn'));
-    socket.on('log', handleMessage('log'));
+    socket.on('console-error', handleMessage('error'));
+    socket.on('console-info', handleMessage('info'));
+    socket.on('console-warn', handleMessage('warn'));
+    socket.on('console-log', handleMessage('log'));
 
     socket.on('disconnect', this.onDisconnect.bind(this));
 

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -135,7 +135,7 @@ function takeOverConsole() {
         doDefault = Testem.handleConsoleMessage(message);
       }
       if (doDefault !== false) {
-        args.unshift(method);
+        args.unshift('console-' + method);
         emit.apply(console, args);
         if (original && original.apply) {
           // Do this for normal browsers


### PR DESCRIPTION
Going to resolve the merge conflicts/clean up the code, we're on 1.6.0.

"error" is a reserved event in socket.io: https://github.com/socketio/socket.io/issues/2285
Thus, console.error logs are never properly sent to the Testem server.
This namespaces console events so that we don't conflict with the reserved event.