### PR TITLE
Incremental conversion of codebase to es6 classes - launcher

### DIFF
--- a/lib/launcher-factory.js
+++ b/lib/launcher-factory.js
@@ -3,17 +3,17 @@
 var Launcher = require('./launcher');
 var extend = require('lodash.assignin');
 
-function LauncherFactory(name, settings, config) {
-  this.name = name;
-  this.config = config;
-  this.settings = settings;
-}
+class LauncherFactory {
+  constructor(name, settings, config) {
+    this.name = name;
+    this.config = config;
+    this.settings = settings;
+  }
 
-LauncherFactory.prototype = {
-  create: function(options) {
+  create(options) {
     var settings = extend({}, this.settings, options);
     return new Launcher(this.name, settings, this.config);
   }
-};
+}
 
 module.exports = LauncherFactory;

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -12,62 +12,62 @@ var ProcessCtl = require('./process-ctl');
 var rimrafAsync = Bluebird.promisify(rimraf);
 var mkdirpAsync = Bluebird.promisify(mkdirp);
 
-function Launcher(name, settings, config) {
-  this.name = name;
-  this.config = config;
-  this.settings = settings;
-  this.setupDefaultSettings();
-  this.id = settings.id || String(Math.floor(Math.random() * 10000));
+class Launcher {
+  constructor(name, settings, config) {
+    this.name = name;
+    this.config = config;
+    this.settings = settings;
+    this.setupDefaultSettings();
+    this.id = settings.id || String(Math.floor(Math.random() * 10000));
 
-  this.processCtl = new ProcessCtl(name, config);
-}
+    this.processCtl = new ProcessCtl(name, config);
+  }
 
-Launcher.prototype = {
-  setupDefaultSettings: function() {
+  setupDefaultSettings() {
     var settings = this.settings;
     if (settings.protocol === 'tap' && !('hide_stdout' in settings)) {
       settings.hide_stdout = true;
     }
-  },
-  isProcess: function() {
+  }
+
+  isProcess() {
     return this.settings.protocol !== 'browser';
-  },
-  protocol: function() {
+  }
+
+  protocol() {
     return this.settings.protocol || 'process';
-  },
-  commandLine: function() {
+  }
+
+  commandLine() {
     if (this.settings.command) {
       return '"' + this.settings.command + '"';
     } else if (this.settings.exe) {
       return '"' + this.settings.exe +
         ' ' + this.getArgs().join(' ') + '"';
     }
-  },
-  start: function() {
+  }
+
+  start() {
     return this.launch();
-  },
-  launch: function() {
-    var self = this;
+  }
+
+  launch() {
     var settings = this.settings;
     var dir = this.browserTmpDir(this.config, this.id);
 
-    return rimrafAsync(dir).then(function() {
-      return mkdirpAsync(dir);
-    }).then(function() {
+    return rimrafAsync(dir).then(() => mkdirpAsync(dir)).then(() => {
       if (settings.setup) {
-        return Bluebird.fromCallback(function(setupCallback) {
-          settings.setup.call(self, self.config, setupCallback);
+        return Bluebird.fromCallback(setupCallback => {
+          settings.setup.call(this, this.config, setupCallback);
         });
       }
 
       return Bluebird.resolve();
-    }).then(function() {
-      return self.doLaunch();
-    });
-  },
-  doLaunch: function() {
+    }).then(() => this.doLaunch());
+  }
+
+  doLaunch() {
     var settings = this.settings;
-    var self = this;
     var options = {};
 
     if (settings.cwd) {
@@ -75,8 +75,8 @@ Launcher.prototype = {
     }
 
     if (settings.exe) {
-      var args = self.getArgs();
-      args = self.template(args);
+      var args = this.getArgs();
+      args = this.template(args);
 
       return this.processCtl.spawn(settings.exe, args, options);
     } else if (settings.command) {
@@ -87,18 +87,21 @@ Launcher.prototype = {
     } else {
       return Bluebird.reject(new Error('No command or exe/args specified for launcher ' + this.name));
     }
-  },
-  getId: function() {
+  }
+
+  getId() {
     return this.isProcess() ? -1 : this.id;
-  },
-  getUrl: function() {
+  }
+
+  getUrl() {
     var baseUrl = this.config.get('url');
     var testPage = this.settings.test_page;
     var id = this.getId();
 
     return baseUrl + id + (testPage ? '/' + testPage : '');
-  },
-  getArgs: function() {
+  }
+
+  getArgs() {
     var settings = this.settings;
     var url = this.getUrl();
     var args = [url];
@@ -108,8 +111,9 @@ Launcher.prototype = {
       args = settings.args.call(this, this.config, url);
     }
     return args;
-  },
-  template: function(thing) {
+  }
+
+  template(thing) {
     if (Array.isArray(thing)) {
       return thing.map(this.template, this);
     } else {
@@ -123,12 +127,13 @@ Launcher.prototype = {
       };
       return template(thing, params);
     }
-  },
-  browserTmpDir: function() {
+  }
+
+  browserTmpDir() {
     var userDataDir = this.config.getUserDataDir();
 
     return path.join(userDataDir, 'testem-' + this.id);
   }
-};
+}
 
 module.exports = Launcher;


### PR DESCRIPTION
Currently the codebase is largely utilizing es5 objects w/prototypical inheritance. This PR starts the conversion to es6 classes to help improve code cleanliness and readability.

Converts launcher-factory.js and launcher.js.