### PR TITLE
Incremental conversion of codebase to es6 classes - reporters

### DIFF
--- a/lib/reporters/dot_reporter.js
+++ b/lib/reporters/dot_reporter.js
@@ -3,24 +3,25 @@
 var indent = require('../strutils').indent;
 var printf = require('printf');
 
-function DotReporter(silent, out) {
-  this.out = out || process.stdout;
-  this.silent = silent;
-  this.stoppedOnError = null;
-  this.id = 1;
-  this.total = 0;
-  this.pass = 0;
-  this.skipped = 0;
-  this.results = [];
-  this.startTime = new Date();
-  this.endTime = null;
-  this.currentLineChars = 0;
-  this.maxLineChars = Math.min(this.out.columns || 65, 65) - 5;
-  this.out.write('\n');
-  this.out.write('  ');
-}
-DotReporter.prototype = {
-  report: function(prefix, data) {
+class DotReporter {
+  constructor(silent, out) {
+    this.out = out || process.stdout;
+    this.silent = silent;
+    this.stoppedOnError = null;
+    this.id = 1;
+    this.total = 0;
+    this.pass = 0;
+    this.skipped = 0;
+    this.results = [];
+    this.startTime = new Date();
+    this.endTime = null;
+    this.currentLineChars = 0;
+    this.maxLineChars = Math.min(this.out.columns || 65, 65) - 5;
+    this.out.write('\n');
+    this.out.write('  ');
+  }
+
+  report(prefix, data) {
     this.results.push({
       launcher: prefix,
       result: data
@@ -32,9 +33,9 @@ DotReporter.prototype = {
     } else if (data.passed) {
       this.pass++;
     }
-  },
+  }
 
-  display: function(prefix, result) {
+  display(prefix, result) {
     if (this.silent) {
       return;
     }
@@ -50,8 +51,9 @@ DotReporter.prototype = {
       this.out.write('F');
     }
     this.currentLineChars += 1;
-  },
-  finish: function() {
+  }
+
+  finish() {
     if (this.silent) {
       return;
     }
@@ -60,8 +62,9 @@ DotReporter.prototype = {
     this.out.write(this.summaryDisplay());
     this.out.write('\n\n');
     this.displayErrors();
-  },
-  displayErrors: function() {
+  }
+
+  displayErrors() {
     this.results.forEach(function(data, idx) {
       var result = data.result;
       var error = result.error;
@@ -87,13 +90,15 @@ DotReporter.prototype = {
 
       this.out.write('\n\n');
     }, this);
-  },
-  summaryDisplay: function() {
+  }
+
+  summaryDisplay() {
     return printf('  %d tests complete (%d ms)', this.total, this.duration());
-  },
-  duration: function() {
+  }
+
+  duration() {
     return Math.round((this.endTime - this.startTime));
   }
-};
+}
 
 module.exports = DotReporter;

--- a/lib/reporters/tap_reporter.js
+++ b/lib/reporters/tap_reporter.js
@@ -2,21 +2,22 @@
 
 var displayutils = require('../displayutils');
 
-function TapReporter(silent, out, config) {
-  this.out = out || process.stdout;
-  this.silent = silent;
-  this.quietLogs = !!config.get('tap_quiet_logs');
-  this.stoppedOnError = null;
-  this.id = 1;
-  this.total = 0;
-  this.pass = 0;
-  this.skipped = 0;
-  this.results = [];
-  this.errors = [];
-  this.logs = [];
-}
-TapReporter.prototype = {
-  report: function(prefix, data) {
+class TapReporter {
+  constructor(silent, out, config) {
+    this.out = out || process.stdout;
+    this.silent = silent;
+    this.quietLogs = !!config.get('tap_quiet_logs');
+    this.stoppedOnError = null;
+    this.id = 1;
+    this.total = 0;
+    this.pass = 0;
+    this.skipped = 0;
+    this.results = [];
+    this.errors = [];
+    this.logs = [];
+  }
+
+  report(prefix, data) {
     this.results.push({
       launcher: prefix,
       result: data
@@ -28,8 +29,9 @@ TapReporter.prototype = {
     } else if (data.passed) {
       this.pass++;
     }
-  },
-  summaryDisplay: function() {
+  }
+
+  summaryDisplay() {
     var lines = [
       '1..' + this.total,
       '# tests ' + this.total,
@@ -43,19 +45,21 @@ TapReporter.prototype = {
       lines.push('# ok');
     }
     return lines.join('\n');
-  },
-  display: function(prefix, result) {
+  }
+
+  display(prefix, result) {
     if (this.silent) {
       return;
     }
     this.out.write(displayutils.resultString(this.id++, prefix, result, this.quietLogs));
-  },
-  finish: function() {
+  }
+
+  finish() {
     if (this.silent) {
       return;
     }
     this.out.write('\n' + this.summaryDisplay() + '\n');
   }
-};
+}
 
 module.exports = TapReporter;

--- a/lib/reporters/teamcity_reporter.js
+++ b/lib/reporters/teamcity_reporter.js
@@ -1,18 +1,19 @@
 'use strict';
 
-function TeamcityReporter(silent, out) {
-  this.out = out || process.stdout;
-  this.silent = silent;
-  this.stoppedOnError = null;
-  this.id = 1;
-  this.total = 0;
-  this.pass = 0;
-  this.skipped = 0;
-  this.startTime = new Date();
-  this.endTime = null;
-}
-TeamcityReporter.prototype = {
-  report: function(prefix, data) {
+class TeamcityReporter {
+  constructor(silent, out) {
+    this.out = out || process.stdout;
+    this.silent = silent;
+    this.stoppedOnError = null;
+    this.id = 1;
+    this.total = 0;
+    this.pass = 0;
+    this.skipped = 0;
+    this.startTime = new Date();
+    this.endTime = null;
+  }
+
+  report(prefix, data) {
     this.out.write('##teamcity[testStarted name=\'' + this._namify(prefix, data) + '\']\n');
     this._display(prefix, data);
     this.total++;
@@ -21,8 +22,9 @@ TeamcityReporter.prototype = {
     } else if (data.passed) {
       this.pass++;
     }
-  },
-  finish: function() {
+  }
+
+  finish() {
     if (this.silent) {
       return;
     }
@@ -30,8 +32,9 @@ TeamcityReporter.prototype = {
     this.out.write('\n\n');
     this.out.write('##teamcity[testSuiteFinished name=\'testem.suite\' duration=\'' + this._duration() + '\']\n');
     this.out.write('\n\n');
-  },
-  _display: function(prefix, result) {
+  }
+
+  _display(prefix, result) {
     if (this.silent) {
       return;
     }
@@ -44,16 +47,18 @@ TeamcityReporter.prototype = {
     }
     this.out.write('##teamcity[testFinished name=\'' + this._namify(prefix, result) + '\']\n');
 
-  },
-  _namify: function(prefix, result) {
+  }
+
+  _namify(prefix, result) {
     var line = (prefix ? (prefix + ' - ') : '') +
       result.name.trim();
     return escape(line);
-  },
-  _duration: function() {
+  }
+
+  _duration() {
     return Math.round((this.endTime - this.startTime));
   }
-};
+}
 
 /**
  * Borrowed from https://github.com/travisjeffery/mocha-teamcity-reporter

--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -2,21 +2,22 @@
 
 var XmlDom = require('xmldom');
 
-function XUnitReporter(silent, out, config) {
-  this.out = out || process.stdout;
-  this.excludeStackTraces = config.get('xunit_exclude_stack');
-  this.silent = silent;
-  this.stoppedOnError = null;
-  this.id = 1;
-  this.total = 0;
-  this.pass = 0;
-  this.skipped = 0;
-  this.results = [];
-  this.startTime = new Date();
-  this.endTime = null;
-}
-XUnitReporter.prototype = {
-  report: function(prefix, data) {
+class XUnitReporter {
+  constructor(silent, out, config) {
+    this.out = out || process.stdout;
+    this.excludeStackTraces = config.get('xunit_exclude_stack');
+    this.silent = silent;
+    this.stoppedOnError = null;
+    this.id = 1;
+    this.total = 0;
+    this.pass = 0;
+    this.skipped = 0;
+    this.results = [];
+    this.startTime = new Date();
+    this.endTime = null;
+  }
+
+  report(prefix, data) {
     this.results.push({
       launcher: prefix,
       result: data
@@ -28,16 +29,18 @@ XUnitReporter.prototype = {
     } else if (data.passed) {
       this.pass++;
     }
-  },
-  finish: function() {
+  }
+
+  finish() {
     if (this.silent) {
       return;
     }
     this.endTime = new Date();
     this.out.write(this.summaryDisplay());
     this.out.write('\n');
-  },
-  summaryDisplay: function() {
+  }
+
+  summaryDisplay() {
     var doc = new XmlDom.DOMImplementation().createDocument('', 'testsuite');
 
     var rootNode = doc.documentElement;
@@ -53,13 +56,15 @@ XUnitReporter.prototype = {
       rootNode.appendChild(testcaseNode);
     }
     return doc.documentElement.toString();
-  },
-  display: function() {
+  }
+
+  display() {
     // As the output is XML, the XUnitReporter can only write its results after all
     // tests have finished.
     return;
-  },
-  getTestResultNode: function(document, result) {
+  }
+
+  getTestResultNode(document, result) {
     var launcher = result.launcher;
     result = result.result;
 
@@ -86,14 +91,17 @@ XUnitReporter.prototype = {
     }
 
     return resultNode;
-  },
-  failures: function() {
+  }
+
+  failures() {
     return this.total - this.pass - this.skipped;
-  },
-  duration: function() {
+  }
+
+  duration() {
     return this._durationFromMs(this.endTime - this.startTime);
-  },
-  _durationFromMs: function(ms) {
+  }
+
+  _durationFromMs(ms) {
     if (ms)
     {
       return (ms / 1000).toFixed(3);
@@ -102,6 +110,6 @@ XUnitReporter.prototype = {
       return 0;
     }
   }
-};
+}
 
 module.exports = XUnitReporter;

--- a/tests/utils/reporter_tests.js
+++ b/tests/utils/reporter_tests.js
@@ -181,10 +181,8 @@ describe('Reporter', function() {
     });
 
     it('creates a reporter when custom reporter dependent on configs is provided', function() {
-      var CustomReporter = function() {
-        TapReporter.apply(this, arguments);
-      };
-      CustomReporter.prototype = Object.create(TapReporter.prototype);
+      class CustomReporter extends TapReporter {
+      }
 
       var config = { get: sinon.stub() };
       config.get.withArgs('reporter').returns(CustomReporter);


### PR DESCRIPTION
Currently the codebase is largely utilizing es5 objects w/prototypical inheritance. This PR starts the conversion to es6 classes to help improve code cleanliness and readability.

Converts
- dot_reporter.js
- tap_reporter.js
- teamcity_reporter.js
- xunit_reporter.js