### PR TITLE
Improve the output of the dot reporter

### DIFF
--- a/lib/reporters/dot_reporter.js
+++ b/lib/reporters/dot_reporter.js
@@ -84,7 +84,7 @@ DotReporter.prototype = {
         printf(this.out, '\n%s', indent(error.stack, 5));
       }
 
-      this.out.write('\n');
+      this.out.write('\n\n');
     }, this);
   },
   summaryDisplay: function() {

--- a/lib/reporters/dot_reporter.js
+++ b/lib/reporters/dot_reporter.js
@@ -14,6 +14,7 @@ function DotReporter(silent, out) {
   this.results = [];
   this.startTime = new Date();
   this.endTime = null;
+  this.currentLineChars = 0;
   this.out.write('\n');
   this.out.write('  ');
 }
@@ -36,6 +37,10 @@ DotReporter.prototype = {
     if (this.silent) {
       return;
     }
+    if (this.currentLineChars > 60) {
+      this.currentLineChars = 0;
+      this.out.write('\n  ');
+    }
     if (result.passed) {
       this.out.write('.');
     } else if (result.skipped) {
@@ -43,6 +48,7 @@ DotReporter.prototype = {
     } else {
       this.out.write('F');
     }
+    this.currentLineChars += 1;
   },
   finish: function() {
     if (this.silent) {

--- a/lib/reporters/dot_reporter.js
+++ b/lib/reporters/dot_reporter.js
@@ -15,6 +15,7 @@ function DotReporter(silent, out) {
   this.startTime = new Date();
   this.endTime = null;
   this.currentLineChars = 0;
+  this.maxLineChars = Math.min(this.out.columns || 65, 65) - 5;
   this.out.write('\n');
   this.out.write('  ');
 }
@@ -37,7 +38,7 @@ DotReporter.prototype = {
     if (this.silent) {
       return;
     }
-    if (this.currentLineChars > 60) {
+    if (this.currentLineChars > this.maxLineChars) {
       this.currentLineChars = 0;
       this.out.write('\n  ');
     }

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -271,6 +271,7 @@ describe('test reporters', function() {
         assert.match(output.shift(), / {7}actual: 'Seven'/);
         output.shift();
         assert.match(output.shift(), / {5}trace/);
+        output.shift();
         assert.equal(output, '');
       });
     });


### PR DESCRIPTION
A small improvement to the output of the dot reporter. At the moment it just displays dots indefinitely which is not pleasant to see if the terminal is wide. This PR limits the output to 60 dots per line. 60 is just an arbitrary number that can be adjusted if needed. It also makes the report of failed tests more readable.

Before this PR (this could just be one straight line if the terminal is wide enough):
<img width="946" alt="before" src="https://user-images.githubusercontent.com/619917/29603259-2a49172c-87ec-11e7-9757-2c7227666b6d.png">

After this PR:
<img width="524" alt="after" src="https://user-images.githubusercontent.com/619917/29603273-37822afa-87ec-11e7-89d5-0d0e6188cf8a.png">