### PR TITLE
Use config.cwd() to determine available launchers

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -13,8 +13,8 @@ var Bluebird = require('bluebird');
 var fileutils = require('./fileutils');
 var envWithLocalPath = require('./env-with-local-path');
 
-var executableExists = function(exe) {
-  return fileutils.executableExists(exe, { env: envWithLocalPath() });
+var executableExists = function(exe, config) {
+  return fileutils.executableExists(exe, { env: envWithLocalPath(config) });
 };
 var fileExists = fileutils.fileExists;
 
@@ -25,7 +25,7 @@ function getAvailableBrowsers(config, browsers, cb) {
   });
 
   return Bluebird.filter(browsers, function(browser) {
-    return isInstalled(browser).then(function(result) {
+    return isInstalled(browser, config).then(function(result) {
       if (!result) {
         return false;
       }
@@ -36,13 +36,15 @@ function getAvailableBrowsers(config, browsers, cb) {
   }).asCallback(cb);
 }
 
-function isInstalled(browser) {
+function isInstalled(browser, config) {
   return checkBrowser(browser, 'possiblePath', fileExists).then(function(result) {
     if (result) {
       return result;
     }
 
-    return checkBrowser(browser, 'possibleExe', executableExists);
+    return checkBrowser(browser, 'possibleExe', function(exe) {
+      return executableExists(exe, config);
+    });
   });
 }
 

--- a/lib/env-with-local-path.js
+++ b/lib/env-with-local-path.js
@@ -1,11 +1,18 @@
 'use strict';
 
 var path = require('path');
+var fs = require('fs');
 var addToPATH = require('./add-to-PATH');
 
-var modulesPath = path.join(process.cwd(), 'node_modules', '.bin');
+module.exports = function envWithLocalPath(config) {
+  var configPath = path.join(config.cwd(), 'node_modules', '.bin');
+  var modulesPath;
 
-module.exports = function envWithLocalPath() {
+  if (fs.existsSync(configPath)) {
+    modulesPath = configPath;
+  } else {
+    modulesPath = path.join(process.cwd(), 'node_modules', '.bin');
+  }
   return addToPATH(modulesPath);
 };
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -19,7 +19,7 @@ function Launcher(name, settings, config) {
   this.setupDefaultSettings();
   this.id = settings.id || String(Math.floor(Math.random() * 10000));
 
-  this.processCtl = new ProcessCtl(name);
+  this.processCtl = new ProcessCtl(name, config);
 }
 
 Launcher.prototype = {

--- a/lib/process-ctl.js
+++ b/lib/process-ctl.js
@@ -15,10 +15,11 @@ var Process = require('./utils/process');
 var fileExists = fileutils.fileExists;
 var executableExists = fileutils.executableExists;
 
-function ProcessCtl(name, options) {
+function ProcessCtl(name, config, options) {
   options = options || {};
 
   this.name = name;
+  this.config = config;
   this.killTimeout = options.killTimeout || 5000;
 }
 
@@ -26,7 +27,7 @@ ProcessCtl.prototype.__proto__ = EventEmitter.prototype;
 
 ProcessCtl.prototype.prepareOptions = function(options) {
   var defaults = {
-    env: envWithLocalPath()
+    env: envWithLocalPath(this.config)
   };
 
   return extend({}, defaults, options);

--- a/lib/runners/hook_runner.js
+++ b/lib/runners/hook_runner.js
@@ -34,7 +34,7 @@ HookRunner.prototype = {
       }.bind(this));
     }
 
-    this.processCtl = new ProcessCtl(hook);
+    this.processCtl = new ProcessCtl(hook, this.config);
 
     var command;
     var exe;

--- a/tests/browser_launcher_tests.js
+++ b/tests/browser_launcher_tests.js
@@ -3,11 +3,14 @@
 var expect = require('chai').expect;
 
 var browserLauncher = require('../lib/browser_launcher');
+var Config = require('../lib/config');
+
+var config = new Config('ci', {}, {});
 
 describe('browserLauncher', function() {
   describe('with a defined path', function() {
     it('returns a single existing path', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possiblePath: __filename
       }]).then(function(browsers) {
@@ -21,7 +24,7 @@ describe('browserLauncher', function() {
     });
 
     it('returns an array with an existing path', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possiblePath: ['not-found', __filename, 'also-not-existing']
       }]).then(function(browsers) {
@@ -35,7 +38,7 @@ describe('browserLauncher', function() {
     });
 
     it('filters a not existing path', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possiblePath: 'not-found'
       }]).then(function(browsers) {
@@ -44,7 +47,7 @@ describe('browserLauncher', function() {
     });
 
     it('filters when no path exists', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possiblePath: ['not-found', 'also-not-existing']
       }]).then(function(browsers) {
@@ -55,7 +58,7 @@ describe('browserLauncher', function() {
 
   describe('with an executable', function() {
     it('returns a single globally existing executable', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possibleExe: 'node'
       }]).then(function(browsers) {
@@ -69,7 +72,7 @@ describe('browserLauncher', function() {
     });
 
     it('returns a single locally existing executable', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possibleExe: 'mocha'
       }]).then(function(browsers) {
@@ -83,7 +86,7 @@ describe('browserLauncher', function() {
     });
 
     it('returns an array with an existing executable', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possibleExe: ['not-found', 'node', 'also-not-existing']
       }]).then(function(browsers) {
@@ -97,7 +100,7 @@ describe('browserLauncher', function() {
     });
 
     it('filters a not existing executable', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possibleExe: 'not-found'
       }]).then(function(browsers) {
@@ -106,7 +109,7 @@ describe('browserLauncher', function() {
     });
 
     it('filters when no executable exists', function() {
-      return browserLauncher.getAvailableBrowsers({}, [{
+      return browserLauncher.getAvailableBrowsers(config, [{
         name: 'Test',
         possibleExe: ['not-found', 'also-not-existing']
       }]).then(function(browsers) {

--- a/tests/env-with-local-path_tests.js
+++ b/tests/env-with-local-path_tests.js
@@ -1,21 +1,45 @@
 'use strict';
 
 var path = require('path');
+var fs = require('fs');
 
 var expect = require('chai').expect;
 
 var envWithLocalPath = require('../lib/env-with-local-path');
+var Config = require('../lib/config');
 
 describe('envWithLocalPath', function() {
+  it('returns the process env with the local node module path from the config added if it exists', function() {
+    var tempPath = path.join(process.cwd(), 'tmp');
+    var cumulativeTempPath = tempPath;
+    fs.mkdirSync(cumulativeTempPath);
+    cumulativeTempPath = path.join(cumulativeTempPath, 'node_modules');
+    fs.mkdirSync(cumulativeTempPath);
+    cumulativeTempPath = path.join(cumulativeTempPath, '.bin');
+    fs.mkdirSync(cumulativeTempPath);
+    var config = new Config('ci', {}, {
+      cwd: tempPath
+    });
+    var env = envWithLocalPath(config);
+    expect(env[envWithLocalPath.PATH]).to.contain(cumulativeTempPath);
+    fs.rmdirSync(cumulativeTempPath);
+    cumulativeTempPath = path.dirname(cumulativeTempPath);
+    fs.rmdirSync(cumulativeTempPath);
+    cumulativeTempPath = path.dirname(cumulativeTempPath);
+    fs.rmdirSync(cumulativeTempPath);
+  });
+
   it('returns the process env with the local node module path added', function() {
-    var env = envWithLocalPath();
+    var config = new Config('ci', {}, {});
+    var env = envWithLocalPath(config);
     expect(env[envWithLocalPath.PATH]).to.contain(
       path.join(process.cwd(), 'node_modules', '.bin')
     );
   });
 
   it('does not modify process.env', function() {
-    envWithLocalPath();
+    var config = new Config('ci', {}, {});
+    envWithLocalPath(config);
     expect(process.env[envWithLocalPath.PATH]).not.to.contain(
       path.join(process.cwd(), 'node_modules', '.bin')
     );

--- a/tests/process-ctl_tests.js
+++ b/tests/process-ctl_tests.js
@@ -6,16 +6,18 @@ var sinon = require('sinon');
 var expect = require('chai').expect;
 
 var ProcessCtl = require('../lib/process-ctl');
+var Config = require('../lib/config');
 
 var isWin = /^win/.test(process.platform);
 var isNodeLt012 = require('./support/is-node-lt-012');
+var config = new Config('ci', {}, {});
 
 describe('ProcessCtl', function() {
   describe('spawn', function() {
     var processCtl;
 
     beforeEach(function() {
-      processCtl = new ProcessCtl('test');
+      processCtl = new ProcessCtl('test', config);
     });
 
     it('emits a processStarted event', function() {
@@ -126,7 +128,7 @@ describe('ProcessCtl', function() {
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
-      processCtl = new ProcessCtl('test');
+      processCtl = new ProcessCtl('test', config);
     });
 
     beforeEach(function() {
@@ -157,7 +159,7 @@ describe('ProcessCtl', function() {
     var processCtl;
 
     beforeEach(function() {
-      processCtl = new ProcessCtl('test', { killTimeout: 50 });
+      processCtl = new ProcessCtl('test', config, { killTimeout: 50 });
     });
 
     it('kills regular processes', function() {


### PR DESCRIPTION
The "cwd" property from the config was not respected when
determining available launchers. If the current working directory
was different than the one from the current process, the available
launchers could not be accurately determined. This commit fixes
this issue (#1122).