### PR TITLE
Fixes executing commands with quotes

### DIFF
--- a/lib/process-ctl.js
+++ b/lib/process-ctl.js
@@ -71,7 +71,7 @@ ProcessCtl.prototype.spawn = function(exe, args, options) {
 
 ProcessCtl.prototype.exec = function(cmd, options) {
   log.info('executing: ' + cmd);
-  var cmdParts = spawnargs(cmd,  { removequotes: 'always' });
+  var cmdParts = spawnargs(cmd);
   var exe = cmdParts[0];
   var args = cmdParts.slice(1);
 


### PR DESCRIPTION
Arguments aren't quoted when using shell: true, keep the quoting from
the original cmd.