### PR TITLE
move to proxy behind the static files, so you serve static files before the proxies

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -111,8 +111,6 @@ class Server extends EventEmitter {
 
     this.injectMiddleware(app);
 
-    this.configureProxy(app);
-
     app.get('/', (req, res) => {
       res.redirect(`/${String(Math.floor(Math.random() * 10000))}`);
     });
@@ -127,6 +125,8 @@ class Server extends EventEmitter {
 
     app.all(/^\/(?:-?[0-9]+)(\/.+)$/, serveStaticFile);
     app.all(/^(.+)$/, serveStaticFile);
+
+    this.configureProxy(app);
 
     app.use((err, req, res, next) => {
       if (err) {
@@ -324,7 +324,7 @@ class Server extends EventEmitter {
     };
   }
 
-  serveStaticFile(uri, req, res) {
+  serveStaticFile(uri, req, res, next) {
     var config = this.config;
     var routeRes = this.route(uri);
     uri = routeRes.uri;
@@ -346,6 +346,9 @@ class Server extends EventEmitter {
       fs.stat(filePath, (err, stat) => {
         this.emit('file-requested', filePath);
         if (err) {
+          if (next) {
+            return next('route');
+          }
           return res.sendFile(filePath);
         }
         if (stat.isDirectory()) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -84,8 +84,8 @@ class Server extends EventEmitter {
 
   createExpress() {
     var app = this.express = express();
-    var serveStaticFile = (req, res) => {
-      this.serveStaticFile(req.params[0], req, res);
+    var serveStaticFile = (req, res, next) => {
+      this.serveStaticFile(req.params[0], req, res, next);
     };
 
     if (this.config.get('key') || this.config.get('pfx')) {
@@ -127,6 +127,8 @@ class Server extends EventEmitter {
     app.all(/^(.+)$/, serveStaticFile);
 
     this.configureProxy(app);
+
+    app.all(/.*/, (req, res) => res.status(404).send("Not found: " + req.originalUrl));
 
     app.use((err, req, res, next) => {
       if (err) {

--- a/tests/api4/hello.js
+++ b/tests/api4/hello.js
@@ -1,0 +1,6 @@
+/* exported hello */
+'use strict';
+
+function hello() {
+  return 'hello world';
+}

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -334,7 +334,7 @@ describe('Server', function() {
           }
         };
         request.get(options, function(err, req, text) {
-          expect(text).to.equal('Not found: /api3/test');
+          expect(text).to.equal('<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /api3/test</pre>\n</body>\n');
           done();
         });
       });

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -339,6 +339,10 @@ describe('Server', function() {
         });
       });
 
+      it('it tries to get the static file before trying the proxy', function(done) {
+        assertUrlReturnsFileContents(baseUrl + 'api4/hello.js', 'tests/api4/hello.js', done);
+      });
+
       it('returns an error when a requst can not be proxied', function(done) {
         let options = {
           url: baseUrl + 'api-error/test'

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -334,7 +334,7 @@ describe('Server', function() {
           }
         };
         request.get(options, function(err, req, text) {
-          expect(text).to.equal('<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /api3/test</pre>\n</body>\n');
+          expect(text).to.equal('Not found: /api3/test');
           done();
         });
       });


### PR DESCRIPTION
I wanted to proxy a website into an iframe to run tests on the website. But for that to work the proxy url needed to be `/`. So all the assets can come in via the proxy aswel.

This however creates a problem because the proxy then intercepts all requests to the testem files and my local tests files. 

To solve this I moved the proxy to after the `serveStaticFile` calls. To make sure the serveStaticFile doesn't return a 404 but continues on to the next route I've added a call to `next('route')` in the `serveStaticFile` function.

I've had to change only one failing tests: `'proxies get html request to api3'` which is probably the wrong name for the tests as it doesn't test the proxy but the error handler. 

This change does cause that to fail, because when the file is not found it tries something else instead of throwing an error. 

To solve this I think we could just add `app.all(".*", (req, res) => res.send("Not found: " + req.originalUrl));` at the end to catch everything.
