### PR TITLE
Fix arguments passed to emitted events

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -164,8 +164,8 @@ var Testem = {
   },
   emit: function(evt) {
     var argsWithoutFirst = new Array(arguments.length - 1);
-    for (var i = 0; i < argsWithoutFirst.length; ++i) {
-      argsWithoutFirst[i] = arguments[i];
+    for (var i = 1; i < arguments.length; ++i) {
+      argsWithoutFirst[i - 1] = arguments[i];
     }
 
     if (this.evtHandlers && this.evtHandlers[evt]) {


### PR DESCRIPTION
Looks like during the refactor of `emit` done [here](https://github.com/testem/testem/commit/417825a821abd0a384c743452d56fdd0af696894#diff-d00c538143575786bc4538042415bccdR166), the logic for the arguments passed to emitted events was changed. This resulted in event data not actually getting passed to event handlers, such as reported here: https://github.com/trentmwillis/ember-exam/issues/88.

This PR fixes it.

