### PR TITLE
Adding testContext to tests-start event & logging test name during global errors

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -17,6 +17,7 @@ class BrowserTestRunner {
     this.launcherId = this.launcher.id;
     this.singleRun = singleRun;
     this.logs = [];
+    this.currentTestContext = {};
 
     this.pendingTimer = undefined;
     this.onProcessExitTimer = undefined;
@@ -103,6 +104,7 @@ class BrowserTestRunner {
     var socketHeartbeatTimeout = this.launcher.config.get('socket_heartbeat_timeout');
     socket.server.set('heartbeat timeout', socketHeartbeatTimeout * 1000);
 
+    socket.on('tests-start', this.onTestsStart.bind(this));
     socket.on('test-result', this.onTestResult.bind(this));
     socket.on('test-metadata', this.onTestMetadata.bind(this));
     socket.on('top-level-error', this.onGlobalError.bind(this));
@@ -138,9 +140,16 @@ class BrowserTestRunner {
   reportResults(err, code, browserProcess) {
     browserProcess = browserProcess || this.process;
 
-    var result = toResult(this.launcherId, err, code, browserProcess, this.config);
+    var result = toResult(this.launcherId, err, code, browserProcess, this.config, this.currentTestContext);
     this.reporter.report(this.launcher.name, result);
     this.finish();
+  }
+
+  onTestsStart(testData) {
+    if (testData) {
+      this.currentTestContext = testData;
+      this.currentTestContext.state = 'executing';
+    }
   }
 
   onTestResult(result) {
@@ -160,6 +169,7 @@ class BrowserTestRunner {
       items: result.items
     });
     this.logs = [];
+    this.currentTestContext.state = 'complete';
   }
 
   onTestMetadata(tag, metadata) {
@@ -191,14 +201,25 @@ class BrowserTestRunner {
     var message = `${msg} at ${url}, line ${line}\n`;
     this.logs.push({
       type: 'error',
+      testContext: this.currentTestContext,
       text: message
     });
+
+    if (this.currentTestContext && this.currentTestContext.name) {
+      if (this.currentTestContext.state === 'executing') {
+        message = `Global error: ${msg} at ${url}, line ${line}\n While executing test: ${this.currentTestContext.name}\n`;
+      } else if (this.currentTestContext.state === 'complete') {
+        message = `Global error: ${msg} at ${url}, line ${line}\n After execution of test: ${this.currentTestContext.name}\n`;
+      }
+    } else {
+      message = `Global error: ${msg} at ${url}, line ${line}\n`;
+    }
 
     var config = this.launcher.config;
     if (config.get('bail_on_uncaught_error')) {
       this.onTestResult.call(this, {
         failed: 1,
-        name: `Global error: ${msg} at ${url}, line ${line}\n`,
+        name: message,
         logs: [],
         error: {}
       });

--- a/lib/runners/to-result.js
+++ b/lib/runners/to-result.js
@@ -2,9 +2,10 @@
 
 var log = require('npmlog');
 
-module.exports = function toResult(launcherId, err, code, runnerProcess, config, testContext = {}) {
+module.exports = function toResult(launcherId, err, code, runnerProcess, config, testContext) {
   var logs = [];
   var message = '';
+  testContext = testContext ? testContext : {};
 
   if (err) {
     logs.push({

--- a/lib/runners/to-result.js
+++ b/lib/runners/to-result.js
@@ -2,7 +2,7 @@
 
 var log = require('npmlog');
 
-module.exports = function toResult(launcherId, err, code, runnerProcess, config) {
+module.exports = function toResult(launcherId, err, code, runnerProcess, config, testContext = {}) {
   var logs = [];
   var message = '';
 
@@ -13,6 +13,15 @@ module.exports = function toResult(launcherId, err, code, runnerProcess, config)
     });
 
     message += err + '\n';
+  }
+
+  if (testContext.name) {
+    logs.push({
+      type: 'error',
+      text: `Error while executing test: ${testContext.name}`
+    });
+
+    message += `Error while executing test: ${testContext.name}\n`;
   }
 
   if (code !== 0) {
@@ -51,6 +60,7 @@ module.exports = function toResult(launcherId, err, code, runnerProcess, config)
     failed: code === 0 && !err ? 0 : 1,
     passed: code === 0 && !err ? 1 : 0,
     name: 'error',
+    testContext: testContext,
     launcherId: launcherId,
     logs: logs
   };

--- a/public/testem/jasmine2_adapter.js
+++ b/public/testem/jasmine2_adapter.js
@@ -27,6 +27,13 @@ function jasmine2Adapter() {
       emit('tests-start');
     };
 
+    this.specStarted = function(spec) {
+      var currentTest = {
+        name: spec.fullName
+      };
+      emit('tests-start', currentTest);
+    };
+
     this.specDone = function(spec) {
 
       var test = {

--- a/public/testem/jasmine_adapter.js
+++ b/public/testem/jasmine_adapter.js
@@ -24,6 +24,14 @@ function jasmineAdapter() {
   JasmineAdapterReporter.prototype.reportRunnerStarting = function() {
     emit('tests-start');
   };
+
+  JasmineAdapterReporter.prototype.reportSpecStarting = function(spec) {
+    var currentTest = {
+      name: spec.getFullName()
+    };
+    emit('tests-start', currentTest);
+  };
+
   JasmineAdapterReporter.prototype.reportSpecResults = function(spec) {
     if (spec.results().skipped) {
       return;

--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -49,7 +49,7 @@ function mochaAdapter() {
   Runner.prototype.emit = function(evt, test, err) {
     var name = getFullName(test);
     if (evt === 'start') {
-      emit('tests-start', { name });
+      emit('tests-start', { name: name });
     } else if (evt === 'end') {
       if (waiting === 0) {
         emit('all-test-results');

--- a/public/testem/mocha_adapter.js
+++ b/public/testem/mocha_adapter.js
@@ -49,7 +49,7 @@ function mochaAdapter() {
   Runner.prototype.emit = function(evt, test, err) {
     var name = getFullName(test);
     if (evt === 'start') {
-      emit('tests-start');
+      emit('tests-start', { name });
     } else if (evt === 'end') {
       if (waiting === 0) {
         emit('all-test-results');

--- a/public/testem/qunit_adapter.js
+++ b/public/testem/qunit_adapter.js
@@ -84,7 +84,7 @@ function qunitAdapter() {
       name: (params.module ? params.module + ': ' : '') + params.name,
       items: []
     };
-    emit('tests-start');
+    emit('tests-start', currentTest);
   });
   QUnit.testDone(function(params) {
     currentTest.failed = params.failed;

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -101,6 +101,33 @@ describe('browser test runner', function() {
     });
   });
 
+  describe('onTestsStart', function() {
+    var runner, reporter;
+
+    beforeEach(function() {
+      reporter = new FakeReporter();
+      var config = new Config('ci', {
+        parallel: 2,
+        reporter: reporter
+      });
+      var launcher = new Launcher('ci', { protocol: 'browser' }, config);
+      runner = new BrowserTestRunner(launcher, reporter);
+    });
+
+    it('saves the currentTextContext if passed as parameter', function() {
+      runner.onTestsStart({
+        name: 'testname',
+      });
+      expect(runner.currentTestContext.name).to.equal('testname');
+      expect(runner.currentTestContext.state).to.equal('executing');
+    });
+
+    it('has empty currentTextContext if no testcontext passed', function() {
+      runner.onTestsStart();
+      expect(runner.currentTestContext).to.deep.eq({});
+    });
+  });
+
   describe('onTestResult', function() {
     var runner, reporter;
 
@@ -231,7 +258,8 @@ describe('browser test runner', function() {
             type: 'error'
           }],
           name: 'error',
-          passed: 0
+          passed: 0,
+          testContext: {}
         });
         done();
       });
@@ -248,7 +276,8 @@ describe('browser test runner', function() {
           logs: [{
             type: 'error'
           }],
-          passed: 0
+          passed: 0,
+          testContext: {}
         });
         expect(reporter.results[0].result.error.message).to.match(/ENOENT/);
         expect(reporter.results[0].result.logs[0].text).to.match(/ENOENT/);
@@ -271,7 +300,8 @@ describe('browser test runner', function() {
             type: 'error'
           }],
           name: 'error',
-          passed: 0
+          passed: 0,
+          testContext: {}
         });
         done();
       });
@@ -295,7 +325,8 @@ describe('browser test runner', function() {
             type: 'log'
           }],
           name: 'error',
-          passed: 0
+          passed: 0,
+          testContext: {}
         });
         done();
       });
@@ -356,7 +387,8 @@ describe('browser test runner', function() {
             type: 'error'
           }],
           name: 'error',
-          passed: 0
+          passed: 0,
+          testContext: {}
         });
         done();
       });

--- a/tests/runners/process_test_runner_tests.js
+++ b/tests/runners/process_test_runner_tests.js
@@ -64,7 +64,8 @@ describe('ProcessTestRunner', function() {
           }],
           name: 'error',
           failed: 0,
-          passed: 1
+          passed: 1,
+          testContext: {},
         }
       }]);
       done();
@@ -94,6 +95,7 @@ describe('ProcessTestRunner', function() {
           name: 'error',
           failed: 1,
           passed: 0,
+          testContext: {},
           error: {
             message: 'Non-zero exit code: 1\nStderr: \n foobar\n'
           }
@@ -136,6 +138,7 @@ describe('ProcessTestRunner', function() {
           name: 'error',
           failed: 1,
           passed: 0,
+          testContext: {},
           error: {
             message: expectedMessage
           }


### PR DESCRIPTION
This PR will add testContext to the tests-start event when it is available. TestContext contains the name of the test, and the state of the test: `executing` or `completed`
The testContext and the test name will be added to the error logs for tests that was executing when global failures, browser timeout or browser exit unexpectedly error is reported.

Note. No testContext was added the tests-start event emittion of `buster_adapter.js`, since there isn't a test start hook that provides the test object, which contains the test name. Rather, the `test:start` event only provides a `context` object.