### PR TITLE
Wait for on_exit to finish on failure

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -86,8 +86,11 @@ App.prototype = {
 
                 self.emit('tests-error');
 
-                Bluebird.using(self.runHook('on_exit'), function() {});
-                throw error;
+                return new Bluebird(function(resolve, reject) {
+                  Bluebird.using(self.runHook('on_exit'), function() {}).then(function() {
+                    reject(error);
+                  });
+                });
               });
             });
           });

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -251,14 +251,23 @@ describe('App', function() {
   describe('start', function() {
     var finish;
     var onExitCb;
+    var onExitFinished;
+
     beforeEach(function() {
-      onExitCb = sandbox.stub().yields(null);
+      onExitFinished = false;
+      onExitCb = sinon.stub().callsFake(function(config, data, callback) {
+        setTimeout(function() {
+          callback(null);
+          onExitFinished = true;
+        }, 10);
+      });
       config = new Config('dev', {}, {
         reporter: new FakeReporter(),
         on_exit: onExitCb
       });
       app = new App(config, function() {
         expect(onExitCb.called).to.be.true();
+        expect(onExitFinished).to.be.true();
         finish();
       });
       app.once('testRun', app.exit);
@@ -270,7 +279,7 @@ describe('App', function() {
       app.start();
     });
 
-    it('calls on_exit hook on failure', function(done) {
+    it('calls on_exit hook on failure and waits for it to finish', function(done) {
       finish = done;
       sandbox.stub(app, 'waitForTests').usingPromise(Bluebird.Promise).rejects();
       app.start();


### PR DESCRIPTION
The on_exit hook was being called on failure as part of #1157 ,
but the lifecycle system wasn't waiting for the hook to finish (i.e.,
call the callback passed to it) before exiting. This led to unwanted
side effects, so this commit fixes this issue.