### PR TITLE
Generate unique id in launcher-factory, app.js to use launch-factory

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -14,7 +14,7 @@ const TapProcessTestRunner = require('./runners/tap_process_test_runner');
 const HookRunner = require('./runners/hook_runner');
 const cleanExit = require('./clean_exit');
 const FileWatcher = require('./file_watcher');
-const Launcher = require('./launcher');
+const LauncherFactory = require('./launcher-factory');
 
 const RunTimeout = require('./utils/run-timeout');
 const Reporter = require('./utils/reporter');
@@ -238,10 +238,10 @@ module.exports = class App extends EventEmitter {
     });
 
     if (!browser) {
-      let launcher = new Launcher(browserName, {
+      let launcher = new LauncherFactory(browserName, {
         id: id,
         protocol: 'browser'
-      }, this.config);
+      }, this.config).create();
       browser = new BrowserTestRunner(launcher, this.reporter, this.runnerIndex++, this.config);
       this.addRunner(browser);
     }

--- a/lib/launcher-factory.js
+++ b/lib/launcher-factory.js
@@ -8,10 +8,25 @@ module.exports = class LauncherFactory {
     this.name = name;
     this.config = config;
     this.settings = settings;
+    this.ids = {};
+  }
+
+  getUniqueId() {
+    let id = this.generateId();
+    while (this.ids[id]) {
+      id = this.generateId();
+    }
+    this.ids[id] = id;
+    return id;
+  }
+
+  generateId() {
+    return String(Math.floor(Math.random() * 10000));
   }
 
   create(options) {
-    let settings = extend({}, this.settings, options);
+    var id = this.getUniqueId();
+    var settings = extend({ id }, this.settings, options);
     return new Launcher(this.name, settings, this.config);
   }
 };

--- a/lib/launcher-factory.js
+++ b/lib/launcher-factory.js
@@ -8,25 +8,15 @@ module.exports = class LauncherFactory {
     this.name = name;
     this.config = config;
     this.settings = settings;
-    this.ids = {};
   }
 
   getUniqueId() {
-    let id = this.generateId();
-    while (this.ids[id]) {
-      id = this.generateId();
-    }
-    this.ids[id] = id;
-    return id;
-  }
-
-  generateId() {
-    return String(Math.floor(Math.random() * 10000));
+    return process.hrtime().join('');
   }
 
   create(options) {
-    var id = this.getUniqueId();
-    var settings = extend({ id }, this.settings, options);
+    const id = this.getUniqueId();
+    const settings = extend({ id }, this.settings, options);
     return new Launcher(this.name, settings, this.config);
   }
 };

--- a/tests/launcher_factory_tests.js
+++ b/tests/launcher_factory_tests.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const LauncherFactory = require('../lib/launcher-factory');
+const Config = require('../lib/config');
+const expect = require('chai').expect;
+
+describe('Launcher Factory', function() {
+  let settings, config, launcherFactory;
+
+  beforeEach(function() {
+    settings = {protocol: 'browser'};
+    config = new Config(null, {port: '7357', url: 'http://blah.com/'});
+    launcherFactory = new LauncherFactory('browserName', settings, config);
+  });
+
+  it('should generate a unique id', function() {
+    const launcher = launcherFactory.create();
+
+    expect(launcher.name).to.equal('browserName');
+    expect(launcher.id).to.match(/([0-9]+)/);
+  });
+});


### PR DESCRIPTION
Problem: Launcher currently generates the id on every browser-login, but nothing keeps track of the id that is generated, and it could cause a collision. When this happens, I have experienced a browser timeout error.

Solution: In launcher-factory, keep track of the id that are used. And if it is already in use, generate a new one.
Change app.js to use launcher-factory so the above is used.

This should also help with #1021 #1247.