### PR TITLE
Suppress xunit with intermediate v2

### DIFF
--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -36,12 +36,8 @@ XUnitReporter.prototype = {
       return;
     }
     this.endTime = new Date();
-    if (this.printIntermediateOutput) {
-      this.out.write('Disabled XML to stdout when intermediate output is set');
-    } else {
-      this.out.write(this.summaryDisplay());
-      this.out.write('\n');
-    }
+    this.out.write(this.summaryDisplay());
+    this.out.write('\n');
   },
   summaryDisplay: function() {
     var doc = new XmlDom.DOMImplementation().createDocument('', 'testsuite');

--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -108,3 +108,9 @@ XUnitReporter.prototype = {
 };
 
 module.exports = XUnitReporter;
+
+exports.setReportFileProperties = function (reportFile, config) {
+  if (config.get('xunit_intermediate_output')) {
+    reportFile.disableOut();  
+  }
+}

--- a/lib/utils/report-file.js
+++ b/lib/utils/report-file.js
@@ -8,6 +8,7 @@ var Bluebird = require('bluebird');
 
 function ReportFile(reportFile, out) {
   this.file = reportFile;
+  this.disableOut = true;
 
   this.outputStream = new PassThrough();
 
@@ -16,9 +17,11 @@ function ReportFile(reportFile, out) {
   var fileStream = fs.createWriteStream(reportFile, { flags: 'w+' });
 
   this.outputStream.on('data', function(data) {
-    out.write(data);
+    if (!this.disableOut) {
+      out.write(data);
+    }
     fileStream.write(data);
-  });
+  }.bind(this));
 
   var alreadyEnded = false;
   function finish(data) {
@@ -44,5 +47,9 @@ ReportFile.prototype.close = function() {
 
   return this.closePromise;
 };
+
+ReportFile.prototype.disableOut = function() {
+  this.disableOut = true;
+}
 
 module.exports = ReportFile;

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -18,6 +18,10 @@ function Reporter(app, stdout, path) {
   if (isa(reporter, String)) {
     var TestReporter = reporters[reporter];
     if (TestReporter) {
+      if (typeof TestReporter.setReportFileProperties === 'function') {
+        TestReporter.setReportFileProperties(reportFile, app.config);
+      }
+
       this.reporter = new TestReporter(false, this.reportFileStream, app.config, app);
     }
   } else {

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -221,18 +221,6 @@ describe('test reporters', function() {
       assertXmlIsValid(output);
     });
 
-    it('disable writing summary XML when intermediate output is enabled', function() {
-      config.set('xunit_intermediate_output', true);
-      var reporter = new XUnitReporter(false, stream, config);
-      reporter.report('phantomjs', {
-        name: 'it does <cool> \"cool\" \'cool\' stuff',
-        passed: true
-      });
-      reporter.finish();
-      var output = stream.read().toString();
-      assert.match(output, /Disabled XML to stdout when intermediate output is set/);
-    });
-
     it('uses stdout to print intermediate test results when intermediate output is enabled', function() {
       config.set('xunit_intermediate_output', true);
       var reporter = new XUnitReporter(false, stream, config);


### PR DESCRIPTION
Follow up to #1040

I'm not too happy with this. Because of the separation that exists now, this change is difficult to do. Before I write more tests I was wondering if you had some feedback.

Some alternatives:

- Pass a wrapper object to each Reporter that holds either a ReportFile or an out, the Reporter then can set properties on the ReportFile
- Let the reporter create the ReportFile and it can set the flag on its own
- `outputStream` can be piped an object instead of a string, the object would indicate if the string is meant for `out`, `fileStream` or both.