### PR TITLE
Add better reporting for qunit negative assertions

### DIFF
--- a/lib/reporters/dev/split_log_panel.js
+++ b/lib/reporters/dev/split_log_panel.js
@@ -29,7 +29,7 @@ function failureDisplay(item) {
   }
 
   if (item.expected) {
-    extra.push(' expected ' + item.expected);
+    extra.push(' expected ' + (item.negative ? 'NOT ' : '') + item.expected);
   }
 
   if (item.actual) {

--- a/lib/reporters/dot_reporter.js
+++ b/lib/reporters/dot_reporter.js
@@ -80,8 +80,8 @@ module.exports = class DotReporter {
 
       if ('expected' in error && 'actual' in error) {
         printf(this.out, '\n' +
-               '     expected: %O\n' +
-               '       actual: %O\n', error.expected, error.actual);
+               '     expected: %s%O\n' +
+               '       actual: %O\n', (error.negative ? 'NOT ' : ''), error.expected, error.actual);
       }
 
       if (error.stack) {

--- a/lib/reporters/teamcity_reporter.js
+++ b/lib/reporters/teamcity_reporter.js
@@ -110,7 +110,7 @@ module.exports = class TeamcityReporter {
         result.error.hasOwnProperty('actual')
       ) {
         attributes.type = 'comparisonFailure';
-        attributes.expected = escape(result.error.expected);
+        attributes.expected = (result.error.negative ? 'NOT ' : '') + escape(result.error.expected);
         attributes.actual = escape(result.error.actual);
       }
 

--- a/public/testem/qunit_adapter.js
+++ b/public/testem/qunit_adapter.js
@@ -71,7 +71,8 @@ function qunitAdapter() {
           actual: params.actual,
           expected: params.expected,
           stack: params.source,
-          message: params.message
+          message: params.message,
+          negative: params.negative
         });
       }
 

--- a/tests/ui/split_log_panel_tests.js
+++ b/tests/ui/split_log_panel_tests.js
@@ -154,6 +154,22 @@ describe('SplitLogPanel', !isWin ? function() {
       results.set('tests', tests);
       expect(panel.getResultsDisplayText().unstyled()).to.equal('Looking good...');
     });
+    it('prepends NOT to expected for negative assertions', function() {
+      results.set('total', 1);
+      let tests = new Backbone.Collection([
+        new Backbone.Model({
+          name: 'blah', passed: false, failed: 1,
+          items: [
+            {
+              message: 'should not be foo', passed: false, expected: 'foo', negative: true
+            }
+          ]
+        })
+      ]);
+      results.set('tests', tests);
+      results.set('all', true);
+      expect(panel.getResultsDisplayText().unstyled()).to.match(/blah\n {4}[x✘] should not be foo\n {9}expected NOT foo/);
+    });
   });
 
   describe('getMessagesText', function() {


### PR DESCRIPTION
For negative assertions, qunit sets `negative: true`, e.g. [notEqual](https://github.com/qunitjs/qunit/blob/a577183e8d4f975d822e3021cbba552c5ed77549/src/assert.js#L189).

This PR passes along the `negative` key to reporters and prepends `NOT` to the output for `expected` when the `negative` key is truthy in the *dot* and *teamcity* reporters as well as the dev mode reporter (the *tap* and *xunit* reporters do not output `expected`).

This brings testem in parity with qunit's own [html reporter](https://github.com/qunitjs/qunit/blob/a577183e8d4f975d822e3021cbba552c5ed77549/reporter/html.js#L773).