### PR TITLE
Revert "Fix Mocha's duplicate failure logs"

### DIFF
--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -70,6 +70,8 @@ function mochaAdapter() {
           emit('all-test-results', results);
         }
       }, 0);
+    } else if (evt === 'fail') {
+      testFail(test, err);
     }
 
     oEmit.apply(this, arguments);

--- a/tests/mocha_adapter_tests.js
+++ b/tests/mocha_adapter_tests.js
@@ -402,8 +402,21 @@ describe('mochaAdapter', function() {
         expect(originalEmit).to.have.been.calledWith(evt, test, err);
       });
 
-      it('should not emit a "test-result" event', function() {
-        expect(_emit).not.to.have.been.called();
+      it('should emit a "test-result" event', function() {
+        expect(_emit).to.have.been.calledWith('test-result', {
+          failed: 1,
+          id: 1,
+          items: [{
+            passed: false,
+            message: 'The error message',
+            stack: 'The stack trace'
+          }],
+          name: 'foo ',
+          passed: 0,
+          pending: 0,
+          runDuration: 123,
+          total: 1
+        });
       });
     });
   });


### PR DESCRIPTION
Reverts testem/testem#1165

This is causing issues with mocha@2 https://github.com/testem/testem/pull/1165#issuecomment-321833639 