### PR TITLE
register events defined in additionalBrowserSocketEvents and send events to browser side

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -66,6 +66,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
 
 ### Config-level options:
 
+    additional_browser_socket_events    [Object]  an object containing keys corresponding to event names that point to handler functions, which are to be added to the browser socket
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
     browser_paths:               [Object]  hash of browsers (keys) to an string of their binary paths (values)

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -66,7 +66,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
 
 ### Config-level options:
 
-    additional_browser_socket_events    [Object]  an object containing keys corresponding to event names that point to handler functions, which are to be added to the browser socket
+    custom_browser_socket_events    [Object]  an object containing keys corresponding to event names that point to handler functions, which are to be added to the browser socket
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
     browser_paths:               [Object]  hash of browsers (keys) to an string of their binary paths (values)

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -128,6 +128,14 @@ module.exports = class BrowserTestRunner {
     socket.on('all-test-results', this.onAllTestResults.bind(this));
     socket.on('after-tests-complete', this.onAfterTests.bind(this));
 
+    const additionalBrowserSocketEvents = this.launcher.config.get('additional_browser_socket_events');
+
+    if (additionalBrowserSocketEvents) {
+      Object.keys(additionalBrowserSocketEvents).forEach((key) => {
+        socket.on(key, additionalBrowserSocketEvents[key].bind(this));
+      });
+    }
+
     let tap = new BrowserTapConsumer(socket);
     tap.on('test-result', this.onTestResult.bind(this));
     tap.on('all-test-results', this.onAllTestResults.bind(this));

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -128,11 +128,11 @@ module.exports = class BrowserTestRunner {
     socket.on('all-test-results', this.onAllTestResults.bind(this));
     socket.on('after-tests-complete', this.onAfterTests.bind(this));
 
-    const additionalBrowserSocketEvents = this.launcher.config.get('additional_browser_socket_events');
+    const customBrowserSocketEvents = this.launcher.config.get('custom_browser_socket_events');
 
-    if (additionalBrowserSocketEvents) {
-      Object.keys(additionalBrowserSocketEvents).forEach((key) => {
-        socket.on(key, additionalBrowserSocketEvents[key].bind(this));
+    if (customBrowserSocketEvents) {
+      Object.keys(customBrowserSocketEvents).forEach((key) => {
+        socket.on(key, customBrowserSocketEvents[key].bind(this));
       });
     }
 

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -175,6 +175,7 @@ var Testem = {
         handler.apply(this, argsWithoutFirst);
       }
     }
+
     this.emitMessage.apply(this, arguments);
   },
   on: function(evt, callback) {
@@ -266,6 +267,9 @@ var Testem = {
         case 'stop-run':
           self.emit('after-tests-complete');
           break;
+        default:
+          self.emit(type, message.data);
+          break;
       }
     });
   },
@@ -285,6 +289,18 @@ var Testem = {
     }
     // stringify for clients that only can handle string postMessages (IE <= 10)
     return JSON.stringify(message);
+  },
+  removeEventCallbacks: function(evt, callback) {
+    var handlers = this.evtHandlers[evt];
+    var removeIdx = [];
+    for (var i = 0; i < handlers.length; i++) {
+      if (handlers[i] === callback) {
+        removeIdx.push(i);
+      }
+    }
+    for (var j = 0; j < removeIdx.length; j++) {
+      handlers.splice(j, 1);
+    }
   },
   runAfterTests: function() {
     if (Testem.afterTestsQueue.length) {

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -268,7 +268,7 @@ var Testem = {
           self.emit('after-tests-complete');
           break;
         default:
-          if (type.indexOf('testem:') == 0) {
+          if (type.indexOf('testem:') === 0) {
             self.emit(type, message.data);
           }
           break;

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -295,6 +295,9 @@ var Testem = {
   removeEventCallbacks: function(evt, callback) {
     var handlers = this.evtHandlers[evt];
     var removeIdx = [];
+    if (typeof handlers === "undefined") {
+      return;
+    }
     for (var i = 0; i < handlers.length; i++) {
       if (handlers[i] === callback) {
         removeIdx.push(i);

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -268,7 +268,9 @@ var Testem = {
           self.emit('after-tests-complete');
           break;
         default:
-          self.emit(type, message.data);
+          if (type.indexOf('testem:') == 0) {
+            self.emit(type, message.data);
+          }
           break;
       }
     });

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -190,7 +190,7 @@ function initSocket(id) {
     sendMessageToParent('stop-run');
   });
   socket.on('*', function(event) {
-    if (event.data) {
+    if (event.data && event.data[0].indexOf('testem:') == 0 ) {
       var eventName = event.data[0];
       var eventData = event.data[1];
       sendMessageToParent(eventName, eventData);

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -1,4 +1,5 @@
-/* globals document, parent, window, io, navigator */
+/* globals document, parent, io, window, navigator */
+/* globals module */
 'use strict';
 
 var socket;
@@ -37,11 +38,13 @@ function sendMessageToParent(type, data) {
   parent.postMessage(message, '*');
 }
 
-var addListener = window.addEventListener ?
-  function(obj, evt, cb) { obj.addEventListener(evt, cb, false); } :
-  function(obj, evt, cb) { obj.attachEvent('on' + evt, cb); };
-
-addListener(window, 'message', handleMessage);
+var addListener;
+if (typeof window !== 'undefined') {
+  addListener = window.addEventListener ?
+    function(obj, evt, cb) { obj.addEventListener(evt, cb, false); } :
+    function(obj, evt, cb) { obj.attachEvent('on' + evt, cb); };
+    addListener(window, 'message', handleMessage);
+}
 
 var messageListeners = {};
 function handleMessage(event) {
@@ -190,7 +193,7 @@ function initSocket(id) {
     sendMessageToParent('stop-run');
   });
   socket.on('*', function(event) {
-    if (event.data && event.data[0].indexOf('testem:') == 0 ) {
+    if (event.data && event.data[0].indexOf('testem:') === 0 ) {
       var eventName = event.data[0];
       var eventData = event.data[1];
       sendMessageToParent(eventName, eventData);
@@ -198,4 +201,12 @@ function initSocket(id) {
   });
 }
 
-init();
+// We should only call init() if it ran in browser.
+if (typeof window !== 'undefined') {
+  init();
+}
+
+// Exporting this as a module so that it can be unit tested in Node.
+if (typeof module !== 'undefined') {
+  module.exports = patchEmitterForWildcard;
+}

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -417,6 +417,27 @@ describe('browser test runner', function() {
     });
   });
 
+  describe('additionalBrowserSocketEvents', function() {
+    it('binds additional browser socket events', function() {
+      let eventName = 'testEvent';
+      let eventFn = function() {
+        return 'testing additionalBrowserSocketEvents.';
+      }
+      let additional_browser_socket_events = {};
+      additional_browser_socket_events[eventName] = eventFn;
+
+      let socket = new FakeSocket();
+      let reporter = new FakeReporter();
+      let config = new Config('ci', { additional_browser_socket_events, reporter: reporter });
+      let launcher = new Launcher('ci', { protocol: 'browser' }, config);
+      let runner = new BrowserTestRunner(launcher, reporter, null, null, config);
+
+      runner.tryAttach('browser', launcher.id, socket);
+
+      expect(eventFn()).to.deep.equal(socket.listeners(eventName)[0]());
+    });
+  });
+
   describe('finish', function() {
     let runner;
 

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -423,12 +423,12 @@ describe('browser test runner', function() {
       let eventFn = function() {
         return 'testing additionalBrowserSocketEvents.';
       }
-      let additional_browser_socket_events = {};
-      additional_browser_socket_events[eventName] = eventFn;
+      let custom_browser_socket_events = {};
+      custom_browser_socket_events[eventName] = eventFn;
 
       let socket = new FakeSocket();
       let reporter = new FakeReporter();
-      let config = new Config('ci', { additional_browser_socket_events, reporter: reporter });
+      let config = new Config('ci', { custom_browser_socket_events, reporter: reporter });
       let launcher = new Launcher('ci', { protocol: 'browser' }, config);
       let runner = new BrowserTestRunner(launcher, reporter, null, null, config);
 

--- a/tests/testem_connection_tests.js
+++ b/tests/testem_connection_tests.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const patchEmitterForWildcard = require('../public/testem/testem_connection');
+const expect = require('chai').expect;
+const ServerIO = require('socket.io');
+const ClientIO = require('socket.io-client');
+
+describe('Testem Connection', function() {
+  var serverIo, client;
+  var globals = {};
+
+  function replaceGlobals(newGlobals, originalGlobals) {
+    for (let key in newGlobals) {
+      originalGlobals[key] = global[key];
+      global[key] = newGlobals[key];
+    }
+  }
+  
+  before(function() {
+    serverIo = ServerIO();
+    serverIo.listen(8000);
+  
+    replaceGlobals({
+      io: ClientIO
+    }, globals);
+
+    serverIo.on('connection', function (socket) {
+      socket.emit('foo', { bar: 'baz' })
+    });
+  });
+
+  after(function() {
+    serverIo.close();
+    globals = {};
+  });
+
+  afterEach(function() {
+    client.close();
+  });
+  
+  it('patches emitter for wildcard', function(done) {
+    client = ClientIO('http://localhost:8000');
+    patchEmitterForWildcard(client);
+
+    var eventNameArr = [];
+
+    function check(eventName) {
+      eventNameArr.push(eventName);
+      if(eventNameArr.length === 2) {
+        expect(eventNameArr).to.deep.equal(['*', 'foo']);
+        done();
+      }
+    }
+
+    client.on('*', function(event) {
+      expect(event.data[0]).to.equal('foo');
+      expect(event.data[1]).to.deep.equal({bar: 'baz'});
+      check('*');
+    });
+
+    client.on('foo', function(data) {
+      expect(data).to.deep.equal({bar: 'baz'});
+      check('foo');
+    });
+  });
+});


### PR DESCRIPTION
The changes in this PR enables communication between browser and server for test load balancing and is part of a larger set of changes ember-exam. Here’s a link to the RFC: [Test load balancing.
](https://github.com/ember-cli/ember-exam/issues/134)

1. Binds events defined in an `additionalBrowserSocketEvents` option in testem config. 
- The `additionalBrowserSocketEvents` option is an object which maps event names to event handlers. Currently, there is only one way event communication from testem to browser; this opens communication via events originating from the browser to the testem browser instance. An example:

```js
const events = config.additionalBrowserSocketEvents || {};

events['event-name'] = function () {
   return 'foo';
}
```

* Refer this [link](https://github.com/ember-cli/ember-exam/pull/136/files#diff-87b833f28b68e5193e797dd72f03c7a8R381) for how this is used in load balancing work to handle requests for test modules via events from the browser.

2. Testem_client handles the socket communication between testem’s browser instance and the browser running the test. initSocket() whitelists the socket events the browser will handle. Since we are now allowing custom events to be handled on both sides, we need to open up the socket event handling on the browser to handle all requests.

3. `removeEventCallbacks` removes any duplicate handler functions for an event in an event handler queue in order to have unique handler functions per events.  
Example of usage - https://github.com/ember-cli/ember-exam/pull/136/files#diff-babb5d4fe8ce7520c798eaae9f5393a0R60:
The `module-queue-complete` is attached everytime moduleDone() is executed but the event is emitted once a quene is empty.  Then, the event handler queue for the `module-queue-complete`  event will contain multiple number of unhandled registered callbacks. To prevent it, `removeDuplicateCallbacks` is executed to get rid of any duplicate callbacks for an event.
```js
qunit.moduleDone(function() {
    return new Promise(function(resolve) {
      const resolveCallbackFn = function resolveCallback() {
        resolve();
      }
      Testem.once('next-module-response', function getTestModule(moduleName) {
        if (moduleName !== undefined) {
          loadIndividualModule(moduleName);
        }
        // `removeCallback` removes if the event queue has `module-queue-complete` event with a same callback.
        Testem.removeEventCallbacks('module-queue-complete', resolveCallbackFn);
        resolveCallbackFn();
      });
      Testem.on('module-queue-complete', resolveCallbackFn);
      Testem.emit('get-next-module');
    });
  });
}
```



