### PR TITLE
Support running tests from a file: URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ os:
 - osx
 - linux
 osx_image: xcode8
+addons:
+  apt:
+    packages:
+      - xvfb
 language: node_js
 node_js:
   - "0.10"
@@ -27,6 +31,8 @@ before_install:
     fi
   - npm config set spin false
 install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - travis_retry npm install
 before_script:
   - if [ $TRAVIS_OS_NAME == "linux" ] && [ $TRAVIS_NODE_VERSION == "4" ]; then

--- a/bin/run-integration.js
+++ b/bin/run-integration.js
@@ -28,7 +28,8 @@ var skipOnWindows = [
 ];
 var skipDefiningReporter = [
   'node_example',
-  'node_tap_example'
+  'node_tap_example',
+  'electron'
 ];
 var examplesPath = path.join(__dirname, '../examples');
 var DEFAULT_CONCURRENY = 10;

--- a/examples/electron/.gitignore
+++ b/examples/electron/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/electron/README.md
+++ b/examples/electron/README.md
@@ -1,0 +1,9 @@
+## Setup
+
+First install dependencies
+
+    npm install
+
+Then, just run tests
+
+    npm test

--- a/examples/electron/hello.js
+++ b/examples/electron/hello.js
@@ -1,0 +1,3 @@
+function hello(name){
+    return "hello " + (name || 'world');
+}

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -1,0 +1,16 @@
+{
+  "devDependencies": {
+    "electron": "1.4.13",
+    "file-url": "^1.1.0",
+    "qunitjs": "^1.20.0",
+    "tmp": "0.0.31"
+  },
+  "scripts": {
+    "test": "node ../../testem.js ci -P 10"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/testem/testem.git"
+  },
+  "license": "MIT"
+}

--- a/examples/electron/runtests.js
+++ b/examples/electron/runtests.js
@@ -1,0 +1,54 @@
+var os = require('os');
+var path = require('path');
+var fs = require('fs');
+var url = require('url');
+var fileUrl = require('file-url');
+var tmp = require('tmp');
+var execFile = require('child_process').execFile;
+
+var baseObj = url.parse(process.argv[2]);
+var testPageObj = url.parse(process.argv[3], true);
+var id = process.argv[4];
+
+// Find our electron binary
+var platform = os.platform();
+var electronModulePath = path.dirname(require.resolve('electron'));
+var electronPath;
+
+if (platform === 'darwin') {
+  electronPath = path.join(electronModulePath, 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron');
+} else if (platform === 'win32') {
+  electronPath = path.join(electronModulePath, 'dist', 'electron.exe');
+} else {
+  electronPath = path.join(electronModulePath, 'dist', 'electron');
+}
+
+// Build testem.js URL
+baseObj.pathname = '/testem.js';
+var testemJsUrl = url.format(baseObj);
+
+// Process the HTML to point to the correct testem.js, and have a base URL
+// pointing back to this directory.
+var testPagePath = path.join.apply(null, testPageObj.pathname.split('/'));
+var htmlContent = fs.readFileSync(testPagePath, 'utf8').toString();
+htmlContent = htmlContent.replace('<head>', '<head>\n<base href="' + fileUrl(__dirname) + '/">');
+htmlContent = htmlContent.replace('src="/testem.js"', 'src="' + testemJsUrl + '"');
+var tmpFile = tmp.fileSync({ postfix: '.html' });
+fs.writeFileSync(tmpFile.name, htmlContent, 'utf8');
+
+// Build a file: URL to our temp file, preserving query params from the test
+// page and adding the testem id
+var tmpFileObj = url.parse(fileUrl(tmpFile.name));
+tmpFileObj.query = testPageObj.query;
+tmpFileObj.query.testemId = id;
+var testUrl = url.format(tmpFileObj);
+
+var child = execFile(electronPath, [testUrl], function(error) {
+  if (error) {
+    throw error;
+  }
+});
+
+process.on('SIGTERM', function() {
+  child.kill();
+});

--- a/examples/electron/test.html
+++ b/examples/electron/test.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+<title>Test'em</title>
+<link rel="stylesheet" href="node_modules/qunitjs/qunit/qunit.css">
+<script>
+  window.getTestemId = function() {
+    var match = window.location.search.match(/[\?&]testemId=([^\?&]+)/);
+    return match ? match[1] : null;
+  }
+</script>
+<!-- This is going to get re-written before the page is loaded -->
+<script src="/testem.js"></script>
+<script src="node_modules/qunitjs/qunit/qunit.js"></script>
+<script src="hello.js"></script>
+<script src="tests.js"></script>
+<script>
+Testem.hookIntoTestFramework();
+</script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/examples/electron/testem.json
+++ b/examples/electron/testem.json
@@ -1,0 +1,22 @@
+{
+  "framework": "qunit",
+  "test_page": [
+    "test.html"
+  ],
+  "src_files": [
+    "*.js"
+  ],
+  "launchers": {
+    "cli": {
+      "exe": "node",
+      "args": [ "./runtests.js", "<baseUrl>", "<testPage>", "<id>" ],
+      "protocol": "browser"
+    }
+  },
+  "launch_in_dev": [
+    "cli"
+  ],
+  "launch_in_ci": [
+    "cli"
+  ]
+}

--- a/examples/electron/tests.js
+++ b/examples/electron/tests.js
@@ -1,0 +1,3 @@
+QUnit.test('says hello world', function(assert){
+    assert.equal(hello(), 'hello world', 'should equal hello world');
+});

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -88,14 +88,13 @@ Launcher.prototype = {
       return Bluebird.reject(new Error('No command or exe/args specified for launcher ' + this.name));
     }
   },
+  getId: function() {
+    return this.isProcess() ? -1 : this.id;
+  },
   getUrl: function() {
     var baseUrl = this.config.get('url');
     var testPage = this.settings.test_page;
-    var id = this.id;
-
-    if (this.isProcess()) {
-      id = -1;
-    }
+    var id = this.getId();
 
     return baseUrl + id + (testPage ? '/' + testPage : '');
   },
@@ -116,7 +115,10 @@ Launcher.prototype = {
     } else {
       var params = {
         url: this.getUrl(),
-        port: this.config.get('port')
+        baseUrl: this.config.get('url'),
+        port: this.config.get('port'),
+        testPage: this.settings.test_page || '',
+        id: this.getId()
       };
       return template(thing, params);
     }

--- a/tests/launcher_tests.js
+++ b/tests/launcher_tests.js
@@ -131,23 +131,23 @@ describe('Launcher', function() {
 
     beforeEach(function() {
       config = new Config(null, {port: '7357', url: 'http://blah.com/'});
-      settings = {exe: 'node', args: ['-e', echoArgs, 'hello']};
+      settings = {exe: 'node', args: ['-e', echoArgs, 'hello'], test_page: 'tp.html'};
       launcher = new Launcher('test launcher', settings, config);
     });
 
     it('should launch and also kill it', function(done) {
       launcher.start().then(function(launchedProcess) {
         launchedProcess.on('processExit', function(code, stdout) {
-          expect(stdout).to.match(/hello http:\/\/blah.com\/-1+(\r\n|\n)/);
+          expect(stdout).to.match(/hello http:\/\/blah.com\/-1\/tp\.html+(\r\n|\n)/);
           done();
         });
       });
     });
     it('should substitute variables for args', function(done) {
-      settings.args = ['-e', echoArgs, '<port>', '<url>'];
+      settings.args = ['-e', echoArgs, '<port>', '<url>', '<baseUrl>', '<testPage>', '<id>'];
       launcher.start().then(function(launchedProcess) {
         launchedProcess.on('processExit', function(code, stdout) {
-          expect(stdout).to.match(/7357 http:\/\/blah.com\/-1 http:\/\/blah.com\/-1+(\r\n|\n)/);
+          expect(stdout).to.match(/7357 http:\/\/blah.com\/-1\/tp\.html http:\/\/blah.com\/ tp\.html -1 http:\/\/blah.com\/-1\/tp.html+(\r\n|\n)/);
           done();
         });
       });


### PR DESCRIPTION
## Disclaimer

I'm pretty new to the testem code base, so I'm opening this up to see if it or something like it makes any sense, and to get feedback. Maybe there's an easier way of getting electron to run under testem, and if so I'd love to hear it, but this is the best I could figure out. Also, I wrote an integration test, but couldn't really find where unit tests related to these changes live, so I'd love a pointer there.

## The proposed change

There are a couple of changes here that enable (with some hoop-jumping) running tests from file: urls. My use case is electron -- testem is awesome, and I want to be able to test my electron apps using testem. More specifically, I'm doing some work on ember-electron, and ember is already set up to use testem. However, as you can see from the integration test, these changes will support electron in general, not just ember electron.

The primary changes are:
* Instead of using the URL `/testem/connection.html` to load the client into the iframe, parse out testem.js' script tag's src and construct a fully-qualified URL including the scheme, so that the URL from which testem.js is loaded determines where to find connection.html, not the URL from which the host HTML is loaded.
* Allow the host HTML to specify a global function to do custom discovery of the testem ID, so that it can be provided through some other mechanism than being the first path component.

With these two changes in place, a custom runner can process the testem-generated URL, rewrite it to point into the filesystem, munge the test HTML a bit to point to testem.js with a fully-qualified URL, move the testem ID to a query param so it doesn't mess up the file: URL, and then run HTML with an extra <script> tag providing a global function to parse the testem ID out of the query param instead of looking in the path. Bing bang boom, electron runs all the code out of the filesystem, but reports everything seemlessly to testem via the browser protocol as if it were an actual browser running code through the testem proxy server.