### PR TITLE
[XUnit] Show info about failed assertion

### DIFF
--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var XmlDom = require('xmldom');
+var indent = require('../strutils').indent;
 
 class XUnitReporter {
   constructor(silent, out, config) {
@@ -76,11 +77,32 @@ class XUnitReporter {
     var error = result.error;
     if (error) {
       var errorNode = document.createElement('error');
-      errorNode.setAttribute('message', error.message);
+      var errorMessage = '';
+      var errorSection = '';
+
+      if (error.hasOwnProperty('actual') && error.hasOwnProperty('expected')) {
+        errorMessage = 'Assertion Failed';
+
+        errorSection += 'Expected:\n';
+        errorSection += indent(error.expected);
+        errorSection += '\n\n';
+
+        errorSection += 'Result:\n';
+        errorSection += indent((error.negative ? 'NOT ' : '') + error.actual);
+        errorSection += '\n\n';
+      }
+
       if (error.stack && !this.excludeStackTraces) {
-        var cdata = document.createCDATASection(error.stack);
+        errorSection += 'Source:\n';
+        errorSection += error.stack;
+      }
+
+      if (errorSection) {
+        var cdata = document.createCDATASection(errorSection);
         errorNode.appendChild(cdata);
       }
+
+      errorNode.setAttribute('message', error.message || errorMessage);
       resultNode.appendChild(errorNode);
     } else if (result.skipped) {
       var skippedNode = document.createElement('skipped');

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -411,7 +411,51 @@ describe('test reporters', function() {
       var output = stream.read().toString();
       assert.match(output, /it didnt work/);
       assert.match(output, /<error message="it crapped out">/);
-      assert.match(output, /CDATA\[Error: it crapped out/);
+      assert.match(output, /CDATA\[Source:\nError: it crapped out/);
+
+      assertXmlIsValid(output);
+    });
+
+    it('outputs assertion error', function() {
+      var reporter = new XUnitReporter(false, stream, config);
+      reporter.report('phantomjs', {
+        name: 'it didnt work',
+        passed: false,
+        error: {
+          message: undefined,
+          actual: 'foo',
+          expected: 'bar',
+          negative: false,
+          stack: (new Error('it crapped out')).stack
+        }
+      });
+      reporter.finish();
+      var output = stream.read().toString();
+      assert.match(output, /it didnt work/);
+      assert.match(output, /<error message="Assertion Failed">/);
+      assert.match(output, /CDATA\[Expected:\n    bar\n\nResult:\n    foo\n\nSource:\nError: it crapped out/);
+
+      assertXmlIsValid(output);
+    });
+
+    it('outputs negative assertion error', function() {
+      var reporter = new XUnitReporter(false, stream, config);
+      reporter.report('phantomjs', {
+        name: 'it didnt work',
+        passed: false,
+        error: {
+          message: undefined,
+          actual: 'foo',
+          expected: 'bar',
+          negative: true,
+          stack: (new Error('it crapped out')).stack
+        }
+      });
+      reporter.finish();
+      var output = stream.read().toString();
+      assert.match(output, /it didnt work/);
+      assert.match(output, /<error message="Assertion Failed">/);
+      assert.match(output, /CDATA\[Expected:\n    bar\n\nResult:\n    NOT foo\n\nSource:\nError: it crapped out/);
 
       assertXmlIsValid(output);
     });


### PR DESCRIPTION
This kind of error comes from testing Ember applications:

`$ ember test --reporter=xunit`

```javascript
test('Homer can login with valid credentials', async function(assert) {
  await login.authenticate({ email: 'homer@example.com' });
  assert.equal(currentURL(), '/moje-pujckyyyyyy');
});
```

There is an example how XUnit report looks like in Bitbucket Pipelines:

#### Before

<img width="850" alt="screenshot 2019-02-16 at 16 26 10" src="https://user-images.githubusercontent.com/112557/52902630-d6bd2c00-3213-11e9-8b11-049fc0f97bd0.png">

#### After

<img width="937" alt="screenshot 2019-02-16 at 17 08 22" src="https://user-images.githubusercontent.com/112557/52902633-dc1a7680-3213-11e9-84a4-e74700454276.png">