### PR TITLE
Add singleRun to `browserTesrRunner` params

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -259,7 +259,9 @@ module.exports = class App extends EventEmitter {
         id: id,
         protocol: 'browser'
       }, this.config).create();
-      browser = new BrowserTestRunner(launcher, this.reporter, this.runnerIndex++, this.config);
+      const singleRun = this.config.get('single_run');
+
+      browser = new BrowserTestRunner(launcher, this.reporter, this.runnerIndex++, singleRun, this.config);
       this.addRunner(browser);
     }
 


### PR DESCRIPTION
[bug fix] Pass `singleRun` parameter to BrowserTestRunner function corresponding to param changes in BrowserTestRunner:
https://github.com/testem/testem/commit/c5c9376cbddbc72935088d9ddbc2b4648cff87ed#diff-5eae7e485342946ae50eea2a59770c09R10
