### PR TITLE
Disable extra tab in Firefox

### DIFF
--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -77,7 +77,9 @@ function knownBrowsers(platform, config) {
         // and the welcome start page
         var prefs = [
           'user_pref("browser.shell.checkDefaultBrowser", false);',
-          'user_pref("browser.cache.disk.smart_size.first_run", false);'
+          'user_pref("browser.cache.disk.smart_size.first_run", false);',
+          'user_pref("datareporting.policy.dataSubmissionEnabled", false);',
+          'user_pref("datareporting.policy.dataSubmissionPolicyNotifiedTime", "1481830156314");'
         ];
         fs.writeFile(perfJS, prefs.join('\n'), done);
       }

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -96,7 +96,9 @@ describe('knownBrowsers', function() {
           expect(err).to.be.null();
           expect(file(path.join(browserTmpDir, 'user.js'))).to.equal(
             'user_pref("browser.shell.checkDefaultBrowser", false);\n' +
-            'user_pref("browser.cache.disk.smart_size.first_run", false);'
+            'user_pref("browser.cache.disk.smart_size.first_run", false);\n' +
+            'user_pref("datareporting.policy.dataSubmissionEnabled", false);\n' +
+            'user_pref("datareporting.policy.dataSubmissionPolicyNotifiedTime", "1481830156314");'
           );
           done();
         });


### PR DESCRIPTION
Since September 2017 a new tab is opened by default, if no data
reporting preference is recorded. Disable this tab and disable the
data reporting feature.