### PR TITLE
Call on_exit hook even on failure

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -80,6 +80,14 @@ App.prototype = {
                 self.emit('tests-finish');
 
                 return Bluebird.using(self.runHook('on_exit'), function() {});
+              }).catch(function(error) {
+                log.error(error);
+                log.info('Stopping ' + self.config.appMode);
+
+                self.emit('tests-error');
+
+                Bluebird.using(self.runHook('on_exit'), function() {});
+                throw error;
               });
             });
           });

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -247,4 +247,33 @@ describe('App', function() {
       });
     });
   });
+
+  describe('start', function() {
+    var finish;
+    var onExitCb;
+    beforeEach(function() {
+      onExitCb = sandbox.stub().yields(null);
+      config = new Config('dev', {}, {
+        reporter: new FakeReporter(),
+        on_exit: onExitCb
+      });
+      app = new App(config, function() {
+        expect(onExitCb.called).to.be.true();
+        finish();
+      });
+      app.once('testRun', app.exit);
+    });
+
+    it('calls on_exit hook on success', function(done) {
+      finish = done;
+      sandbox.stub(app, 'waitForTests').usingPromise(Bluebird.Promise).resolves();
+      app.start();
+    });
+
+    it('calls on_exit hook on failure', function(done) {
+      finish = done;
+      sandbox.stub(app, 'waitForTests').usingPromise(Bluebird.Promise).rejects();
+      app.start();
+    });
+  });
 });


### PR DESCRIPTION
Previously, the on_exit hook was only being called when all the
tests have passed without errors. This leads to side effects, so
this commit fixes this issue (#1125).