### PR TITLE
Fix Mocha's duplicate failure logs

### DIFF
--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -70,8 +70,6 @@ function mochaAdapter() {
           emit('all-test-results', results);
         }
       }, 0);
-    } else if (evt === 'fail') {
-      testFail(test, err);
     }
 
     oEmit.apply(this, arguments);

--- a/tests/mocha_adapter_tests.js
+++ b/tests/mocha_adapter_tests.js
@@ -402,21 +402,8 @@ describe('mochaAdapter', function() {
         expect(originalEmit).to.have.been.calledWith(evt, test, err);
       });
 
-      it('should emit a "test-result" event', function() {
-        expect(_emit).to.have.been.calledWith('test-result', {
-          failed: 1,
-          id: 1,
-          items: [{
-            passed: false,
-            message: 'The error message',
-            stack: 'The stack trace'
-          }],
-          name: 'foo ',
-          passed: 0,
-          pending: 0,
-          runDuration: 123,
-          total: 1
-        });
+      it('should not emit a "test-result" event', function() {
+        expect(_emit).not.to.have.been.called();
       });
     });
   });


### PR DESCRIPTION
Previously, there was a bug in Mocha where the "fail" event would
not call the "test end" event, resulting in some errors not being
reported. This was accounted for on the Testem side by #1045, but
Mocha has since fixed this issue. This resulted in a bug where
test failures were being reported twice, so this commit fixes
the issue (#1129) by removing the original workaround.