### PR TITLE
Fix multiple tab/reporter issue

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -233,7 +233,7 @@ App.prototype = {
 
   onBrowserLogin: function(browserName, id, socket) {
     var browser = find(this.runners, function(runner) {
-      return runner.pending && runner.launcherId === id;
+      return runner.launcherId === id && (!runner.socket || !runner.socket.connected);
     });
 
     if (!browser) {

--- a/tests/ci/dev_tests.js
+++ b/tests/ci/dev_tests.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var expect = require('chai').expect;
 var path = require('path');
+var sinon = require('sinon');
 
 var App = require('../../lib/app');
 var Config = require('../../lib/config');
@@ -45,6 +46,40 @@ describe('dev mode app', function() {
             });
           });
         });
+      });
+    });
+
+    it('keeps runner association across page reloads', function(done) {
+      var reporter = new FakeReporter();
+      var dir = path.join('tests/fixtures/reload-test');
+      var config = new Config('dev', {}, {
+        file: path.join(dir, 'testem.json'),
+        port: 0,
+        cwd: dir,
+        reporter: reporter,
+        // For some reason the file watcher fires change events for
+        // tests/fixtures/reload-test/testem.json which restarts our runner and
+        // screws up our test, so we need to disable watching
+        disable_watching: true,
+        launch_in_dev: ['PhantomJS']
+      });
+      config.read(function() {
+        var app = new App(config, function() {
+          done();
+        });
+        var logins = 0;
+        var onBrowserLogin = app.onBrowserLogin;
+        sinon.stub(app, 'onBrowserLogin', function() {
+          onBrowserLogin.apply(app, arguments);
+          logins += 1;
+
+          expect(app.runners.length).to.eq(1);
+
+          if (logins === 2) {
+            app.exit();
+          }
+        });
+        app.start();
       });
     });
   });

--- a/tests/fixtures/reload-test/testem.json
+++ b/tests/fixtures/reload-test/testem.json
@@ -1,0 +1,3 @@
+{
+    "framework": "qunit"
+}

--- a/tests/fixtures/reload-test/tests.js
+++ b/tests/fixtures/reload-test/tests.js
@@ -1,0 +1,12 @@
+/* globals QUnit, window */
+'use strict';
+
+QUnit.test('says hello world', function(assert) {
+  assert.ok(true);
+});
+
+QUnit.done(function() {
+  setTimeout(function() {
+    window.location.reload();
+  }, 500);
+});


### PR DESCRIPTION
When running in server mode, if something causes the browser to reload (e.g. the user changing the QUnit filters to run a subset of the tests, or a live reload in a framework like ember-cli), a new reporter and UI tab will be spawned. This was happening because the browser login code was only matching against still-pending runners.

We can make the check more resilient by instead of checking pending, just looking for a runner with the correct id that either doesn't have a socket, or whose socket is not connected. That allows the same browser to connect back to the same reporter any number of times across page refreshes.

This may also fix #1063 although I haven't been able to reproduce that issue myself, so I can't be sure if this fixes it or not.

I'm not really sure how to unit test this fix -- I'm open to suggestions :)