### PR TITLE
Configurable decycle depth

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -69,9 +69,10 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
     browser_args:                [Object]  hash of browsers (keys) to an array of their custom aruments (values)
+    client_decycle_depth         [Number]  number of times to recurse while decycling objects within the client (5)
+    config_dir:                  [Path]    directory to use as root for resolving configs, if different than cwd
     css_files:                   [Array]   string or array of additional stylesheets to include
     cwd:                         [Path]    directory to use as root
-    config_dir:                  [Path]    directory to use as root for resolving configs, if different than cwd
     disable_watching:            [Boolean] disable any file watching
     fail_on_zero_tests:          [Boolean] whether process should exit with error status when no tests found
     firefox_user_js:             [String]  path to firefox custom user.js file to be used

--- a/lib/config.js
+++ b/lib/config.js
@@ -92,6 +92,12 @@ Config.prototype.resolvePath = function(filepath) {
   return path.resolve(this.cwd(), filepath);
 };
 
+Config.prototype.client = function() {
+  return {
+    decycle_depth: this.get('client_decycle_depth')
+  };
+};
+
 Config.prototype.resolveConfigPath = function(filepath) {
   if (this.progOptions.config_dir) {
     return path.resolve(this.progOptions.config_dir, filepath);
@@ -176,7 +182,8 @@ Config.prototype.defaults = {
   reporter: 'tap',
   bail_on_uncaught_error: true,
   browser_start_timeout: 30,
-  browser_disconnect_timeout: 10
+  browser_disconnect_timeout: 10,
+  client_decycle_depth: 5
 };
 
 Config.prototype.mergeUrlAndQueryParams = function(urlString, queryParamsObj) {

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -106,25 +106,18 @@ BrowserTestRunner.prototype = {
     socket.on('test-metadata', this.onTestMetadata.bind(this));
     socket.on('top-level-error', this.onGlobalError.bind(this));
 
-    var handleMessage = function(type) {
-      return function(/* ...args */) {
-        var args = Array.prototype.slice.call(arguments);
-        var message = args.map(function(arg) {
-          return util.inspect(arg);
-        }).join(' ');
+    socket.on('browser-console', function(/* ...args */) {
+      var args = Array.prototype.slice.call(arguments);
+      var type = args.shift();
+      var message = args.map(function(arg) {
+        return util.inspect(arg, { depth: null });
+      }).join(' ');
 
-        this.logs.push({
-          type: type,
-          text: message + '\n'
-        });
-      }.bind(this);
-    }.bind(this);
-
-    var methods = ['log', 'warn', 'error', 'info'];
-
-    for (var method in methods) {
-      socket.on('console-' + methods[method], handleMessage(methods[method]));
-    }
+      this.logs.push({
+        type: type,
+        text: message + '\n'
+      });
+    }.bind(this));
 
     socket.on('disconnect', this.onDisconnect.bind(this));
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -263,6 +263,9 @@ Server.prototype = {
     res.setHeader('Content-Type', 'text/javascript');
 
     res.write(';(function(){');
+    res.write('\n//============== config ==================\n\n');
+    res.write('var TestemConfig = ' + JSON.stringify(this.config.client()) + ';');
+
     var files = [
       'decycle.js',
       'jasmine_adapter.js',

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -496,6 +496,18 @@ describe('Config', function() {
     });
   });
 
+  describe('client_decycle_depth', function() {
+    it('defaults to 5', function() {
+      expect(config.get('client_decycle_depth')).to.eq(5);
+    });
+  });
+
+  describe('client', function() {
+    it('returns config options used within the client', function() {
+      expect(config.client()).to.have.all.keys(['decycle_depth']);
+    });
+  });
+
   describe('debug', function() {
     describe('when unset', function() {
       it('is not defined', function() {


### PR DESCRIPTION
Allow to configure the default decycle depth of 5 and ensure only user
generated content is decycled.

Fixes https://github.com/testem/testem/issues/962