### PR TITLE
Fix xunit_intermediate_output option

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -56,7 +56,7 @@ App.prototype = {
       });
 
       return Bluebird.using(Reporter.with(self, self.stdoutStream, self.reportFileName), function(reporter) {
-        self.reporter = reporter.reporter;
+        self.reporter = reporter;
 
         return Bluebird.using(self.fileWatch(), function() {
           return Bluebird.using(self.getServer(), function() {
@@ -138,9 +138,7 @@ App.prototype = {
 
     var self = this;
 
-    if (this.reporter.onStart) {
-      this.reporter.onStart('testem', { launcherId: 0 });
-    }
+    this.reporter.onStart('testem', { launcherId: 0 });
 
     return Bluebird.using(self.runHook('before_tests'), function() {
       return Bluebird.using(RunTimeout.with(self.config.get('timeout')), function(timeout) {
@@ -174,9 +172,7 @@ App.prototype = {
 
       self.reporter.report('testem', result);
     }).finally(function() {
-      if (self.reporter.onEnd) {
-        self.reporter.onEnd('testem', { launcherId: 0 });
-      }
+      self.reporter.onEnd('testem', { launcherId: 0 });
     });
   },
 
@@ -400,12 +396,12 @@ App.prototype = {
     if (!this.reporter) {
       return new Error('Failed to initialize.');
     }
-    if (this.reporter.total > ((this.reporter.pass || 0) + (this.reporter.skipped || 0))) {
+    if (!this.reporter.hasPassed()) {
       var e = new Error('Not all tests passed.');
       e.hideFromReporter = true;
       return e;
     }
-    if (this.reporter.total === 0 && this.config.get('fail_on_zero_tests')) {
+    if (!this.reporter.hasTests() && this.config.get('fail_on_zero_tests')) {
       return new Error('No tests found.');
     }
     return null;

--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var displayutils = require('../displayutils');
 var XmlDom = require('xmldom');
 
 function XUnitReporter(silent, out, config) {
   this.out = out || process.stdout;
-  this.printIntermediateOutput = config.get('xunit_intermediate_output');
   this.excludeStackTraces = config.get('xunit_exclude_stack');
   this.silent = silent;
   this.stoppedOnError = null;
@@ -36,12 +34,8 @@ XUnitReporter.prototype = {
       return;
     }
     this.endTime = new Date();
-    if (this.printIntermediateOutput) {
-      this.out.write('Disabled XML to stdout when intermediate output is set');
-    } else {
-      this.out.write(this.summaryDisplay());
-      this.out.write('\n');
-    }
+    this.out.write(this.summaryDisplay());
+    this.out.write('\n');
   },
   summaryDisplay: function() {
     var doc = new XmlDom.DOMImplementation().createDocument('', 'testsuite');
@@ -60,11 +54,10 @@ XUnitReporter.prototype = {
     }
     return doc.documentElement.toString();
   },
-  display: function(prefix, result) {
-    if (this.silent || !this.printIntermediateOutput || this.out === process.stdout) {
-      return;
-    }
-    process.stdout.write(displayutils.resultString(this.id++, prefix, result));
+  display: function() {
+    // As the output is XML, the XUnitReporter can only write its results after all
+    // tests have finished.
+    return;
   },
   getTestResultNode: function(document, result) {
     var launcher = result.launcher;

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -173,27 +173,15 @@ BrowserTestRunner.prototype = {
   },
 
   onTestMetadata: function(tag, metadata) {
-    if (!this.reporter.reportMetadata) {
-      return;
-    }
-
     this.reporter.reportMetadata(tag, metadata);
   },
 
   onStart: function() {
-    if (!this.reporter.onStart) {
-      return;
-    }
-
     this.reporter.onStart(this.browser, {
       launcherId: this.launcherId
     });
   },
   onEnd: function() {
-    if (!this.reporter.onEnd) {
-      return;
-    }
-
     this.reporter.onEnd(this.browser, {
       launcherId: this.launcherId
     });

--- a/lib/runners/process_test_runner.js
+++ b/lib/runners/process_test_runner.js
@@ -47,20 +47,12 @@ ProcessTestRunner.prototype = {
   },
 
   onStart: function() {
-    if (!this.reporter.onStart) {
-      return;
-    }
-
     this.reporter.onStart(this.launcher.name, {
       launcherId: this.launcherId
     });
   },
 
   onEnd: function() {
-    if (!this.reporter.onEnd) {
-      return;
-    }
-
     this.reporter.onEnd(this.launcher.name, {
       launcherId: this.launcherId
     });

--- a/lib/runners/tap_process_test_runner.js
+++ b/lib/runners/tap_process_test_runner.js
@@ -65,20 +65,12 @@ TapProcessTestRunner.prototype = {
     this.wrapUp();
   },
   onStart: function() {
-    if (!this.reporter.onStart) {
-      return;
-    }
-
     this.reporter.onStart(this.launcher.name, {
       launcherId: this.launcherId
     });
   },
 
   onEnd: function() {
-    if (!this.reporter.onEnd) {
-      return;
-    }
-
     this.reporter.onEnd(this.launcher.name, {
       launcherId: this.launcherId
     });

--- a/lib/utils/report-file.js
+++ b/lib/utils/report-file.js
@@ -6,25 +6,20 @@ var mkdirp = require('mkdirp');
 var PassThrough = require('stream').PassThrough;
 var Bluebird = require('bluebird');
 
-function ReportFile(reportFile, out) {
+function ReportFile(reportFile) {
   this.file = reportFile;
 
   this.outputStream = new PassThrough();
 
   mkdirp.sync(path.dirname(path.resolve(reportFile)));
 
-  var fileStream = fs.createWriteStream(reportFile, { flags: 'w+' });
-
-  this.outputStream.on('data', function(data) {
-    out.write(data);
-    fileStream.write(data);
-  });
+  this.outputStream = fs.createWriteStream(reportFile, { flags: 'w+' });
 
   var alreadyEnded = false;
   function finish(data) {
     if (!alreadyEnded) {
       alreadyEnded = true;
-      fileStream.end(data);
+      this.outputStream.end(data);
     }
   }
 
@@ -32,11 +27,9 @@ function ReportFile(reportFile, out) {
   this.outputStream.on('error', finish);
 
   this.closePromise = new Bluebird.Promise(function(resolve, reject) {
-    fileStream.on('finish', resolve);
-    fileStream.on('error', reject);
-  });
-
-  this.fileStream = fileStream;
+    this.outputStream.on('finish', resolve);
+    this.outputStream.on('error', reject);
+  }.bind(this));
 }
 
 ReportFile.prototype.close = function() {

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -6,28 +6,49 @@ var reporters = require('../reporters');
 var isa = require('../isa');
 var ReportFile = require('./report-file');
 
-function Reporter(app, stdout, path) {
-  if (path) {
-    this.reportFile = new ReportFile(path, stdout);
-    this.reportFileStream = this.reportFile.outputStream;
-  } else {
-    this.reportFileStream = stdout;
-  }
+function setupReporter(name, out, config, app) {
+  var reporter;
 
-  var reporter = app.config.get('reporter');
-  if (isa(reporter, String)) {
-    var TestReporter = reporters[reporter];
+  if (isa(name, String)) {
+    var TestReporter = reporters[name];
     if (TestReporter) {
-      this.reporter = new TestReporter(false, this.reportFileStream, app.config, app);
+      reporter = new TestReporter(false, out, config, app);
     }
   } else {
-    this.reporter = reporter;
+    reporter = name;
   }
 
-  if (!this.reporter) {
-    throw new Error('Test reporter `' + reporter + '` not found.');
+  if (!reporter) {
+    throw new Error('Test reporter `' + name + '` not found.');
   }
 
+  return reporter;
+}
+
+
+function Reporter(app, stdout, path) {
+  this.total = 0;
+  this.passed = 0;
+  this.skipped = 0;
+
+  if (path) {
+    this.reportFile = new ReportFile(path);
+  }
+
+  var config = app.config;
+
+  if (path && config.get('xunit_intermediate_output') && config.get('reporter') === 'xunit') {
+    this.reporters = [
+      setupReporter('tap', stdout, config, app),
+      setupReporter(config.get('reporter'), this.reportFile.outputStream, config, app)
+    ];
+  } else {
+    this.reporters = [setupReporter(config.get('reporter'), stdout, config, app)];
+
+    if (path) {
+      this.reporters.push(setupReporter(config.get('reporter'), this.reportFile.outputStream, config, app));
+    }
+  }
 }
 
 Reporter.with = function(app, stdout, path) {
@@ -38,7 +59,7 @@ Reporter.with = function(app, stdout, path) {
       var err = promise.reason();
 
       if (!err.hideFromReporter) {
-        reporter.reporter.report(null, {
+        reporter.report(null, {
           passed: false,
           name: err.name || 'unknown error',
           error: {
@@ -49,16 +70,55 @@ Reporter.with = function(app, stdout, path) {
     }
 
     return reporter.close();
-  }.bind(this));
+  });
 };
 
 Reporter.prototype.close = function() {
-  this.reporter.finish();
+  this.finish();
 
   if (this.reportFile) {
     return this.reportFile.close();
   }
 };
 
+Reporter.prototype.hasTests = function() {
+  return this.total > 0;
+};
+
+Reporter.prototype.hasPassed = function() {
+  return this.total <= ((this.passed || 0) + (this.skipped || 0));
+};
+
+function forwardToReporters(fn) {
+  return function() {
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+      args[i] = arguments[i];
+    }
+
+    this.reporters.forEach(function(reporter) {
+      if (reporter[fn]) {
+        reporter[fn].apply(reporter, args);
+      }
+    });
+  };
+}
+
+Reporter.prototype.report = function(name, result) {
+  this.total++;
+  if (result.skipped) {
+    this.skipped++;
+  } else if (result.passed) {
+    this.passed++;
+  }
+
+  this.reporters.forEach(function(reporter) {
+    reporter.report(name, result);
+  });
+};
+
+['finish', 'onStart', 'onEnd', 'reportMetadata'].forEach(function(fn) {
+  Reporter.prototype[fn] = forwardToReporters(fn);
+});
 
 module.exports = Reporter;

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -251,7 +251,7 @@ describe('ci mode app', function() {
       reporter: fakeReporter
     });
     var app = new App(config, function() {
-      assert.strictEqual(app.reporter, fakeReporter);
+      assert.strictEqual(app.reporter.reporters[0], fakeReporter);
       done();
     });
 
@@ -409,29 +409,40 @@ describe('ci mode app', function() {
 
     it('returns 0 if all passed', function() {
       var app = new App(new Config('ci'));
-      var reporter = { total: 1, pass: 1 };
-      app.reporter = reporter;
-      assert.equal(app.getExitCode(), null);
-    });
-
-    it('returns 0 if all skipped', function() {
-      var app = new App(new Config('ci'));
-      var reporter = { total: 1, skipped: 1 };
-      app.reporter = reporter;
+      app.reporter = {
+        hasPassed: function() {
+          return true;
+        },
+        hasTests: function() {
+          return true;
+        }
+      };
       assert.equal(app.getExitCode(), null);
     });
 
     it('returns 1 if fails', function() {
       var app = new App(new Config('ci'));
-      var reporter = { total: 1, pass: 0 };
-      app.reporter = reporter;
+      app.reporter = {
+        hasPassed: function() {
+          return false;
+        },
+        hasTests: function() {
+          return true;
+        }
+      };
       assert.match(app.getExitCode(), /Not all tests passed/);
     });
 
     it('returns 0 if no tests ran', function() {
       var app = new App(new Config('ci'));
-      var reporter = { total: 0, pass: 0 };
-      app.reporter = reporter;
+      app.reporter = {
+        hasPassed: function() {
+          return true;
+        },
+        hasTests: function() {
+          return false;
+        }
+      };
       assert.equal(app.getExitCode(), null);
     });
 
@@ -439,11 +450,16 @@ describe('ci mode app', function() {
       var app = new App(new Config('ci', {
         fail_on_zero_tests: true
       }));
-      var reporter = { total: 0, pass: 0 };
-      app.reporter = reporter;
+      app.reporter = {
+        hasPassed: function() {
+          return true;
+        },
+        hasTests: function() {
+          return false;
+        }
+      };
       assert.match(app.getExitCode(), /No tests found\./);
     });
-
   });
 
   it('runs two browser instances in parallel with different test pages', function(done) {

--- a/tests/ci/report_file_tests.js
+++ b/tests/ci/report_file_tests.js
@@ -86,24 +86,11 @@ describe('report file output', function() {
     });
   });
 
-  it('writes out results to the normal output stream', function(done) {
-    var fakeStdout = new PassThrough();
-    var reportFile = new ReportFile(filename, fakeStdout);
-    reportFile.fileStream.on('finish', function() {
-      var output = fakeStdout.read().toString();
-      expect(output).to.match(/some test results/);
-      done();
-    });
-    reportFile.outputStream.write('some test results');
-    reportFile.outputStream.end();
-  });
-
   it('writes out results to the file', function(done) {
-    var stream = new PassThrough();
-    var reportFile = new ReportFile(filename, stream);
+    var reportFile = new ReportFile(filename);
     var reportStream = reportFile.outputStream;
 
-    reportFile.fileStream.on('finish', function() {
+    reportFile.outputStream.on('finish', function() {
       fs.readFile(filename, function(err, data) {
         if (err) {
           return done(err);
@@ -125,9 +112,8 @@ describe('report file output', function() {
         return done(err);
       }
 
-      var fakeStdout = new PassThrough();
-      var reportFile = new ReportFile(nestedFilename, fakeStdout);
-      reportFile.fileStream.on('finish', function() {
+      var reportFile = new ReportFile(nestedFilename);
+      reportFile.outputStream.on('finish', function() {
         fs.stat(nestedFilename, done);
       });
       reportFile.outputStream.end();

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -221,36 +221,6 @@ describe('test reporters', function() {
       assertXmlIsValid(output);
     });
 
-    it('disable writing summary XML when intermediate output is enabled', function() {
-      config.set('xunit_intermediate_output', true);
-      var reporter = new XUnitReporter(false, stream, config);
-      reporter.report('phantomjs', {
-        name: 'it does <cool> \"cool\" \'cool\' stuff',
-        passed: true
-      });
-      reporter.finish();
-      var output = stream.read().toString();
-      assert.match(output, /Disabled XML to stdout when intermediate output is set/);
-    });
-
-    it('uses stdout to print intermediate test results when intermediate output is enabled', function() {
-      config.set('xunit_intermediate_output', true);
-      var reporter = new XUnitReporter(false, stream, config);
-      var displayed = false;
-      var write = process.stdout.write;
-      process.stdout.write = function(string, encoding, fd) {
-        write.apply(process.stdout, [string, encoding, fd]);
-        displayed = true;
-      };
-      reporter.report('phantomjs', {
-        name: 'it does stuff',
-        passed: true,
-        logs: []
-      });
-      assert(displayed);
-      process.stdout.write = write;
-    });
-
     it('does not print intermediate test results when intermediate output is disabled', function() {
       var reporter = new XUnitReporter(false, stream, config);
       var displayed = false;

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var BrowserTestRunner = require('../../lib/runners/browser_test_runner');
-var TapReporter = require('../../lib/reporters/tap_reporter');
+var FakeReporter = require('../support/fake_reporter');
 var expect = require('chai').expect;
 var sinon = require('sinon');
 var Bluebird = require('bluebird');
@@ -28,6 +28,8 @@ describe('browser test runner', function() {
         this.logsByRunner[browser] = this.logsByRunner[browser] || [];
         this.logsByRunner[browser].push(msg);
       };
+      this.onStart = function() {};
+      this.onEnd = function() {};
     };
 
     beforeEach(function() {
@@ -69,7 +71,7 @@ describe('browser test runner', function() {
     var reporter, socket;
 
     beforeEach(function() {
-      reporter = new TapReporter();
+      reporter = new FakeReporter();
 
       var id = 1;
       var config = new Config('ci', {
@@ -103,7 +105,7 @@ describe('browser test runner', function() {
     var runner, reporter;
 
     beforeEach(function() {
-      reporter = new TapReporter();
+      reporter = new FakeReporter();
       var config = new Config('ci', {
         parallel: 2,
         reporter: reporter
@@ -192,7 +194,7 @@ describe('browser test runner', function() {
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
-      reporter = new TapReporter();
+      reporter = new FakeReporter();
       var config = new Config('ci', { reporter: reporter, browser_start_timeout: 2 });
       launcher = new Launcher('ci', { protocol: 'browser' }, config);
       runner = new BrowserTestRunner(launcher, reporter, null, null, config);
@@ -332,7 +334,7 @@ describe('browser test runner', function() {
     var reporter, launcher, runner, socket;
 
     beforeEach(function() {
-      reporter = new TapReporter();
+      reporter = new FakeReporter();
       var config = new Config('ci', { reporter: reporter, browser_disconnect_timeout: 0.1 });
       launcher = new Launcher('ci', { protocol: 'browser' }, config);
       runner = new BrowserTestRunner(launcher, reporter, null, null, config);
@@ -341,7 +343,7 @@ describe('browser test runner', function() {
 
     it('fails when the browser fails to reconnect', function(done) {
       launcher.settings.exe = 'node';
-      launcher.settings.args = [path.join(__dirname, 'fixtures/processes/just-running.js')];
+      launcher.settings.args = [path.join(__dirname, '../fixtures/processes/just-running.js')];
       runner.start(function() {
         expect(reporter.results[0].result).to.deep.eq({
           error: {
@@ -387,7 +389,7 @@ describe('browser test runner', function() {
     var runner;
 
     beforeEach(function() {
-      var reporter = new TapReporter();
+      var reporter = new FakeReporter();
       var config = new Config('ci', { reporter: reporter });
       var launcher = new Launcher('ci', { protocol: 'browser' }, config);
       runner = new BrowserTestRunner(launcher, reporter, 1, true, config);

--- a/tests/support/fake_reporter.js
+++ b/tests/support/fake_reporter.js
@@ -4,15 +4,22 @@ function FakeReporter() {
   this.results = [];
   this.total = 0;
   this.pass = 0;
+  this.skipped = 0;
 }
 
 FakeReporter.prototype.report = function(prefix, result) {
   if (result.passed) {
     this.pass++;
   }
+  if (result.skipped) {
+    this.skipped++;
+  }
   this.total++;
   this.results.push({ result: result });
 };
 FakeReporter.prototype.finish = function() {};
+FakeReporter.prototype.onStart = function() {};
+FakeReporter.prototype.onEnd = function() {};
+FakeReporter.prototype.reportMetadata = function() {};
 
 module.exports = FakeReporter;

--- a/tests/utils/report-file_tests.js
+++ b/tests/utils/report-file_tests.js
@@ -20,7 +20,7 @@ describe('ReportFile', function() {
 
       var finished = false;
 
-      tmpNameAsync().then(function(path) {
+      return tmpNameAsync().then(function(path) {
         return new ReportFile(path, noopStream);
       }).then(function(reportFile) {
         expect(reportFile.closePromise).to.exist();

--- a/tests/utils/reporter_tests.js
+++ b/tests/utils/reporter_tests.js
@@ -5,11 +5,15 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 var tmp = require('tmp');
 var fs = require('fs');
+var PassThrough = require('stream').PassThrough;
 
 var tmpNameAsync = Bluebird.promisify(tmp.tmpName);
 
 var Reporter = require('../../lib/utils/reporter');
 var FakeReporter = require('../support/fake_reporter');
+
+var fsReadFileAsync = Bluebird.promisify(fs.readFile);
+var fsUnlinkAsync = Bluebird.promisify(fs.unlink);
 
 describe('Reporter', function() {
   function mockApp(reporter) {
@@ -27,10 +31,11 @@ describe('Reporter', function() {
     };
   }
 
-  var sandbox;
+  var sandbox, stream;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
+    stream = new PassThrough();
   });
 
   afterEach(function() {
@@ -41,7 +46,7 @@ describe('Reporter', function() {
     it('can report to a file', function() {
       var close;
       tmpNameAsync().then(function(path) {
-        return new Reporter(mockApp(), process.stdout, path);
+        return new Reporter(mockApp(), stream, path);
       }).then(function(reporter) {
         expect(reporter.reportFile).to.exist();
 
@@ -56,20 +61,18 @@ describe('Reporter', function() {
     // Regresses https://github.com/testem/testem/issues/900
     it('uses file stream when reporting', function() {
       var tapReporterSpy = sandbox.spy(require('../../lib/reporters'), 'tap');
-      var reporter = new Reporter(mockApp('tap'), process.stdout, 'report.xml');
+      var reporter = new Reporter(mockApp('tap'), stream, 'report.xml');
 
-      expect(reporter.reportFileStream).to.not.be.undefined();
-      expect(reporter.reportFileStream).to.not.equal(process.stdout,
-          'expected report file stream to not be process.stdout');
+      expect(reporter.reportFile).to.not.be.undefined();
 
       sinon.assert.calledWithMatch(tapReporterSpy,
         sinon.match.any,
-        sinon.match.same(reporter.reportFileStream),
+        sinon.match.same(reporter.reportFile.outputStream),
         sinon.match.any,
         sinon.match.any);
 
       return reporter.close().then(function() {
-        fs.unlinkSync('report.xml');
+        return fsUnlinkAsync('report.xml');
       });
     });
   });
@@ -78,14 +81,14 @@ describe('Reporter', function() {
     var app = mockApp();
 
     it('can be used as a disposable which returns a reporter', function() {
-      return Bluebird.using(Reporter.with(app, process.stdout), function(reporter) {
+      return Bluebird.using(Reporter.with(app, stream), function(reporter) {
         expect(reporter).to.be.an.instanceof(Reporter);
       });
     });
 
     it('closes the reporter when done', function() {
       var close;
-      return Bluebird.using(Reporter.with(app, process.stdout), function(reporter) {
+      return Bluebird.using(Reporter.with(app, stream), function(reporter) {
         close = sandbox.spy(reporter, 'close');
       }).then(function() {
         expect(close).to.have.been.called();
@@ -94,7 +97,7 @@ describe('Reporter', function() {
 
     it('closes the reporter when promise is rejected with error hidden from the reporter', function() {
       var close;
-      return Bluebird.using(Reporter.with(app, process.stdout), function(reporter) {
+      return Bluebird.using(Reporter.with(app, stream), function(reporter) {
         close = sandbox.spy(reporter, 'close');
 
         var mockError = new Error('Not all tests passed.');
@@ -108,14 +111,201 @@ describe('Reporter', function() {
     it('logs an error when the wrapped promise was rejected', function() {
       var report;
 
-      return Bluebird.using(Reporter.with(app, process.stdout), function(reporter) {
-        report = sandbox.spy(reporter.reporter, 'report');
+      return Bluebird.using(Reporter.with(app, stream), function(reporter) {
+        report = sandbox.spy(reporter, 'report');
         return Bluebird.reject(new Error('Tests failed.'));
       }).catch(function() {
         expect(report).to.have.been.calledWith(null, {
           error: { message: 'Tests failed.' }, name: 'Error', passed: false
         });
       });
+    });
+  });
+
+  describe('new', function() {
+    it('creates a reporter and writes to stream', function() {
+      var reporter = new Reporter({
+        config: {
+          get: function(key) {
+            switch (key) {
+              case 'reporter':
+                return 'tap';
+            }
+          }
+        }
+      }, stream);
+
+      expect(reporter.reporters.length).to.eq(1);
+
+      reporter.report('phantomjs', {
+        name: 'it does <cool> \"cool\" \'cool\' stuff',
+        passed: true
+      });
+      reporter.finish();
+
+      var output = stream.read().toString();
+      expect(output).to.match(/tests 1/);
+    });
+
+    it('creates two reporters and writes to stream and path when path provided', function() {
+      return tmpNameAsync().then(function(path) {
+        var stream = new PassThrough();
+        var reporter = new Reporter({
+          config: {
+            get: function(key) {
+              switch (key) {
+                case 'reporter':
+                  return 'tap';
+              }
+            }
+          }
+        }, stream, path);
+
+        reporter.report('phantomjs', {
+          name: 'it does <cool> \"cool\" \'cool\' stuff',
+          passed: true
+        });
+
+        reporter.finish();
+
+        return reporter.close().then(function() {
+          var output = stream.read().toString();
+          expect(output).to.match(/tests 1/);
+
+          return fsReadFileAsync(path, 'utf-8');
+        }).then(function(output) {
+          expect(output).to.match(/tests 1/);
+        });
+      });
+    });
+
+    it('writes xml to stream and file with xunit reporter and intermediate output is enabled', function() {
+      return tmpNameAsync().then(function(path) {
+        var stream = new PassThrough();
+        var reporter = new Reporter({
+          config: {
+            get: function(key) {
+              switch (key) {
+                case 'reporter':
+                  return 'xunit';
+                case 'xunit_intermediate_output':
+                  return false;
+              }
+            }
+          }
+        }, stream, path);
+
+        reporter.report('phantomjs', {
+          name: 'it does <cool> \"cool\" \'cool\' stuff',
+          passed: true
+        });
+        reporter.finish();
+
+        return reporter.close().then(function() {
+          var output = stream.read().toString();
+          expect(output).to.match(/<testsuite name/);
+
+          return fsReadFileAsync(path, 'utf-8');
+        }).then(function(output) {
+          expect(output).to.match(/<testsuite name/);
+        });
+      });
+    });
+
+    it('writes tap to stream and xml to file with xunit reporter intermediate output is enabled', function() {
+      return tmpNameAsync().then(function(path) {
+        var stream = new PassThrough();
+        var reporter = new Reporter({
+          config: {
+            get: function(key) {
+              switch (key) {
+                case 'reporter':
+                  return 'xunit';
+                case 'xunit_intermediate_output':
+                  return true;
+              }
+            }
+          }
+        }, stream, path);
+
+        reporter.report('phantomjs', {
+          name: 'it does <cool> \"cool\" \'cool\' stuff',
+          passed: true
+        });
+        reporter.finish();
+
+        return reporter.close().then(function() {
+          var output = stream.read().toString();
+          expect(output).to.match(/tests 1/);
+
+          return fsReadFileAsync(path, 'utf-8');
+        }).then(function(output) {
+          expect(output).to.match(/<testsuite name/);
+        });
+      });
+    });
+  });
+
+  describe('hasPassed', function() {
+    var app = mockApp();
+    var reporter;
+
+    beforeEach(function() {
+      reporter = new Reporter(app, stream);
+    });
+
+    it('returns true when all tests passed', function() {
+      reporter.report('test', { passed: 1 });
+
+      expect(reporter.hasPassed()).to.be.true();
+    });
+
+    it('returns true when all tests skipped', function() {
+      var reporter = new Reporter(app, stream);
+
+      reporter.report('test', { skipped: 1 });
+
+      expect(reporter.hasPassed()).to.be.true();
+    });
+
+    it('returns true when all tests skipped or passed', function() {
+      var reporter = new Reporter(app, stream);
+
+      reporter.report('test', { passed: 1 });
+      reporter.report('test', { skipped: 1 });
+
+      expect(reporter.hasPassed()).to.be.true();
+    });
+
+    it('returns false when not all passed / skipped', function() {
+      var reporter = new Reporter(app, stream);
+
+      reporter.report('test', { passed: 1 });
+      reporter.report('test', { skipped: 1 });
+      reporter.report('test', { });
+
+      expect(reporter.hasPassed()).to.be.false();
+    });
+  });
+
+  describe('hasTests', function() {
+    var app = mockApp();
+    var reporter;
+
+    beforeEach(function() {
+      reporter = new Reporter(app, stream);
+    });
+
+    it('returns false without reported tests', function() {
+      var reporter = new Reporter(app, stream);
+
+      expect(reporter.hasTests()).to.be.false();
+    });
+
+    it('returns true when tests were reported', function() {
+      reporter.report('test', {});
+
+      expect(reporter.hasTests()).to.be.true();
     });
   });
 });


### PR DESCRIPTION
Refactor internals to use two reporter instance when a report_file is
defined.

This simplifies the logic around xunit_intermediate_output and prepares
support for multiple reporters.

Fixes https://github.com/testem/testem/pull/1042