### PR TITLE
Adding configuration to set socket heartbeat timeout

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -92,6 +92,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
     reporter:                    [String]  name of the reporter to be used in ci mode ("tap" (default), "xunit", "dot", "teamcity") or an object implementing https://github.com/testem/testem/blob/master/docs/custom_reporter.md
     report_file:                 [String]  file to write test results to (stdout)
     route or routes:             [Object]  overrides for assets paths
+    socket_heartbeat_timeout     [Number]  heartbeat timeout on browser socket in seconds (5s)
     src_files:                   [Array]   string or array list of files or file patterns to use
     src_files_ignore:            [Array]   string or array list of files or file patterns to exclude from usage
     serve_files:                 [Array]   string or array list of files or file patterns to inject into test playground (defaults to `src_files`)

--- a/lib/config.js
+++ b/lib/config.js
@@ -492,7 +492,8 @@ Config.prototype.defaults = {
   bail_on_uncaught_error: true,
   browser_start_timeout: 30,
   browser_disconnect_timeout: 10,
-  client_decycle_depth: 5
+  client_decycle_depth: 5,
+  socket_heartbeat_timeout: 5
 };
 
 module.exports = Config;

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -100,6 +100,9 @@ class BrowserTestRunner {
 
     this.onStart.call(this);
 
+    var socketHeartbeatTimeout = this.launcher.config.get('socket_heartbeat_timeout');
+    socket.server.set('heartbeat timeout', socketHeartbeatTimeout * 1000);
+
     socket.on('test-result', this.onTestResult.bind(this));
     socket.on('test-metadata', this.onTestMetadata.bind(this));
     socket.on('top-level-error', this.onGlobalError.bind(this));

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -542,6 +542,12 @@ describe('Config', function() {
     });
   });
 
+  describe('socket_heartbeat_timeout', function() {
+    it('defaults to 5 seconds', function() {
+      expect(config.get('socket_heartbeat_timeout')).to.eq(5);
+    });
+  });
+
   describe('client_decycle_depth', function() {
     it('defaults to 5', function() {
       expect(config.get('client_decycle_depth')).to.eq(5);


### PR DESCRIPTION
Adding configuration to set socket heartbeat timeout.
This gets set in browser_test_runner when the browser-login event is handled, which is when the client socket is recognized as connected.

In socketio, the `heartbeat timeout` value is used for the amount of time allowed for the both the server and client side to respond to a heartbeat request. If this timeout is exceeded, such as any action that causes the main thread to be blocked, the socket will close and a disconnect event will be emitted. This cause testem to exit with `browser timeout` error.

Due to socket disconnecting as part of tests execution, making the heartbeat timeout configurable can give the socket more time to respond to the heartbeat requests, potentially mitigating the socket disconnections.