### PR TITLE
Custom reporter

### DIFF
--- a/examples/custom_reporter/.gitignore
+++ b/examples/custom_reporter/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/custom_reporter/README.md
+++ b/examples/custom_reporter/README.md
@@ -1,0 +1,9 @@
+## Setup
+
+First install dependencies
+
+    npm install
+
+Then, just run tests
+
+    npm test

--- a/examples/custom_reporter/hello.js
+++ b/examples/custom_reporter/hello.js
@@ -1,0 +1,3 @@
+function hello(name){
+    return "hello " + (name || 'world');
+}

--- a/examples/custom_reporter/hello_spec.js
+++ b/examples/custom_reporter/hello_spec.js
@@ -1,0 +1,10 @@
+var expect = chai.expect;
+
+describe('hello', function(){
+    it('should say hello', function(){
+        expect(hello()).to.equal('hello world');
+    });
+    it('should say hello to person', function(){
+        expect(hello('Bob')).to.equal('hello Bob');
+    });
+});

--- a/examples/custom_reporter/my-reporter.js
+++ b/examples/custom_reporter/my-reporter.js
@@ -1,0 +1,23 @@
+function MyReporter(out) {
+    this.out = out || process.stdout;
+    this.total = 0;
+    this.pass = 0;
+}
+
+MyReporter.prototype = {
+    report: function(prefix, data) {
+        // increment counters
+        this.total++;
+        if (data.passed) {
+            this.pass++;
+        }
+        // output results
+        var status = data.passed ? 'ok' : 'failed';
+        this.out.write(prefix+'\t'+status+'\t'+data.name.trim()+'\n');
+    },
+    finish: function() {
+        this.out.write(this.passed+'/'+this.total+' tests passed\n')
+    }
+}
+
+module.exports = MyReporter;

--- a/examples/custom_reporter/package.json
+++ b/examples/custom_reporter/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "test": "node ../../testem.js ci -P 10"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/testem/testem.git"
+  },
+  "license": "MIT"
+}

--- a/examples/custom_reporter/testem.js
+++ b/examples/custom_reporter/testem.js
@@ -1,0 +1,9 @@
+var MyReporter = require('./my-reporter');
+
+module.exports = {
+    "framework": "mocha+chai",
+    "src_files": [
+      "hello*.js",
+    ],
+    "reporter": new MyReporter()
+};

--- a/lib/app.js
+++ b/lib/app.js
@@ -42,6 +42,11 @@ function App(config, finalizer) {
       alreadyExit = true;
 
       var exitCode = err ? 1 : 0;
+
+      if (err && err.hideFromReporter) {
+        err = null;
+      }
+
       (finalizer || cleanExit)(exitCode, err);
     }
   };


### PR DESCRIPTION
Internally testem uses errors when not all tests passed or the run
was canceled. As those errors are already visible in the reporter
and affect the exit code, there is no need to return the error.

Fixes https://github.com/testem/testem/issues/906

Requires:
- [x] https://github.com/ember-cli/ember-cli/pull/6385 merge
- [x] ember-cli/ember-cli#6385 in an ember-release
