### PR TITLE
Make the progress indicator useful for QUnit

### DIFF
--- a/public/testem/qunit_adapter.js
+++ b/public/testem/qunit_adapter.js
@@ -28,6 +28,7 @@ function qunitAdapter() {
     tests: []
   };
   var currentTest;
+  var supportsTotalToRun = false;
   var id = 1;
 
   function lineNumber(e) {
@@ -49,6 +50,15 @@ function qunitAdapter() {
     }
     return undefined;
   }
+
+  QUnit.begin(function(data) {
+    if ('totalToRun' in data) {
+      // Older versions of QUnit do not have this:
+      // https://github.com/qunitjs/qunit/pull/1256
+      results.total = data.totalToRun;
+      supportsTotalToRun = true;
+    }
+  });
 
   QUnit.log(function(params, e) {
     if (e) {
@@ -90,10 +100,12 @@ function qunitAdapter() {
     currentTest.failed = params.failed;
     currentTest.passed = params.passed;
     currentTest.skipped = params.skipped;
-    currentTest.total = params.total;
     currentTest.runDuration = params.runtime;
 
-    results.total++;
+    if (!supportsTotalToRun) {
+      results.total++;
+      currentTest.total = params.total;
+    }
 
     if (currentTest.skipped) {
       results.skipped++;


### PR DESCRIPTION
Test output will not contain:

```
numberOfTestsThatHaveRun/numberOfTestsThatShouldRun
```

instead of

```
numberOfTestsThatHaveRun/numberOfTestsThatHaveRun
```

----

notes:
* Depends on: https://github.com/qunitjs/qunit/pull/1256
* Has the current behavior as a fallback