### PR TITLE
fix(teamcity_reporter): use comparisonFailure error type if applicable

### DIFF
--- a/lib/reporters/teamcity_reporter.js
+++ b/lib/reporters/teamcity_reporter.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {assign} = Object;
+
 class TeamcityReporter {
   constructor(silent, out) {
     this.out = out || process.stdout;
@@ -14,8 +16,13 @@ class TeamcityReporter {
   }
 
   report(prefix, data) {
-    this.out.write('##teamcity[testStarted name=\'' + this._namify(prefix, data) + '\']\n');
+    const name = this._namify(prefix, data);
+    this.out.write(this._teamcityLine('testStarted', {name}));
     this._display(prefix, data);
+    this.out.write(this._teamcityLine('testFinished', assign(
+      {name},
+      this._runDurationAttribute(data)
+    )));
     this.total++;
     if (data.skipped) {
       this.skipped++;
@@ -30,7 +37,10 @@ class TeamcityReporter {
     }
     this.endTime = new Date();
     this.out.write('\n\n');
-    this.out.write('##teamcity[testSuiteFinished name=\'testem.suite\' duration=\'' + this._duration() + '\']\n');
+    this.out.write(this._teamcityLine('testSuiteFinished', {
+      name: 'testem.suite',
+      duration: this._duration(),
+    }));
     this.out.write('\n\n');
   }
 
@@ -38,15 +48,35 @@ class TeamcityReporter {
     if (this.silent) {
       return;
     }
-    if (result.skipped) {
-      this.out.write('##teamcity[testIgnored name=\'' + this._namify(prefix, result) + '\' message=\'pending\']\n');
-    } else if (!result.passed) {
-      var message = (result.error && result.error.message) || '';
-      var stack = (result.error && result.error.stack) || '';
-      this.out.write('##teamcity[testFailed name=\'' + this._namify(prefix, result) + '\' message=\'' + escape(message) + '\' details=\'' + escape(stack) + '\']\n');
-    }
-    this.out.write('##teamcity[testFinished name=\'' + this._namify(prefix, result) + '\'' + this._runDurationAttribute(result) + ']\n');
+    const name = this._namify(prefix, result);
 
+    if (result.skipped) {
+      this.out.write(this._teamcityLine('testIgnored', {
+        name,
+        message: 'pending',
+      }));
+    } else if (!result.passed) {
+      const hasError = result.error;
+      const attributes = {name};
+
+      const message = (hasError && result.error.message) || '';
+      const stack = (hasError && result.error.stack) || '';
+
+      attributes.message = escape(message);
+      attributes.details = escape(stack);
+
+      if (
+        hasError &&
+        result.error.hasOwnProperty('expected') &&
+        result.error.hasOwnProperty('actual')
+      ) {
+        attributes.type = 'comparisonFailure';
+        attributes.expected = escape(result.error.expected);
+        attributes.actual = escape(result.error.actual);
+      }
+
+      this.out.write(this._teamcityLine('testFailed', attributes))
+    }
   }
 
   _namify(prefix, result) {
@@ -59,8 +89,16 @@ class TeamcityReporter {
     return Math.round((this.endTime - this.startTime));
   }
 
+  _teamcityLine(type, options) {
+    const attributes = Object.keys(options)
+      .map(attributeName => `${attributeName}='${options[attributeName]}'`)
+      .join(' ');
+
+    return `##teamcity[${type} ${attributes}]\n`;
+  }
+
   _runDurationAttribute(result) {
-    return typeof result.runDuration === 'number' ? ' duration=\'' + result.runDuration + '\'' : '';
+    return typeof result.runDuration === 'number' ? {duration: result.runDuration} : undefined;
   }
 }
 

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -517,5 +517,34 @@ describe('test reporters', function() {
       assert.match(output, /##teamcity\[testFailed name='phantomjs - it handles undefined errors' message='' details='']/);
       assert.match(output, /##teamcity\[testFinished name='phantomjs - it handles undefined errors' duration='42']/);
     });
+
+    it('uses comparisonFailure type for comparison errors', function () {
+      var reporter = new TeamcityReporter(false, stream);
+
+      reporter.report('firefox', {
+        name: 'it handles failures',
+        passed: false,
+        error: {
+          passed: false,
+          expected: 'foo',
+          actual: 'bar'
+        }
+      });
+
+      reporter.finish();
+      var output = stream.read().toString();
+
+      assert.match(output, /##teamcity\[testFailed name='firefox - it handles failures' message='' details='' type='comparisonFailure' expected='foo' actual='bar']/);
+    });
+
+    it('generates teamcity lines', function () {
+      var reporter = new TeamcityReporter(false, stream);
+
+      [
+        ['testStarted', {bar: 'baz'}, "##teamcity[testStarted bar='baz']\n"],
+        ['testIgnored', {bar: 'baz', runDuration: 42}, "##teamcity[testIgnored bar='baz' runDuration='42']\n"],
+      ].forEach(([type, options, expected]) =>
+        assert.equal(reporter._teamcityLine(type, options), expected));
+    });
   });
 });


### PR DESCRIPTION
fixes #1269

This also refactors the teamcity reporter slightly to reduce amount of escaping needed when building a teamcity report line