### PR TITLE
Decycle: Fix attempted to access "nodeType" on a factory manager

### DIFF
--- a/public/testem/decycle.js
+++ b/public/testem/decycle.js
@@ -64,7 +64,7 @@ function decycle(object, maxDepth) {
     if (value === null || typeof value === 'undefined' || value instanceof Boolean || value instanceof Number) {
       return value;
     }
-    if (typeof value === 'object' && typeof value.nodeType === 'number') {
+    if (value instanceof Element) {
       return String(value);
     }
 


### PR DESCRIPTION
Use a different (and better) method to detect DOM nodes.

Fixes https://github.com/testem/testem/issues/1105