### PR TITLE
Testing and known browsers

### DIFF
--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -136,24 +136,6 @@ function knownBrowsers(platform, config) {
       }
     },
     {
-      name: 'Safari Technology Preview',
-      possiblePath: [
-        process.env.HOME + '/Applications/Safari\ Technology\ Preview.app/Contents/MacOS/Safari\ Technology\ Preview',
-        '/Applications/Safari\ Technology\ Preview.app/Contents/MacOS/Safari\ Technology\ Preview'
-      ],
-      setup: function(config, done) {
-        var url = this.getUrl();
-        fs.writeFile(
-          path.join(this.browserTmpDir(), 'start.html'),
-          '<script>window.location = \'' + url + '\'</script>',
-          done
-        );
-      },
-      args: function() {
-        return [path.join(this.browserTmpDir(), 'start.html')];
-      }
-    },
-    {
       name: 'Opera',
       possiblePath: [
         'C:\\Program Files\\Opera\\opera.exe',
@@ -190,12 +172,29 @@ function knownBrowsers(platform, config) {
   ];
 
   if (isWin(platform)) {
-    browsers = browsers.concat([
-      {
-        name: 'IE',
-        possiblePath: 'C:\\Program Files\\Internet Explorer\\iexplore.exe'
+    browsers.push({
+      name: 'IE',
+      possiblePath: 'C:\\Program Files\\Internet Explorer\\iexplore.exe'
+    });
+  } else {
+    browsers.push({
+      name: 'Safari Technology Preview',
+      possiblePath: [
+        process.env.HOME + '/Applications/Safari\ Technology\ Preview.app/Contents/MacOS/Safari\ Technology\ Preview',
+        '/Applications/Safari\ Technology\ Preview.app/Contents/MacOS/Safari\ Technology\ Preview'
+      ],
+      setup: function(config, done) {
+        var url = this.getUrl();
+        fs.writeFile(
+          path.join(this.browserTmpDir(), 'start.html'),
+          '<script>window.location = \'' + url + '\'</script>',
+          done
+        );
+      },
+      args: function() {
+        return [path.join(this.browserTmpDir(), 'start.html')];
       }
-    ]);
+    });
   }
 
   return browserArgs.addCustomArgs(browsers, config);

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -29,7 +29,8 @@ describe('App', function() {
         reporter: new FakeReporter()
       });
       app = new App(config, function() {
-        finish();
+        if (finish) { finish(); }
+        else { done(); }
       });
       sandbox.spy(app, 'triggerRun');
       sandbox.spy(app, 'stopRunners');

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -214,17 +214,18 @@ describe('ci mode app', function() {
   });
 
   it('fails with explicitly defined missing launchers', function(done) {
+    var browser = isWin ? 'Safari Technology Preview' : 'IE';
     var config = new Config('ci', {
       file: 'tests/fixtures/basic_test/testem.json',
       port: 0,
       cwd: path.join('tests/fixtures/basic_test/'),
-      launch_in_ci: ['opera'],
+      launch_in_ci: [browser],
       reporter: new FakeReporter()
     });
     config.read(function() {
       var app = new App(config, function(exitCode, err) {
         expect(exitCode).to.eq(1);
-        expect(err.message).to.eq('Launcher opera not found. Not installed?');
+        expect(err.message).to.eq('Launcher ' + browser + ' not found. Not installed?');
         done();
       });
       app.start();
@@ -326,7 +327,8 @@ describe('ci mode app', function() {
 
   it('kills launchers on wrapUp', function(done) {
     var app = new App(new Config('ci', {
-      launch_in_ci: []
+      launch_in_ci: [],
+      reporter: new FakeReporter()
     }), function() {
       assert(app.killRunners.called, 'clean up launchers should be called');
       done();


### PR DESCRIPTION
- Only add "Safari Technology Preview" to known browsers if not on Windows
- Testing: Prevent potential `beforeEach` error
- Testing: Suppress test output for "kills launchers on wrapUp" ci test
- Testing: Instead of assuming opera is missing, assume IE is missing on non-Windows and assume Safarai Technology Preview is missing on Windows
