### PR TITLE
Allow custom binary path for all supported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,18 @@ This will display something like the following
 
 This displays the current list of launchers that are available. Launchers can launch either a browser or a custom process &mdash; as shown in the "Type" column. Custom launchers can be defined to launch custom processes. The "CI" column indicates the launchers which will be automatically launched in CI-mode. Similarly, the "Dev" column lists those that will automatically launch in dev-mode.
 
+Customizing Browser Paths
+-----------------------------
+You can add your own custom paths to browser binaries by including the `browser_paths` option in your Testem configuration. For example:
+
+```javascript
+"browser_paths": {
+  "Chromium": "./node_modules/puppeteer/.local-chromium/mac-549031/chrome-mac/Chromium.app/Contents/MacOS/Chromium"
+}
+```
+
+Adding a browser_path for a browser will override all default places for testem to look for the browser. So if the browser doesn't exist at the path you provided, you will get failures.
+
 Customizing Browser Arguments
 -----------------------------
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -68,6 +68,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
 
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
+    browser_paths:               [Object]  hash of browsers (keys) to an string of their binary paths (values)
     browser_args:                [Object]  hash of browsers (keys) to an array of their custom arguments (values) or an object with a mode and arguments
     client_decycle_depth         [Number]  number of times to recurse while decycling objects within the client (5)
     config_dir:                  [Path]    directory to use as root for resolving configs, if different than cwd

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -217,6 +217,17 @@ function knownBrowsers(platform, config) {
     });
   }
 
+  // Add config defined 'path' for binary to browser objects
+  var browserPaths = config.get('browser_paths');
+  if(browserPaths){
+    browsers.forEach(function(browserObject){
+      var browserPath = browserPaths[browserObject.name];
+      if (browserPath) {
+        browserObject.possiblePath = browserPath;
+      }
+    });
+  }
+
   return browserArgs.addCustomArgs(browsers, config);
 }
 

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -219,8 +219,8 @@ function knownBrowsers(platform, config) {
 
   // Add config defined 'path' for binary to browser objects
   var browserPaths = config.get('browser_paths');
-  if(browserPaths){
-    browsers.forEach(function(browserObject){
+  if (browserPaths) {
+    browsers.forEach(function(browserObject) {
       var browserPath = browserPaths[browserObject.name];
       if (browserPath) {
         browserObject.possiblePath = browserPath;

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -122,6 +122,24 @@ describe('knownBrowsers', function() {
         });
       });
 
+      it('a custom browser path for firefox is listed as the possiblePath', function(){
+        var customPath = '/my/custom/path/to/firefox';
+
+        config.get = function(name) {
+          if (name === 'browser_paths') {
+            return {
+              Firefox: customPath
+            }
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        firefox = findBrowser(browsers, 'Firefox');
+
+        expect(firefox.possiblePath).to.be.a('string');
+        expect(firefox.possiblePath).to.equal(customPath);
+      });
+
       describe('browser_args', function() {
         beforeEach(function() {
           setup('Firefox');
@@ -184,6 +202,24 @@ describe('knownBrowsers', function() {
           process.env.HOME + '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
           '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
         ]);
+      });
+
+      it('a custom browser path for chrome is listed as the possiblePath', function(){
+        var customPath = '/my/custom/path/to/chrome';
+
+        config.get = function(name) {
+          if (name === 'browser_paths') {
+            return {
+              Chrome: customPath
+            }
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        chrome = findBrowser(browsers, 'Chrome');
+
+        expect(chrome.possiblePath).to.be.a('string');
+        expect(chrome.possiblePath).to.equal(customPath);
       });
 
       describe('browser_args', function() {
@@ -250,6 +286,24 @@ describe('knownBrowsers', function() {
         });
       });
 
+      it('a custom browser path for safari is listed as the possiblePath', function(){
+        var customPath = '/my/custom/path/to/safari';
+
+        config.get = function(name) {
+          if (name === 'browser_paths') {
+            return {
+              Safari: customPath
+            }
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        safari = findBrowser(browsers, 'Safari');
+
+        expect(safari.possiblePath).to.be.a('string');
+        expect(safari.possiblePath).to.equal(customPath);
+      });
+
       describe('browser_args', function() {
         beforeEach(function() {
           setup('Safari');
@@ -306,6 +360,24 @@ describe('knownBrowsers', function() {
         });
       });
 
+      it('a custom browser path for Safari Technology Preview is listed as the possiblePath', function(){
+        var customPath = '/my/custom/path/to/safari-technology-preview';
+
+        config.get = function(name) {
+          if (name === 'browser_paths') {
+            return {
+              "Safari Technology Preview": customPath
+            }
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        safariTP = findBrowser(browsers, 'Safari Technology Preview');
+
+        expect(safariTP.possiblePath).to.be.a('string');
+        expect(safariTP.possiblePath).to.equal(customPath);
+      });
+
       describe('browser_args', function() {
         beforeEach(function() {
           setup('Safari Technology Preview');
@@ -350,6 +422,24 @@ describe('knownBrowsers', function() {
         expect(opera.args.call(launcher, config, url)).to.deep.eq([
           '--user-data-dir=' + browserTmpDir, '-pd', browserTmpDir, url
         ]);
+      });
+
+      it('a custom browser path for opera is listed as the possiblePath', function(){
+        var customPath = '/my/custom/path/to/opera';
+
+        config.get = function(name) {
+          if (name === 'browser_paths') {
+            return {
+              Opera: customPath
+            }
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        opera = findBrowser(browsers, 'Opera');
+
+        expect(opera.possiblePath).to.be.a('string');
+        expect(opera.possiblePath).to.equal(customPath);
       });
 
       describe('browser_args', function() {
@@ -425,6 +515,24 @@ describe('knownBrowsers', function() {
         expect(phantomJS.args.call(launcher, config, url)).to.deep.eq([
           'arg1', 'arg2', scriptPath, url
         ]);
+      });
+
+      it('a custom browser path for phantomjs is listed as the possiblePath', function(){
+        var customPath = '/my/custom/path/to/phantomjs';
+
+        config.get = function(name) {
+          if (name === 'browser_paths') {
+            return {
+              PhantomJS: customPath
+            }
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        phantomJS = findBrowser(browsers, 'PhantomJS');
+
+        expect(phantomJS.possiblePath).to.be.a('string');
+        expect(phantomJS.possiblePath).to.equal(customPath);
       });
 
       describe('browser_args', function() {
@@ -518,6 +626,24 @@ describe('knownBrowsers', function() {
 
       it('exists', function() {
         expect(internetExplorer).to.exist();
+      });
+
+      it('a custom browser path for IE is listed as the possiblePath', function(){
+        var customPath = 'c:\\my\\custom\\path\\to\\IE';
+
+        config.get = function(name) {
+          if (name === 'browser_paths') {
+            return {
+              IE: customPath
+            }
+          }
+        };
+
+        browsers = knownBrowsers('win32', config);
+        internetExplorer = findBrowser(browsers, 'IE');
+
+        expect(internetExplorer.possiblePath).to.be.a('string');
+        expect(internetExplorer.possiblePath).to.equal(customPath);
       });
 
       describe('browser_args', function() {

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -122,7 +122,7 @@ describe('knownBrowsers', function() {
         });
       });
 
-      it('a custom browser path for firefox is listed as the possiblePath', function(){
+      it('allows a custom path to be used as the possiblePath for firefox ', function(){
         var customPath = '/my/custom/path/to/firefox';
 
         config.get = function(name) {
@@ -204,7 +204,7 @@ describe('knownBrowsers', function() {
         ]);
       });
 
-      it('a custom browser path for chrome is listed as the possiblePath', function(){
+      it('allows a custom path to be used as the possiblePath for chrome ', function(){
         var customPath = '/my/custom/path/to/chrome';
 
         config.get = function(name) {
@@ -286,7 +286,7 @@ describe('knownBrowsers', function() {
         });
       });
 
-      it('a custom browser path for safari is listed as the possiblePath', function(){
+      it('allows a custom path to be used as the possiblePath for safari ', function(){
         var customPath = '/my/custom/path/to/safari';
 
         config.get = function(name) {
@@ -360,7 +360,7 @@ describe('knownBrowsers', function() {
         });
       });
 
-      it('a custom browser path for Safari Technology Preview is listed as the possiblePath', function(){
+      it('allows a custom path to be used as the possiblePath for Safari Technology Preview ', function(){
         var customPath = '/my/custom/path/to/safari-technology-preview';
 
         config.get = function(name) {
@@ -424,7 +424,7 @@ describe('knownBrowsers', function() {
         ]);
       });
 
-      it('a custom browser path for opera is listed as the possiblePath', function(){
+      it('allows a custom path to be used as the possiblePath for opera ', function(){
         var customPath = '/my/custom/path/to/opera';
 
         config.get = function(name) {
@@ -517,7 +517,7 @@ describe('knownBrowsers', function() {
         ]);
       });
 
-      it('a custom browser path for phantomjs is listed as the possiblePath', function(){
+      it('allows a custom path to be used as the possiblePath for phantomjs ', function(){
         var customPath = '/my/custom/path/to/phantomjs';
 
         config.get = function(name) {
@@ -628,7 +628,7 @@ describe('knownBrowsers', function() {
         expect(internetExplorer).to.exist();
       });
 
-      it('a custom browser path for IE is listed as the possiblePath', function(){
+      it('allows a custom path to be used as the possiblePath for IE ', function(){
         var customPath = 'c:\\my\\custom\\path\\to\\IE';
 
         config.get = function(name) {

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -122,14 +122,14 @@ describe('knownBrowsers', function() {
         });
       });
 
-      it('allows a custom path to be used as the possiblePath for firefox ', function(){
+      it('allows a custom path to be used as the possiblePath for firefox ', function() {
         var customPath = '/my/custom/path/to/firefox';
 
         config.get = function(name) {
           if (name === 'browser_paths') {
             return {
               Firefox: customPath
-            }
+            };
           }
         };
 
@@ -204,14 +204,14 @@ describe('knownBrowsers', function() {
         ]);
       });
 
-      it('allows a custom path to be used as the possiblePath for chrome ', function(){
+      it('allows a custom path to be used as the possiblePath for chrome ', function() {
         var customPath = '/my/custom/path/to/chrome';
 
         config.get = function(name) {
           if (name === 'browser_paths') {
             return {
               Chrome: customPath
-            }
+            };
           }
         };
 
@@ -286,14 +286,14 @@ describe('knownBrowsers', function() {
         });
       });
 
-      it('allows a custom path to be used as the possiblePath for safari ', function(){
+      it('allows a custom path to be used as the possiblePath for safari ', function() {
         var customPath = '/my/custom/path/to/safari';
 
         config.get = function(name) {
           if (name === 'browser_paths') {
             return {
               Safari: customPath
-            }
+            };
           }
         };
 
@@ -360,14 +360,14 @@ describe('knownBrowsers', function() {
         });
       });
 
-      it('allows a custom path to be used as the possiblePath for Safari Technology Preview ', function(){
+      it('allows a custom path to be used as the possiblePath for Safari Technology Preview ', function() {
         var customPath = '/my/custom/path/to/safari-technology-preview';
 
         config.get = function(name) {
           if (name === 'browser_paths') {
             return {
-              "Safari Technology Preview": customPath
-            }
+              'Safari Technology Preview': customPath
+            };
           }
         };
 
@@ -424,14 +424,14 @@ describe('knownBrowsers', function() {
         ]);
       });
 
-      it('allows a custom path to be used as the possiblePath for opera ', function(){
+      it('allows a custom path to be used as the possiblePath for opera ', function() {
         var customPath = '/my/custom/path/to/opera';
 
         config.get = function(name) {
           if (name === 'browser_paths') {
             return {
               Opera: customPath
-            }
+            };
           }
         };
 
@@ -517,14 +517,14 @@ describe('knownBrowsers', function() {
         ]);
       });
 
-      it('allows a custom path to be used as the possiblePath for phantomjs ', function(){
+      it('allows a custom path to be used as the possiblePath for phantomjs ', function() {
         var customPath = '/my/custom/path/to/phantomjs';
 
         config.get = function(name) {
           if (name === 'browser_paths') {
             return {
               PhantomJS: customPath
-            }
+            };
           }
         };
 
@@ -628,14 +628,14 @@ describe('knownBrowsers', function() {
         expect(internetExplorer).to.exist();
       });
 
-      it('allows a custom path to be used as the possiblePath for IE ', function(){
+      it('allows a custom path to be used as the possiblePath for IE ', function() {
         var customPath = 'c:\\my\\custom\\path\\to\\IE';
 
         config.get = function(name) {
           if (name === 'browser_paths') {
             return {
               IE: customPath
-            }
+            };
           }
         };
 


### PR DESCRIPTION
This PR adds support for customizing the path and binary name for all supported browsers.

I have located the path key `browser_paths` at the top level config object.
```javascript
"browser_paths": {
  "Chromium": "my/local/path/Chromium"
}
```

This PR replaces https://github.com/testem/testem/pull/1243 and addresses https://github.com/testem/testem/issues/1241