### PR TITLE
add warning when multiple config files are found

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -67,6 +67,12 @@ Config.prototype.read = function(callback) {
     var files = ['testem.json', '.testem.json', '.testem.yml', 'testem.yml', 'testem.js', '.testem.js'];
     return Bluebird.filter(files.map(this.resolveConfigPath.bind(this)), fileExists).then(function(matched) {
       var configFile = matched[0];
+      if (matched.length > 1) {
+        var baseNames = matched.map(function(fileName) {
+          return path.basename(fileName);
+        });
+        console.warn('Found ' + matched.length + ' config files (' + baseNames + '), using ' + baseNames[0]);
+      }
       if (configFile) {
         this.readConfigFile(configFile, callback);
       } else {


### PR DESCRIPTION
If a project accidentally has multiple config files, it can be unclear to the user why changes to a lower-priority file aren't being picked up by testem.

This PR adds an explicit warning making clear which of the files is being used.