### PR TITLE
[FEAT BUGFIX] add test time and duration to TapReporter, fix double-exit check, print timeout error on exit if required

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -33,11 +33,14 @@ module.exports = class App extends EventEmitter {
     this.runnerIndex = 0;
     this.runners = [];
     this.timeoutID = undefined;
+    this.testSuiteTimedOut = null;
+    this.testSuiteTimedOut = false;
 
     this.reportFileName = this.config.get('report_file');
 
+    let alreadyExit = false;
+
     this.cleanExit = err => {
-      let alreadyExit = false;
       if (!alreadyExit) {
         alreadyExit = true;
 
@@ -45,6 +48,11 @@ module.exports = class App extends EventEmitter {
 
         if (err && err.hideFromReporter) {
           err = null;
+        }
+
+        if (this.testSuiteTimedOut === true) {
+          let timeoutSeconds = this.testSuiteTimeout.timeout;
+          err = new Error(`Test suite execution has timed out (config.timeout = ${timeoutSeconds} seconds). Terminated all test runners.`);
         }
 
         (finalizer || cleanExit)(exitCode, err);
@@ -150,12 +158,13 @@ module.exports = class App extends EventEmitter {
 
     return Bluebird.using(this.runHook('before_tests'), () => {
       return Bluebird.using(RunTimeout.with(this.config.get('timeout')), timeout => {
+        this.testSuiteTimeout = timeout;
+
         timeout.on('timeout', () => {
           let timeoutSeconds = timeout.timeout;
-          if (timeoutSeconds) {
-            log.info(`Test suite execution has timed out (config.timeout = ${timeoutSeconds} seconds). Terminating all test runners`);
-            this.testSuiteTimedOut = true;
-          }
+
+          log.info(`Test suite execution has timed out (config.timeout = ${timeoutSeconds} seconds). Terminating all test runners`);
+          this.testSuiteTimedOut = true;
           this.killRunners();
         });
         this.timeoutID = timeout.timeoutID; // TODO Remove, just for the tests

--- a/lib/app.js
+++ b/lib/app.js
@@ -53,6 +53,7 @@ module.exports = class App extends EventEmitter {
         if (this.testSuiteTimedOut === true) {
           let timeoutSeconds = this.testSuiteTimeout.timeout;
           err = new Error(`Test suite execution has timed out (config.timeout = ${timeoutSeconds} seconds). Terminated all test runners.`);
+          exitCode = 1;
         }
 
         (finalizer || cleanExit)(exitCode, err);

--- a/lib/displayutils.js
+++ b/lib/displayutils.js
@@ -6,17 +6,23 @@ const util = require('util');
 const strutils = require('./strutils');
 
 function resultDisplay(id, prefix, result) {
-
   let parts = [];
+
   if (prefix) {
     parts.push(prefix);
   }
+
+  parts.push(`[${result.runDuration} ms]`);
+
   if (result.name) {
     parts.push(result.name.trim());
   }
 
   let line = parts.join(' - ');
-  return (result.skipped ? 'skip ' : (result.passed ? 'ok ' : 'not ok ')) + id + ' ' + line;
+  let output = (result.skipped ? 'skip ' : (result.passed ? 'ok ' : 'not ok ')) + id + ' ' + line;
+  let curTime = new Date();
+
+  return `[${curTime.toLocaleTimeString()}] ${output}`;
 }
 
 function yamlDisplay(err, logs) {

--- a/lib/displayutils.js
+++ b/lib/displayutils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('util');
+const CurrentTime = require('./utils/current-time');
 
 // Method to format test results.
 const strutils = require('./strutils');
@@ -20,9 +21,8 @@ function resultDisplay(id, prefix, result) {
 
   let line = parts.join(' - ');
   let output = (result.skipped ? 'skip ' : (result.passed ? 'ok ' : 'not ok ')) + id + ' ' + line;
-  let curTime = new Date();
 
-  return `[${curTime.toLocaleTimeString()}] ${output}`;
+  return `[${CurrentTime.asLocaleTimeString()}] ${output}`;
 }
 
 function yamlDisplay(err, logs) {

--- a/lib/utils/current-time.js
+++ b/lib/utils/current-time.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function currentTimeAsLocaleTimeString() {
+  let dateTime = new Date();
+
+  return dateTime.toLocaleTimeString();
+}
+
+module.exports = {
+  asLocaleTimeString: currentTimeAsLocaleTimeString
+};


### PR DESCRIPTION
Previous testem output:

```
ok 1 phantomjs - My Awesome Test Scenario
```

New Output

```
[12:31:30] ok 1 phantomjs - [50 ms] - My Awesome Test Scenario
```

Previous global timeout error message:

```
Browser exited on request from test driver
```

New global timeout error message

```
Test suite execution has timed out (config.timeout = 300 seconds). Terminated all test runners.
```