### PR TITLE
Sending qunit testId in test-result event and exposing originalResultObject to reporter.

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -169,7 +169,8 @@ module.exports = class BrowserTestRunner {
       launcherId: this.launcherId,
       failed: result.failed,
       pending: result.pending,
-      items: result.items
+      items: result.items,
+      originalResultObj: result
     });
     this.logs = [];
     this.currentTestContext.state = 'complete';
@@ -252,8 +253,8 @@ module.exports = class BrowserTestRunner {
     if (this.finished) { return; }
 
     this.onProcessExitTimer = setTimeout(() => {
-      if (this.finished) { 
-        return; 
+      if (this.finished) {
+        return;
       }
 
       this.reportResults(new Error(this.exitRequested

--- a/public/testem/qunit_adapter.js
+++ b/public/testem/qunit_adapter.js
@@ -93,6 +93,7 @@ function qunitAdapter() {
     currentTest.skipped = params.skipped;
     currentTest.total = params.total;
     currentTest.runDuration = params.runtime;
+    currentTest.testId = params.testId;
 
     results.total++;
 


### PR DESCRIPTION
This will allow custom reporters to report the testId in qunit, which can be used to rerun tests.