### PR TITLE
Provide testem's cwd to launcher templates

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -114,6 +114,7 @@ Launcher.prototype = {
       return thing.map(this.template, this);
     } else {
       var params = {
+        cwd: this.config.cwd(),
         url: this.getUrl(),
         baseUrl: this.config.get('url'),
         port: this.config.get('port'),

--- a/tests/launcher_tests.js
+++ b/tests/launcher_tests.js
@@ -130,7 +130,7 @@ describe('Launcher', function() {
     var config, settings, launcher;
 
     beforeEach(function() {
-      config = new Config(null, {port: '7357', url: 'http://blah.com/'});
+      config = new Config(null, {port: '7357', url: 'http://blah.com/', cwd: '/foo/bar'});
       settings = {exe: 'node', args: ['-e', echoArgs, 'hello'], test_page: 'tp.html'};
       launcher = new Launcher('test launcher', settings, config);
     });
@@ -144,10 +144,10 @@ describe('Launcher', function() {
       });
     });
     it('should substitute variables for args', function(done) {
-      settings.args = ['-e', echoArgs, '<port>', '<url>', '<baseUrl>', '<testPage>', '<id>'];
+      settings.args = ['-e', echoArgs, '<port>', '<url>', '<baseUrl>', '<testPage>', '<id>', '<cwd>'];
       launcher.start().then(function(launchedProcess) {
         launchedProcess.on('processExit', function(code, stdout) {
-          expect(stdout).to.match(/7357 http:\/\/blah.com\/-1\/tp\.html http:\/\/blah.com\/ tp\.html -1 http:\/\/blah.com\/-1\/tp.html+(\r\n|\n)/);
+          expect(stdout).to.match(/7357 http:\/\/blah.com\/-1\/tp\.html http:\/\/blah.com\/ tp\.html -1 \/foo\/bar http:\/\/blah.com\/-1\/tp.html+(\r\n|\n)/);
           done();
         });
       });


### PR DESCRIPTION
This is a follow-up to #1060 -- I think of it at the time, but often systems using file-url functionality will be running on built/minified/etc output in a temp directory. Testem makes this easy with the `cwd` options, telling it where to serve files from. Propagating the `cwd` into the template context allows test runners to know where the built content is so they can mirror this behavior.