### PR TITLE
Pin socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "npmlog": "^4.0.0",
     "printf": "^0.2.3",
     "rimraf": "^2.4.4",
-    "socket.io": "^1.5.1",
+    "socket.io": "1.6.0",
     "spawn-args": "^0.2.0",
     "styled_string": "0.0.1",
     "tap-parser": "^3.0.2",


### PR DESCRIPTION
socket.io >= 1.7.0 breaks IE 8, pin socket.io until
https://github.com/socketio/socket.io-client/issues/1040 is resolved.