### PR TITLE
adding better error handling when test-suite timeout occurs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -150,7 +150,14 @@ module.exports = class App extends EventEmitter {
 
     return Bluebird.using(this.runHook('before_tests'), () => {
       return Bluebird.using(RunTimeout.with(this.config.get('timeout')), timeout => {
-        timeout.on('timeout', () => this.killRunners());
+        timeout.on('timeout', () => {
+          let timeoutSeconds = timeout.timeout;
+          if (timeoutSeconds) {
+            log.info(`Test suite execution has timed out (config.timeout = ${timeoutSeconds} seconds). Terminating all test runners`);
+            this.testSuiteTimedOut = true;
+          }
+          this.killRunners();
+        });
         this.timeoutID = timeout.timeoutID; // TODO Remove, just for the tests
         this.currentRun = this.singleRun(timeout);
         this.emit('testRun');

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -21,6 +21,7 @@ module.exports = class BrowserTestRunner {
 
     this.pendingTimer = undefined;
     this.onProcessExitTimer = undefined;
+    this.exitRequested = false;
   }
 
   start(onFinish) {
@@ -60,6 +61,11 @@ module.exports = class BrowserTestRunner {
     if (!this.process) {
       return Bluebird.resolve();
     }
+
+    // mark that somebody (generally app.js) has requested that the
+    // test runner exit. This is not an unexpected exit--this setting
+    // is to tell the processExit handler that.
+    this.exitRequested = true;
 
     log.info(`Closing browser ${this.name()}.`);
     return this.process.kill().then(() => {
@@ -246,11 +252,15 @@ module.exports = class BrowserTestRunner {
     if (this.finished) { return; }
 
     this.onProcessExitTimer = setTimeout(() => {
-      if (this.finished) {
-        return;
+      if (this.finished) { 
+        return; 
       }
 
-      this.reportResults(new Error('Browser exited unexpectedly'), code, browserProcess);
+      this.reportResults(new Error(this.exitRequested
+                                   ? "Browser exited on request from test driver"
+                                   : "Browser exited unexpectedly"),
+                         code,
+                         browserProcess);
     }, 1000);
   }
 


### PR DESCRIPTION
Recently we were running our large (many thousands of tests) test suite on an Ember app, and intermittently got a 'Browser exited unexpectedly' error. We finally tracked it down to we set the testem 'timeout' config value to a number not high enough to get through all the tests the browser was to run (we're also partitioning tests across browsers, which confused things as more tests were added over time). The problem was that testem did not put anything in the log when it decided to shut down the browser due to expiring the timeout value. The browser onProcessExit handler then put out its normal "browser exited unexpectedly" message, which we thought for a time meant "the browser crashed" (which is wrong).

This fix is to add a flag when testem itself kills the browser, and some handling in onProcessExit to change the exit message when the flag is true, to provide context for why the process exited early. This would have saved us a week of debugging. ;-)