### PR TITLE
Fixes testem crashing when restarting

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -109,13 +109,13 @@ App.prototype = {
     log.info(src + ' triggered test run.');
     var self = this;
 
-    if (self.stopping) {
+    if (self.restarting) {
       return;
     }
-    self.stopping = true;
+    self.restarting = true;
 
     return this.stopCurrentRun().catch(self.exit.bind(this)).then(function() {
-      self.stopping = false;
+      self.restarting = false;
 
       return self.runTests();
     });
@@ -370,10 +370,13 @@ App.prototype = {
     }
 
     return Bluebird.map(this.runners, function(runner) {
-      if (this.stopping || this.exited) {
+      if (this.exited) {
         var e = new Error('Run canceled.');
         e.hideFromReporter = true;
         return Bluebird.reject(e);
+      }
+      if (this.restarting) {
+        return Bluebird.resolve();
       }
       return timeout.try(function() {
         return runner.start();

--- a/lib/utils/run-timeout.js
+++ b/lib/utils/run-timeout.js
@@ -22,12 +22,16 @@ RunTimeout.prototype.start = function() {
 
   if (this.timeout) {
     this.timeoutID = setTimeout(function() {
-      self.timedOut = true;
-      self.emit('timeout');
+      self.setTimedOut();
     }, this.timeout * 1000);
   }
 
   return Bluebird.resolve(this);
+};
+
+RunTimeout.prototype.setTimedOut = function() {
+  this.timedOut = true;
+  this.emit('timeout');
 };
 
 RunTimeout.prototype.stop = function() {


### PR DESCRIPTION
When testem restarts during a run, it was crashing due to restart
causing the run promise to reject.

Prevent this by only rejecting the run when testem is killed during
the test run on not when restarting.