### PR TITLE
Fix Node >= 4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "charm": "^1.0.0",
     "commander": "^2.6.0",
     "consolidate": "^0.14.0",
-    "cross-spawn": "^5.0.0",
+    "cross-spawn": "^5.1.0",
     "express": "^4.10.7",
     "fireworm": "^0.7.0",
     "glob": "^7.0.4",


### PR DESCRIPTION
Node 4.8 supports the shell option for spawn now, update cross-spawn to
respect that.

Fixes https://github.com/testem/testem/issues/1074 https://github.com/testem/testem/issues/1076 https://github.com/testem/testem/issues/1077 https://github.com/testem/testem/issues/1078

Requires:
- [ ] https://github.com/IndigoUnited/node-cross-spawn/pull/67