### PR TITLE
Fix TestemConfig always being reset to {}

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -119,7 +119,7 @@ function Message(socket, emitArgs) {
 }
 
 // eslint-disable-next-line no-use-before-define
-if (typeof TestemConfig === 'undefined' || {}) {
+if (typeof TestemConfig === 'undefined') {
   var TestemConfig = {};
 }
 


### PR DESCRIPTION
I'm not entirely sure what the original intention was here, but `typeof TestemConfig === ‘undefined’ || {}` always evaluates to true, regardless of whether TestemConfig is actually undefined.