### PR TITLE
Allowing testem.js file to provide cwd, config_dir etc without being overridden by other options like program options.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -53,6 +53,7 @@ function Api() {}
 Api.prototype.setup = function(mode, finalizer) {
   var self = this;
   this.config = new Config(mode, this.options);
+  this.config.setDefaultOptions(this.defaultOptions);
   this.configureLogging();
   log.info('Test\'em starting..');
   this.config.read(function() {
@@ -88,7 +89,9 @@ Api.prototype.startCI = function(options, finalizer) {
 
 Api.prototype.startServer = function(options) {
   this.options = options;
-  var config = this.config = new Config('server', this.options);
+  this.config = new Config('server', this.options);
+  this.config.setDefaultOptions(this.defaultOptions);
+  var config = this.config;
   config.read(function() {
     var server = new Server(config);
     server.start();
@@ -96,6 +99,10 @@ Api.prototype.startServer = function(options) {
       console.log('Open ' + config.get('url') + ' in a browser to connect.');
     });
   });
+};
+
+Api.prototype.setDefaultOptions = function(defaultOptions) {
+  this.defaultOptions = defaultOptions;
 };
 
 module.exports = Api;

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,6 +34,7 @@ var globAsync = Bluebird.promisify(glob);
 function Config(appMode, progOptions, config) {
   this.appMode = appMode;
   this.progOptions = progOptions || {};
+  this.defaultOptions = {};
   this.fileOptions = {};
   this.config = config || {};
   this.getters = {
@@ -54,6 +55,10 @@ function Config(appMode, progOptions, config) {
     this.progOptions.single_run = true;
   }
 }
+
+Config.prototype.setDefaultOptions = function(defaultOptions) {
+  this.defaultOptions = defaultOptions;
+};
 
 Config.prototype.read = function(callback) {
   var configFile = this.progOptions.file;
@@ -102,6 +107,8 @@ Config.prototype.client = function() {
 Config.prototype.resolveConfigPath = function(filepath) {
   if (this.progOptions.config_dir) {
     return path.resolve(this.progOptions.config_dir, filepath);
+  } else if (this.defaultOptions && this.defaultOptions.config_dir) {
+    return path.resolve(this.defaultOptions.config_dir, filepath);
   } else {
     return this.resolvePath(filepath);
   }
@@ -235,6 +242,9 @@ Config.prototype.getConfigProperty = function(key) {
   }
   if (key in this.fileOptions && typeof this.fileOptions[key] !== 'undefined') {
     return this.fileOptions[key];
+  }
+  if (this.defaultOptions && key in this.defaultOptions && typeof this.defaultOptions[key] !== 'undefined') {
+    return this.defaultOptions[key];
   }
   if (key in this.defaults) {
     var defaultVal = this.defaults[key];

--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -43,6 +43,56 @@ describe('Api', function() {
     });
   });
 
+  describe('defaultOptions', function() {
+    it('set in testem when using dev mode', function() {
+      var api = new Api();
+      var options = {
+        host: 'localhost',
+        port: 7337,
+        config_dir: process.cwd(),
+        test_page: 'http://my/test/page'
+      };
+
+      api.setDefaultOptions(options);
+      api.startDev({parallel: 5, on_exit: 'test'});
+      expect(api.config.read.callCount).to.equal(1);
+      expect(api.config.defaultOptions).to.equals(options);
+    });
+
+    it('set in testem when using CI mode', function() {
+      var api = new Api();
+      var options = {
+        host: 'localhost',
+        port: 7337,
+        config_dir: process.cwd(),
+        test_page: 'http://my/test/page'
+      };
+      api.setDefaultOptions(options);
+      api.startCI({parallel: 5, on_exit: 'test'});
+      expect(api.config.read.callCount).to.equal(1);
+      expect(api.config.get('host')).to.equal('localhost');
+      expect(api.config.get('port')).to.equal(7337);
+      expect(api.config.get('config_dir')).to.equal(process.cwd());
+      expect(api.config.defaultOptions).to.equals(options);
+    });
+
+    it('set in testem when startServer is called', function() {
+      var api = new Api();
+      var options = {
+        host: 'localhost',
+        port: 7337,
+        config_dir: process.cwd(),
+        test_page: 'http://my/test/page'
+      };
+      api.setDefaultOptions(options);
+      api.startServer(options);
+      expect(api.config.get('host')).to.equal('localhost');
+      expect(api.config.get('port')).to.equal(7337);
+      expect(api.config.get('config_dir')).to.equal(process.cwd());
+      expect(api.config.defaultOptions).to.equals(options);
+    });
+  });
+
   describe('restart', function() {
     // ensure pending timeouts are cancelled
     it('allows to restart the tests', function(done) {

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -39,6 +39,22 @@ describe('Config', function() {
     expect(config.get('port')).not.to.be.undefined();
   });
 
+  it('gives defaultOptions properties when got', function() {
+    var defaultOptions = {
+      host: 'localhost',
+      port: 7337,
+      config_dir: process.cwd(),
+      test_page: 'http://my/test/page',
+      file: 'defaultFile'
+    };
+    config.setDefaultOptions(defaultOptions);
+    expect(config.get('host')).to.equal('localhost');
+    expect(config.get('port')).to.equal(7337);
+    expect(config.get('config_dir')).to.equal(process.cwd());
+    // returns file from progOptions and not defaultOptions because progOptions has higher priority
+    expect(config.get('file')).to.equal(progOptions.file);
+  });
+
   describe('accepts empty config file', function() {
     var config;
     beforeEach(function(done) {

--- a/tests/ui/fake_screen.js
+++ b/tests/ui/fake_screen.js
@@ -45,7 +45,7 @@ var FakeScreen = {
   },
   write: function(str) {
     // get rid of all display codes
-    str = str.replace(/\u001b\[[0-9]+m/g, '');
+    str = str.replace(/\\x1b\[[0-9]+m/g, '');
 
     var original = buffer[line];
     if (!original) {


### PR DESCRIPTION
When ember-cli invokes testem it provides defaultOptions for testem to use as a fallback option. But currently, the fallback option from ember-cli is used as progOptions in testem. And since progOptions has higher priority than fileOptions, the cwd being set in the testem.js file is being overridden by ember-cli's fallbackOption.

Solution is to add defaultOptions as a sibling to progOptions and fileOptions in testem. And frameworks like ember-cli can set defaultOptions if needed.
