### PR TITLE
Inheriting from internal reporters

### DIFF
--- a/docs/custom_reporter.md
+++ b/docs/custom_reporter.md
@@ -71,8 +71,5 @@ To use your custom reporter, set `reporter` in your `testem.js` config file:
             "src/*.js",
             "tests/*_tests.js"
         ]
-        "reporter": new MyReporter()
+        "reporter": MyReporter
     };
-
-
-

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -14,6 +14,10 @@ function setupReporter(name, out, config, app) {
     if (TestReporter) {
       reporter = new TestReporter(false, out, config, app);
     }
+  } else if (isa(name, Function)) {
+    // name is a constructor function, ignore new-cap and instantiate
+    // eslint-disable-next-line new-cap
+    reporter = new name(false, out, config, app);
   } else {
     reporter = name;
   }


### PR DESCRIPTION
(This is my first pull request so please let me know if I'm missing anything major)

This is an attempt to re-enable extending off of custom reporters based off @rwjblue's thoughts in #1115. Please see more details below:

# Problem Statement
The [currently documented route](https://github.com/testem/testem/blob/master/docs/custom_reporter.md#configuration) of passing `reporter: new MyCustomReporter()` no longer works for extending off of internal reporters such as the [TapReporter](https://github.com/testem/testem/blob/master/lib/reporters/tap_reporter.js) due to [how it accesses config options](https://github.com/testem/testem/blob/master/lib/reporters/tap_reporter.js#L8) introduced by 3729d91 to support configuration for the [TapReporter](https://github.com/testem/testem/blob/master/lib/reporters/tap_reporter.js). 

As a means of re-enabling usage of configs and custom reporters, passing a constructor reference instead of a reporter instance was suggested in #1115 as a means of keeping config management internal.

# Summary of Changes
- Test case to capture the use case (perhaps there's a better place or more tests to write, please let me know)
- Code to handle passing in a constructor reference to a testem configuration
- Documentation updates