### PR TITLE
Add ability to specify different browser_args based on mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Testem passes its own list of arguments to some of the browsers it launches. You
 }
 ```
 
-You can supply arguments to any number of browsers Testem has available by using the launcher name as a key in `browser_args`. Values may be an array of string arguments or, if only one, a single string.
+You can supply arguments to any number of browsers Testem has available by using the launcher name as a key in `browser_args`. Values may be an array of string arguments, a single string, or an object specifying `args` and a `mode` to apply them to.
 
 Read [more details](docs/browser_args.md) about the browser argument options.
 

--- a/docs/browser_args.md
+++ b/docs/browser_args.md
@@ -32,7 +32,6 @@ Conventions
 * The keys are launcher names, e.g., "Chrome" and they don't need to be capitalized
 * The values can be either:
   * An array of strings (if you need to add many arguments)
-  * A single string (if you only need to add one argument)
 
     ```javascript
     "browser_args": {
@@ -40,11 +39,24 @@ Conventions
         "--auto-open-devtools-for-tabs"
       ]
     }
+    ```
 
-    // OR
+  * A single string (if you only need to add one argument)
 
+    ```javascript
     "browser_args": {
       "chrome": "--auto-open-devtools-for-tabs"
+     }
+     ```
+
+  * An object specifying a string `mode` (either `ci` or `dev`) and `args` in the form of one of the first two options. The `mode` will determine which environments the given `args` apply to.
+
+     ```javascript
+     "browser_args": {
+       "chrome": {
+         "mode": "ci",
+         "args": [ "--auto-open-devtools-for-tabs" ]
+       }
      }
     ```
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -68,7 +68,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
 
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
-    browser_args:                [Object]  hash of browsers (keys) to an array of their custom aruments (values)
+    browser_args:                [Object]  hash of browsers (keys) to an array of their custom arguments (values) or an object with a mode and arguments
     client_decycle_depth         [Number]  number of times to recurse while decycling objects within the client (5)
     config_dir:                  [Path]    directory to use as root for resolving configs, if different than cwd
     css_files:                   [Array]   string or array of additional stylesheets to include

--- a/lib/utils/browser-args.js
+++ b/lib/utils/browser-args.js
@@ -23,7 +23,25 @@ module.exports = {
     if (browserArgs && typeof browserArgs === 'object') {
       for (browserName in browserArgs) {
         if (browserArgs.hasOwnProperty(browserName)) {
-          this.parseArgs(capitalize(browserName), browserArgs[browserName], knownBrowsers);
+          var args = browserArgs[browserName];
+
+          if (typeof args === 'object' && !Array.isArray(args)) {
+            if (!args.mode) {
+              warn('Type error: when using an object to specify browser_args for ' + browserName + ' you must specify a mode');
+              continue;
+            } else if (!args.args) {
+              warn('Type error: when using an object to specify browser_args for ' + browserName + ' you must specify args');
+              continue;
+            }
+
+            if (args.mode !== config.appMode) {
+              continue;
+            }
+
+            args = args.args;
+          }
+
+          this.parseArgs(capitalize(browserName), args, knownBrowsers);
         }
       }
     } else if (browserArgs !== undefined) {

--- a/tests/utils/browser-args_tests.js
+++ b/tests/utils/browser-args_tests.js
@@ -57,6 +57,80 @@ describe('browserArgs', function() {
         browserArgs.addCustomArgs(createKnownBrowsers(), config);
       });
 
+      it('warns if args for a browser is an object but missing mode field', function(done) {
+        config.browser_args = {
+          chrome: {
+            args: '--fake'
+          }
+        };
+
+        log.once('log.warn', function(warning) {
+          expect(warning.message).to.equal('Type error: when using an object to specify browser_args for chrome you must specify a mode');
+          done();
+        });
+
+        browserArgs.addCustomArgs(createKnownBrowsers(), config);
+      });
+
+      it('warns if args for a browser is an object but missing args field', function(done) {
+        config.browser_args = {
+          chrome: {
+            mode: 'dev'
+          }
+        };
+
+        log.once('log.warn', function(warning) {
+          expect(warning.message).to.equal('Type error: when using an object to specify browser_args for chrome you must specify args');
+          done();
+        });
+
+        browserArgs.addCustomArgs(createKnownBrowsers(), config);
+      });
+
+      it('ignores args that specify a mode different from the current mode', function() {
+        // Get Chrome's default args
+        var defaultArgs = createKnownBrowsers()[0].args();
+
+        knownBrowsers = createKnownBrowsers();
+
+        config.appMode = 'ci';
+        config.browser_args = {
+          chrome: {
+            mode: 'dev',
+            args: '--fake'
+          }
+        };
+
+        browserArgs.addCustomArgs(knownBrowsers, config);
+
+        expect(knownBrowsers[0].args()).to.deep.equal(defaultArgs);
+
+        // Resets known browsers value
+        knownBrowsers = createKnownBrowsers();
+      });
+
+      it('adds args in object form when specifying a matching mode and args fields', function() {
+        // Get Chrome's default args
+        var defaultArgs = createKnownBrowsers()[0].args();
+
+        knownBrowsers = createKnownBrowsers();
+
+        config.appMode = 'dev';
+        config.browser_args = {
+          chrome: {
+            mode: 'dev',
+            args: '--fake'
+          }
+        };
+
+        browserArgs.addCustomArgs(knownBrowsers, config);
+
+        expect(knownBrowsers[0].args()).to.deep.equal([ '--fake' ].concat(defaultArgs));
+
+        // Resets known browsers value
+        knownBrowsers = createKnownBrowsers();
+      });
+
       // NOTE: knownBrowsers[0] is Chrome
       it('adds args to browser regardless of key capitalization', function() {
         // Get Chrome's default args


### PR DESCRIPTION
Addresses https://github.com/testem/testem/issues/1139.

Implements the first option to support specifying mode-specific `browser_args`:

```json
{
  "browser_args": {
    "chrome": {
      "mode": "ci",
      "args": [ "--headless", "--disable-gpu", "--remove-debugging-port=9222" ]
    }
  }
}
```