### PR TITLE
Guard this.onFinish() in browser_test_runner.js

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -264,7 +264,10 @@ BrowserTestRunner.prototype = {
       return;
     }
     return this.exit().then(function() {
-      this.onFinish();
+      // TODO: Not sure how this can happen, but sometimes onFinish is not defined
+      if (this.onFinish) {
+        this.onFinish();
+      }
     }.bind(this));
   }
 };


### PR DESCRIPTION
This change adds a simple guard to avoid calling `onFinish` if it's not defined, fixing #1056.

Not sure how(/whether) to test this — any guidance would be appreciated 🙂 