### PR TITLE
tap_quiet_logs: only show logs for failed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ TAP is a human-readable and language-agnostic test result format. TAP plugins ex
 * [Jenkins TAP plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin) - I've added [detailed instructions](https://github.com/testem/testem/blob/master/docs/use_with_jenkins.md) for setup with Jenkins.
 * [TeamCity TAP plugin](https://github.com/pavelsher/teamcity-tap-parser)
 
+## TAP Options
+
+By default, the TAP reporter outputs logs from all tests that emit logs. You cann disable this behavior and only emit logs for failed tests using:
+
+```json
+{
+  "tap_quiet_logs": true
+}
+```
+
 ## Other Test Reporters
 
 Testem has other test reporters than TAP: `dot`, `xunit` and `teamcity`. You can use the `-R` to specify them

--- a/lib/displayutils.js
+++ b/lib/displayutils.js
@@ -39,9 +39,9 @@ function yamlDisplay(err, logs) {
     '...'].join('\n'));
 }
 
-function resultString(id, prefix, result) {
+function resultString(id, prefix, result, quietLogs) {
   var string = resultDisplay(id, prefix, result) + '\n';
-  if (result.error || result.logs && result.logs.length) {
+  if (result.error || (!quietLogs && result.logs && result.logs.length)) {
     string += yamlDisplay(result.error, result.logs) + '\n';
   }
   return string;

--- a/lib/reporters/tap_reporter.js
+++ b/lib/reporters/tap_reporter.js
@@ -2,9 +2,10 @@
 
 var displayutils = require('../displayutils');
 
-function TapReporter(silent, out) {
+function TapReporter(silent, out, config) {
   this.out = out || process.stdout;
   this.silent = silent;
+  this.quietLogs = !!config.get('tap_quiet_logs');
   this.stoppedOnError = null;
   this.id = 1;
   this.total = 0;
@@ -47,7 +48,7 @@ TapReporter.prototype = {
     if (this.silent) {
       return;
     }
-    this.out.write(displayutils.resultString(this.id++, prefix, result));
+    this.out.write(displayutils.resultString(this.id++, prefix, result, this.quietLogs));
   },
   finish: function() {
     if (this.silent) {

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -16,6 +16,10 @@ var FakeReporter = require('../support/fake_reporter');
 
 var isWin = /^win/.test(process.platform);
 
+function makeTestReporter() {
+  return new TestReporter(true, undefined, new Config('ci', {}));
+}
+
 describe('ci mode app', function() {
   this.timeout(90000);
   var sandbox;
@@ -39,7 +43,7 @@ describe('ci mode app', function() {
     });
 
     it('runs them tests on node, nodetap, and browser', function(done) {
-      var reporter = new TestReporter(true);
+      var reporter = makeTestReporter();
       var dir = path.join('tests/fixtures/tape');
       var config = new Config('ci', {
         file: path.join(dir, 'testem.json'),
@@ -99,7 +103,7 @@ describe('ci mode app', function() {
         port: 0,
         cwd: dir,
         launch_in_ci: ['phantomjs'],
-        reporter: new TestReporter(true)
+        reporter: makeTestReporter()
       });
       config.read(function() {
         var app = new App(config, function(exitCode) {
@@ -117,7 +121,7 @@ describe('ci mode app', function() {
         port: 0,
         cwd: dir,
         launch_in_ci: ['phantomjs'],
-        reporter: new TestReporter(true)
+        reporter: makeTestReporter()
       });
       config.read(function() {
         var app = new App(config, function(exitCode) {
@@ -136,7 +140,7 @@ describe('ci mode app', function() {
         port: 0,
         cwd: dir,
         launch_in_ci: ['phantomjs'],
-        reporter: new TestReporter(true),
+        reporter: makeTestReporter(),
         on_start: function(config, data, callback) {
           var launcher = app.launchers()[0];
 
@@ -169,7 +173,7 @@ describe('ci mode app', function() {
         port: 0,
         cwd: dir,
         launch_in_ci: ['phantomjs'],
-        reporter: new TestReporter(true),
+        reporter: makeTestReporter(),
         browser_disconnect_timeout: 0.1
       });
       config.read(function() {
@@ -182,7 +186,7 @@ describe('ci mode app', function() {
     });
 
     it('forwards console messages to the reporter', function(done) {
-      var reporter = new TestReporter(true);
+      var reporter = makeTestReporter();
       var dir = path.join('tests/fixtures/console-test');
       var config = new Config('ci', {
         file: path.join(dir, 'testem.json'),
@@ -369,7 +373,7 @@ describe('ci mode app', function() {
       cwd: path.join('tests/fixtures/fail_later'),
       timeout: 2,
       launch_in_ci: ['phantomjs'],
-      reporter: new TestReporter(true)
+      reporter: makeTestReporter()
     });
     config.read(function() {
       var app = new App(config);
@@ -384,7 +388,7 @@ describe('ci mode app', function() {
   });
 
   it('returns with non zero exit code and reports an error when a hook was not executable', function(done) {
-    var reporter = new TestReporter(true);
+    var reporter = makeTestReporter();
     var config = new Config('ci', {
       port: 0,
       cwd: path.join('tests/fixtures/basic_test'),
@@ -463,7 +467,7 @@ describe('ci mode app', function() {
   });
 
   it('runs two browser instances in parallel with different test pages', function(done) {
-    var reporter = new TestReporter(true);
+    var reporter = makeTestReporter();
     var config = new Config('ci', {
       file: 'tests/fixtures/multiple_pages/testem.json',
       port: 0,


### PR DESCRIPTION
This adds a tap_quiet_logs option to only show logs when a test fails.
The option defaults to false, which is the current behavior (i.e. show
logs whenever they're present).

The underlying motivation here is to be able to silence verbose logging
we get when receiving our tests, except when the tests fail, so that we
can have generally quiet logs and full debug information if a test
fails.