### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -300,7 +300,7 @@ describe('browser test runner', function() {
 
     it('allows to cancel the timeout', function(done) {
       launcher.settings.exe = 'node';
-      launcher.settings.args = [path.join(__dirname, 'fixtures/processes/just-running.js')];
+      launcher.settings.args = [path.join(__dirname, '../fixtures/processes/just-running.js')];
       runner.start(function() {
         expect(reporter.results.length).to.eq(0);
         done();

--- a/tests/utils/reporter_tests.js
+++ b/tests/utils/reporter_tests.js
@@ -68,7 +68,9 @@ describe('Reporter', function() {
         sinon.match.any,
         sinon.match.any);
 
-      fs.unlinkSync('report.xml');
+      return reporter.close().then(function() {
+        fs.unlinkSync('report.xml');
+      });
     });
   });
 


### PR DESCRIPTION
Fix wrong fixture path causing a different stderr on slow environments.
Ensure report file is closed before trying to remove it.