### PR TITLE
Updates node-notifier to v5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash.find": "^4.5.1",
     "mkdirp": "^0.5.1",
     "mustache": "^2.2.1",
-    "node-notifier": "^4.3.1",
+    "node-notifier": "^5.0.1",
     "npmlog": "^4.0.0",
     "printf": "^0.2.3",
     "rimraf": "^2.4.4",


### PR DESCRIPTION
Updates the dependency of `node-notifier` to the latest [newly released `v5.0.1`](https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md#v500).

With this change there are a lot fewer dependencies as the built in CLI is removed, and other dependencies are trimmed. 

No change in the way it's used in this package.