### PR TITLE
Namespace log events with console- prefix

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -113,10 +113,9 @@ BrowserTestRunner.prototype = {
       }.bind(this);
     }.bind(this);
 
-    socket.on('error', handleMessage('error'));
-    socket.on('info', handleMessage('info'));
-    socket.on('warn', handleMessage('warn'));
-    socket.on('log', handleMessage('log'));
+    for (var method in ['log', 'warn', 'error', 'info']) {
+      socket.on('console-' + method, handleMessage(method));
+    }
 
     socket.on('disconnect', this.onDisconnect.bind(this));
 

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -312,7 +312,7 @@ function takeOverConsole() {
         doDefault = Testem.handleConsoleMessage(message);
       }
       if (doDefault !== false) {
-        args.unshift(method);
+        args.unshift('console-' + method);
         emit.apply(console, args);
         if (original && original.apply) {
           // Do this for normal browsers


### PR DESCRIPTION
Going to resolve the merge conflicts/clean up the code, we're on 1.6.0.

"error" is a reserved event in socket.io: socketio/socket.io#2285
Thus, console.error logs are never properly sent to the Testem server.
This namespaces console events so that we don't conflict with the reserved event.