### PR TITLE
Moving set heartbeat timeout from browser_test_runner to server/index

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -101,9 +101,6 @@ module.exports = class BrowserTestRunner {
 
     this.onStart.call(this);
 
-    let socketHeartbeatTimeout = this.launcher.config.get('socket_heartbeat_timeout');
-    socket.server.set('heartbeat timeout', socketHeartbeatTimeout * 1000);
-
     socket.on('tests-start', this.onTestsStart.bind(this));
     socket.on('test-result', this.onTestResult.bind(this));
     socket.on('test-metadata', this.onTestMetadata.bind(this));

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -102,6 +102,9 @@ class Server extends EventEmitter {
     }
     this.io = socketIO(this.server);
 
+    let socketHeartbeatTimeout = this.config.get('socket_heartbeat_timeout');
+    this.io.set('heartbeat timeout', socketHeartbeatTimeout * 1000);
+
     this.io.on('connection', this.onClientConnected.bind(this));
 
     this.configureExpress(app);


### PR DESCRIPTION
The original place where heartbeat_timeout is set (in browser_test_runner.js) is too late to set the heartbeat_timeout for the first browser instance. 

Problem: The first browser is spawned with the default timeout value. BrowserLogin event is emitted and handled, then testem tell the server to set the subsequent browsers to use the newly configured heartbeat timeout value. 

Fix: move the configuration code earlier, right after the testem server socket is initiated.