### PR TITLE
fix(teamcity_reporter): add runDuration to finished test

### DIFF
--- a/lib/reporters/teamcity_reporter.js
+++ b/lib/reporters/teamcity_reporter.js
@@ -45,7 +45,7 @@ class TeamcityReporter {
       var stack = (result.error && result.error.stack) || '';
       this.out.write('##teamcity[testFailed name=\'' + this._namify(prefix, result) + '\' message=\'' + escape(message) + '\' details=\'' + escape(stack) + '\']\n');
     }
-    this.out.write('##teamcity[testFinished name=\'' + this._namify(prefix, result) + '\']\n');
+    this.out.write('##teamcity[testFinished name=\'' + this._namify(prefix, result) + '\'' + this._runDurationAttribute(result) + ']\n');
 
   }
 
@@ -57,6 +57,10 @@ class TeamcityReporter {
 
   _duration() {
     return Math.round((this.endTime - this.startTime));
+  }
+
+  _runDurationAttribute(result) {
+    return typeof result.runDuration === 'number' ? ' duration=\'' + result.runDuration + '\'' : '';
   }
 }
 

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -474,7 +474,8 @@ describe('test reporters', function() {
       var reporter = new TeamcityReporter(false, stream);
       reporter.report('phantomjs', {
         name: 'it does <cool> "cool" \'cool\' stuff',
-        passed: true
+        passed: true,
+        runDuration: 1234
       });
       reporter.report('phantomjs', {
         name: 'it skips stuff',
@@ -496,7 +497,8 @@ describe('test reporters', function() {
         passed: false,
         skipped: undefined,
         error: undefined,
-        pending: undefined
+        pending: undefined,
+        runDuration: 42
       });
 
       reporter.finish();
@@ -504,7 +506,7 @@ describe('test reporters', function() {
 
       assert.match(output, /##teamcity\[testSuiteFinished name='testem\.suite' duration='(\d+(\.\d+)?)'\]/);
       assert.match(output, /##teamcity\[testStarted name='phantomjs - it does <cool> "cool" \|'cool\|' stuff']/);
-      assert.match(output, /##teamcity\[testFinished name='phantomjs - it does <cool> "cool" \|'cool\|' stuff']/);
+      assert.match(output, /##teamcity\[testFinished name='phantomjs - it does <cool> "cool" \|'cool\|' stuff' duration='1234']/);
       assert.match(output, /##teamcity\[testStarted name='phantomjs - it skips stuff']/);
       assert.match(output, /##teamcity\[testIgnored name='phantomjs - it skips stuff' message='pending']/);
       assert.match(output, /##teamcity\[testFinished name='phantomjs - it skips stuff']/);
@@ -513,7 +515,7 @@ describe('test reporters', function() {
       assert.match(output, /##teamcity\[testFinished name='phantomjs - it handles failures']/);
       assert.match(output, /##teamcity\[testStarted name='phantomjs - it handles undefined errors']/);
       assert.match(output, /##teamcity\[testFailed name='phantomjs - it handles undefined errors' message='' details='']/);
-      assert.match(output, /##teamcity\[testFinished name='phantomjs - it handles undefined errors']/);
+      assert.match(output, /##teamcity\[testFinished name='phantomjs - it handles undefined errors' duration='42']/);
     });
   });
 });


### PR DESCRIPTION
The commit adds the `duration` attribute to each finished test. This results in any teamcity reader being able to display each tests run duration:

![20171023-121023](https://user-images.githubusercontent.com/1205444/31884060-3b6f7f16-b7ec-11e7-8107-0231d498b9e5.png)

fixes #1186

I'm unsure if we should fall back to a `0` duration or remove the duration attribute if no runDuration is provided.
