### PR TITLE
Added support for browser_exes

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,11 +342,14 @@ This displays the current list of launchers that are available. Launchers can la
 
 Customizing Browser Paths
 -----------------------------
-You can add your own custom paths to browser binaries by including the `browser_paths` option in your Testem configuration. For example:
+You can add your own custom paths to browser binaries by including `browser_paths` and/or `browser_exes` options in your Testem configuration. For example:
 
 ```javascript
 "browser_paths": {
   "Chromium": "./node_modules/puppeteer/.local-chromium/mac-549031/chrome-mac/Chromium.app/Contents/MacOS/Chromium"
+}
+"browser_exes": {
+  "Chromium": "chrome-custom-binary"
 }
 ```
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -69,6 +69,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
     browser_paths:               [Object]  hash of browsers (keys) to an string of their binary paths (values)
+    browser_exes:                [Object]  hash of browsers (keys) to an string of their binary names (values)
     browser_args:                [Object]  hash of browsers (keys) to an array of their custom arguments (values) or an object with a mode and arguments
     client_decycle_depth         [Number]  number of times to recurse while decycling objects within the client (5)
     config_dir:                  [Path]    directory to use as root for resolving configs, if different than cwd

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -87,7 +87,8 @@ function knownBrowsers(platform, config) {
       possiblePath: chromeWinPaths(userHomeDir, 'Chrome').concat(chromeOSXPaths('Google Chrome')),
       possibleExe: [
         'google-chrome',
-        'google-chrome-stable'
+        'google-chrome-stable',
+        'chrome'
       ],
       args: function(config, url) {
         return chromeArgs(this.browserTmpDir(), url);

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -223,8 +223,8 @@ function knownBrowsers(platform, config) {
   var browserExes = config.get('browser_exes');  // Add config defined 'exe' for binary
   if (browserPaths || browserExes) {
     browsers.forEach(function(browserObject) {
-      var browserPath = browserPaths[browserObject.name];
-      var browserExe = browserExes[browserObject.name];
+      var browserPath = browserPaths ? browserPaths[browserObject.name] : undefined;
+      var browserExe = browserExes ? browserExes[browserObject.name] : undefined;
       if (browserPath) {
         browserObject.possiblePath = browserPath;
       }

--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -218,13 +218,18 @@ function knownBrowsers(platform, config) {
     });
   }
 
-  // Add config defined 'path' for binary to browser objects
-  var browserPaths = config.get('browser_paths');
-  if (browserPaths) {
+  // Add user-defined configs to browser objects
+  var browserPaths = config.get('browser_paths'); // Add config defined 'path' for binary
+  var browserExes = config.get('browser_exes');  // Add config defined 'exe' for binary
+  if (browserPaths || browserExes) {
     browsers.forEach(function(browserObject) {
       var browserPath = browserPaths[browserObject.name];
+      var browserExe = browserExes[browserObject.name];
       if (browserPath) {
         browserObject.possiblePath = browserPath;
+      }
+      if (browserExe) {
+        browserObject.possibleExe = browserExe;
       }
     });
   }

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -140,6 +140,24 @@ describe('knownBrowsers', function() {
         expect(firefox.possiblePath).to.equal(customPath);
       });
 
+      it('allows a custom exe to be used as the possibleExe for firefox ', function() {
+        var customExe = 'firefox-custom';
+
+        config.get = function(name) {
+          if (name === 'browser_exes') {
+            return {
+              Firefox: customExe
+            };
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        firefox = findBrowser(browsers, 'Firefox');
+
+        expect(firefox.possibleExe).to.be.a('string');
+        expect(firefox.possibleExe).to.equal(customExe);
+      });
+
       describe('browser_args', function() {
         beforeEach(function() {
           setup('Firefox');
@@ -220,6 +238,24 @@ describe('knownBrowsers', function() {
 
         expect(chrome.possiblePath).to.be.a('string');
         expect(chrome.possiblePath).to.equal(customPath);
+      });
+
+      it('allows a custom exe to be used as the possibleExe for chrome ', function() {
+        var customExe = 'chrome-custom';
+
+        config.get = function(name) {
+          if (name === 'browser_exes') {
+            return {
+              Chrome: customExe
+            };
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        chrome = findBrowser(browsers, 'Chrome');
+
+        expect(chrome.possibleExe).to.be.a('string');
+        expect(chrome.possibleExe).to.equal(customExe);
       });
 
       describe('browser_args', function() {
@@ -304,6 +340,24 @@ describe('knownBrowsers', function() {
         expect(safari.possiblePath).to.equal(customPath);
       });
 
+      it('allows a custom exe to be used as the possibleExe for safari ', function() {
+        var customExe = 'safari-custom';
+
+        config.get = function(name) {
+          if (name === 'browser_exes') {
+            return {
+              Safari: customExe
+            };
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        safari = findBrowser(browsers, 'Safari');
+
+        expect(safari.possibleExe).to.be.a('string');
+        expect(safari.possibleExe).to.equal(customExe);
+      });
+
       describe('browser_args', function() {
         beforeEach(function() {
           setup('Safari');
@@ -378,6 +432,24 @@ describe('knownBrowsers', function() {
         expect(safariTP.possiblePath).to.equal(customPath);
       });
 
+      it('allows a custom exe to be used as the possibleExe for Safari Technology Preview ', function() {
+        var customExe = 'safari-technology-preview-custom';
+
+        config.get = function(name) {
+          if (name === 'browser_exes') {
+            return {
+              'Safari Technology Preview': customExe
+            };
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        safariTP = findBrowser(browsers, 'Safari Technology Preview');
+
+        expect(safariTP.possibleExe).to.be.a('string');
+        expect(safariTP.possibleExe).to.equal(customExe);
+      });
+
       describe('browser_args', function() {
         beforeEach(function() {
           setup('Safari Technology Preview');
@@ -440,6 +512,24 @@ describe('knownBrowsers', function() {
 
         expect(opera.possiblePath).to.be.a('string');
         expect(opera.possiblePath).to.equal(customPath);
+      });
+
+      it('allows a custom exe to be used as the possibleExe for opera ', function() {
+        var customExe = 'opera-custom';
+
+        config.get = function(name) {
+          if (name === 'browser_exes') {
+            return {
+              Opera: customExe
+            };
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        opera = findBrowser(browsers, 'Opera');
+
+        expect(opera.possibleExe).to.be.a('string');
+        expect(opera.possibleExe).to.equal(customExe);
       });
 
       describe('browser_args', function() {
@@ -533,6 +623,24 @@ describe('knownBrowsers', function() {
 
         expect(phantomJS.possiblePath).to.be.a('string');
         expect(phantomJS.possiblePath).to.equal(customPath);
+      });
+
+      it('allows a custom exe to be used as the possibleExe for phantomjs ', function() {
+        var customExe = 'phantomjs-custom';
+
+        config.get = function(name) {
+          if (name === 'browser_exes') {
+            return {
+              PhantomJS: customExe
+            };
+          }
+        };
+
+        browsers = knownBrowsers('any', config);
+        phantomJS = findBrowser(browsers, 'PhantomJS');
+
+        expect(phantomJS.possibleExe).to.be.a('string');
+        expect(phantomJS.possibleExe).to.equal(customExe);
       });
 
       describe('browser_args', function() {
@@ -644,6 +752,24 @@ describe('knownBrowsers', function() {
 
         expect(internetExplorer.possiblePath).to.be.a('string');
         expect(internetExplorer.possiblePath).to.equal(customPath);
+      });
+
+      it('allows a custom exe to be used as the possibleExe for IE ', function() {
+        var customExe = 'iexplore-custom.exe';
+
+        config.get = function(name) {
+          if (name === 'browser_exes') {
+            return {
+              IE: customExe
+            };
+          }
+        };
+
+        browsers = knownBrowsers('win32', config);
+        internetExplorer = findBrowser(browsers, 'IE');
+
+        expect(internetExplorer.possibleExe).to.be.a('string');
+        expect(internetExplorer.possibleExe).to.equal(customExe);
       });
 
       describe('browser_args', function() {


### PR DESCRIPTION
PR for my comment in https://github.com/testem/testem/issues/1241
Similar to https://github.com/testem/testem/pull/1244

This PR adds support for a `browser_exes` arg, so that you can supply a custom binary name for a browser without needing to specify a path (or in addition to specifying path)

This is useful for puppeteer installs, which installs the Chrome browser as `chrome` (rather than what testem expects, which is `google-chrome`)

And for good measure I also added `chrome` to the default possibleExe list anyway