### PR TITLE
Default 2nd reporter type in dev mode to tap or use dev_mode_file_reporter conf

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -75,6 +75,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
     config_dir:                  [Path]    directory to use as root for resolving configs, if different than cwd
     css_files:                   [Array]   string or array of additional stylesheets to include
     cwd:                         [Path]    directory to use as root
+    dev_mode_file_reporter:      [String]  in dev mode the default reporter is 'dev' for the standard output. It is possible to specify a custom reporter which will report to report_file ('tap' reporter is used otherwise)
     disable_watching:            [Boolean] disable any file watching
     fail_on_zero_tests:          [Boolean] whether process should exit with error status when no tests found
     firefox_user_js:             [String]  path to firefox custom user.js file to be used

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Bluebird = require('bluebird');
+const log = require('npmlog');
 
 const reporters = require('../reporters');
 const isa = require('../isa');
@@ -52,7 +53,11 @@ class Reporter {
 
       if (path) {
         if (config.appMode === 'dev') {
-          const devModeFileReporter = config.get('dev_mode_file_reporter') || 'tap';
+          let devModeFileReporter = config.get('dev_mode_file_reporter');
+          if (!devModeFileReporter) {
+            log.warn('You configured a `report_file`, you may want to configure the `dev_mode_file_reporter` as well. Using the `tap` logger now.');
+            devModeFileReporter = 'tap';
+          }
           this.reporters.push(setupReporter(devModeFileReporter, this.reportFile.outputStream, config, app));
         } else {
           this.reporters.push(setupReporter(config.get('reporter'), this.reportFile.outputStream, config, app));

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -51,7 +51,11 @@ class Reporter {
       this.reporters = [setupReporter(config.get('reporter'), stdout, config, app)];
 
       if (path) {
-        this.reporters.push(setupReporter(config.get('reporter'), this.reportFile.outputStream, config, app));
+        if (config.appMode === 'dev') {
+          this.reporters.push(setupReporter('tap', this.reportFile.outputStream, config, app));
+        } else {
+          this.reporters.push(setupReporter(config.get('reporter'), this.reportFile.outputStream, config, app));
+        }
       }
     }
   }

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -52,7 +52,8 @@ class Reporter {
 
       if (path) {
         if (config.appMode === 'dev') {
-          this.reporters.push(setupReporter('tap', this.reportFile.outputStream, config, app));
+          const devModeFileReporter = config.get('dev_mode_file_reporter') || 'tap';
+          this.reporters.push(setupReporter(devModeFileReporter, this.reportFile.outputStream, config, app));
         } else {
           this.reporters.push(setupReporter(config.get('reporter'), this.reportFile.outputStream, config, app));
         }

--- a/tests/utils/reporter_tests.js
+++ b/tests/utils/reporter_tests.js
@@ -12,6 +12,7 @@ const tmpNameAsync = Bluebird.promisify(tmp.tmpName);
 const Reporter = require('../../lib/utils/reporter');
 const FakeReporter = require('../support/fake_reporter');
 const TapReporter = require('../../lib/reporters/tap_reporter');
+const XUnitReporter = require('../../lib/reporters/xunit_reporter');
 
 const fsReadFileAsync = Bluebird.promisify(fs.readFile);
 const fsUnlinkAsync = Bluebird.promisify(fs.unlink);
@@ -203,6 +204,34 @@ describe('Reporter', function() {
         expect(reporter.reporters).to.have.lengthOf(2);
         expect(reporter.reporters[0]).to.be.an.instanceof(FakeReporter);
         expect(reporter.reporters[1]).to.be.an.instanceof(TapReporter);
+      });
+    });
+
+    it('creates two reporters in dev mode if path is present and 2nd reporter is dev_mode_file_reporter', function() {
+      return tmpNameAsync().then(function(path) {
+        let stream = new PassThrough();
+        let reporter = new Reporter({
+          config: {
+            appMode: 'dev',
+            get: function(key) {
+              switch (key) {
+                case 'reporter':
+                  return FakeReporter;
+                case 'path':
+                  return 'dev';
+                case 'dev_mode_file_reporter':
+                  return 'xunit';
+                case 'url':
+                  return 'abc';
+              }
+            }
+          },
+          on: () => {},
+        }, stream, path);
+
+        expect(reporter.reporters).to.have.lengthOf(2);
+        expect(reporter.reporters[0]).to.be.an.instanceof(FakeReporter);
+        expect(reporter.reporters[1]).to.be.an.instanceof(XUnitReporter);
       });
     });
 

--- a/tests/utils/reporter_tests.js
+++ b/tests/utils/reporter_tests.js
@@ -180,6 +180,32 @@ describe('Reporter', function() {
       });
     });
 
+    it('creates two reporters in dev mode if path is present and 2nd reporter is tap', function() {
+      return tmpNameAsync().then(function(path) {
+        let stream = new PassThrough();
+        let reporter = new Reporter({
+          config: {
+            appMode: 'dev',
+            get: function(key) {
+              switch (key) {
+                case 'reporter':
+                  return FakeReporter;
+                case 'path':
+                  return 'dev';
+                case 'url':
+                  return 'abc';
+              }
+            }
+          },
+          on: () => {},
+        }, stream, path);
+
+        expect(reporter.reporters).to.have.lengthOf(2);
+        expect(reporter.reporters[0]).to.be.an.instanceof(FakeReporter);
+        expect(reporter.reporters[1]).to.be.an.instanceof(TapReporter);
+      });
+    });
+
     it('creates a reporter when custom reporter dependent on configs is provided', function() {
       class CustomReporter extends TapReporter {
       }


### PR DESCRIPTION
Fixes https://github.com/testem/testem/issues/1075.

See https://github.com/testem/testem/issues/1075#issuecomment-412674637 for a detailed description of the issue.

@johanneswuerbach I'm still not 100% sure this is the best solution. I like the idea that we are logging to a file, but assuming a `tap` reporter will always work fine seems wrong to me. What if the `report_file` is an `XML` file?

I think if we really want to have two reporters we might as well have a config property like `dev_mode_file_reporter` that the user can set to the preferred reporter type. Let me know what you think, otherwise this PR does just what we discussed on #1075.