### PR TITLE
Improve browser console log & add console.group as additional method to interrupt

### DIFF
--- a/lib/displayutils.js
+++ b/lib/displayutils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const util = require('util');
-
 // Method to format test results.
 const strutils = require('./strutils');
 
@@ -30,14 +28,19 @@ function yamlDisplay(err, logs) {
     .filter(key => key !== 'passed')
     .map(key => key + ': >\n' + strutils.indent(String(err[key])));
   if (logs) {
-    testLogs = ['Log: |'].concat(logs.map(log => strutils.indent(util.inspect(log))));
+    testLogs = ['browser log: |'].concat(
+      logs.map(
+        log => strutils.indent(log.toString())
+      )
+    );
   } else {
     testLogs = [];
   }
   return strutils.indent([
     '---',
     strutils.indent(failed.concat(testLogs).join('\n')),
-    '...'].join('\n'));
+    '...'
+  ].join('\n'));
 }
 
 function resultString(id, prefix, result, quietLogs) {

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -2,9 +2,9 @@
 
 const log = require('npmlog');
 const BrowserTapConsumer = require('../browser_tap_consumer');
-const util = require('util');
 const Bluebird = require('bluebird');
 
+const LogEntry = require('../utils/log-entry');
 const toResult = require('./to-result');
 
 module.exports = class BrowserTestRunner {
@@ -115,12 +115,10 @@ module.exports = class BrowserTestRunner {
     socket.on('browser-console', function(/* ...args */) {
       let args = Array.prototype.slice.call(arguments);
       let type = args.shift();
-      let message = args.map(arg => util.inspect(arg, { depth: null })).join(' ');
-
-      this.logs.push({
-        type: type,
-        text: `${message}\n`
-      });
+      let message = args.join(' ');
+      this.logs.push(
+        new LogEntry(type, message)
+      );
     }.bind(this));
 
     socket.on('disconnect', this.onDisconnect.bind(this));
@@ -211,11 +209,9 @@ module.exports = class BrowserTestRunner {
 
   onGlobalError(msg, url, line) {
     let message = `${msg} at ${url}, line ${line}\n`;
-    this.logs.push({
-      type: 'error',
-      testContext: this.currentTestContext,
-      text: message
-    });
+    this.logs.push(
+      new LogEntry('error', message, this.currentTestContext)
+    );
 
     if (this.currentTestContext && this.currentTestContext.name) {
       if (this.currentTestContext.state === 'executing') {
@@ -266,10 +262,10 @@ module.exports = class BrowserTestRunner {
       }
 
       this.reportResults(new Error(this.exitRequested
-                                   ? "Browser exited on request from test driver"
-                                   : "Browser exited unexpectedly"),
-                         code,
-                         browserProcess);
+        ? 'Browser exited on request from test driver'
+        : 'Browser exited unexpectedly'),
+      code,
+      browserProcess);
     }, 1000);
   }
 

--- a/lib/utils/log-entry.js
+++ b/lib/utils/log-entry.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * A class to a single log entry.
+ *
+ * @class LogEntry
+ */
+module.exports = class LogEntry {
+  constructor(type, text, testContext) {
+    this.type = type;
+    this.text = text;
+    if (testContext) {
+      this.testContext = testContext;
+    }
+  }
+
+  toString() {
+    return this.testContext ?
+      `testContext: ${this.testContext}\n${this.type.toUpperCase()}: ${this.text}` :
+      `${this.type.toUpperCase()}: ${this.text}`;
+  }
+};

--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -268,7 +268,7 @@ var Testem = {
           self.emit('after-tests-complete');
           break;
         default:
-          if (type.indexOf('testem:') === 0) {
+          if (type && type.indexOf('testem:') === 0) {
             self.emit(type, message.data);
           }
           break;
@@ -295,7 +295,7 @@ var Testem = {
   removeEventCallbacks: function(evt, callback) {
     var handlers = this.evtHandlers[evt];
     var removeIdx = [];
-    if (typeof handlers === "undefined") {
+    if (typeof handlers === 'undefined') {
       return;
     }
     for (var i = 0; i < handlers.length; i++) {
@@ -404,7 +404,7 @@ function takeOverConsole() {
       }
     };
   }
-  var methods = ['log', 'warn', 'error', 'info'];
+  var methods = ['log', 'warn', 'error', 'info', 'group'];
   for (var i = 0; i < methods.length; i++) {
     if (window.console && console[methods[i]]) {
       intercept(methods[i]);
@@ -435,10 +435,10 @@ if (typeof window !== 'undefined') {
   // this will prevent browser disconnect failures
   window.alert = function() {
     throw new Error('[Testem] Calling window.alert() in tests is disabled, because it causes testem to fail with browser disconnect error.');
-  }
+  };
 
   window.confirm = function() {
     throw new Error('[Testem] Calling window.confirm() in tests is disabled, because it causes testem to fail with browser disconnect error.');
-  }
+  };
   init();
 }

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -43,7 +43,7 @@ if (typeof window !== 'undefined') {
   addListener = window.addEventListener ?
     function(obj, evt, cb) { obj.addEventListener(evt, cb, false); } :
     function(obj, evt, cb) { obj.attachEvent('on' + evt, cb); };
-    addListener(window, 'message', handleMessage);
+  addListener(window, 'message', handleMessage);
 }
 
 var messageListeners = {};
@@ -164,7 +164,7 @@ function init() {
 function patchEmitterForWildcard(socket) {
   var emit = io.Manager.prototype.emit;
 
-  function onevent (packet) {
+  function onevent(packet) {
     var args = packet.data || [];
     emit.call(this, '*', packet);
     return emit.apply(this, args);
@@ -193,7 +193,7 @@ function initSocket(id) {
     sendMessageToParent('stop-run');
   });
   socket.on('*', function(event) {
-    if (event.data && event.data[0].indexOf('testem:') === 0 ) {
+    if (event.data && event.data[0].indexOf('testem:') === 0) {
       var eventName = event.data[0];
       var eventData = event.data[1];
       sendMessageToParent(eventName, eventData);

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -200,10 +200,10 @@ describe('ci mode app', function() {
         var app = new App(config, function(exitCode) {
           expect(exitCode).to.eq(0);
           expect(reporter.results[0].result.logs).to.deep.eq([
-            { type: 'log', text: '\'log - test\'\n' },
-            { type: 'warn', text: '\'warn - test\'\n' },
-            { type: 'error', text: '\'error - test\'\n' },
-            { type: 'info', text: '\'info - test\'\n' }
+            { type: 'log', text: 'log - test' },
+            { type: 'warn', text: 'warn - test' },
+            { type: 'error', text: 'error - test' },
+            { type: 'info', text: 'info - test' }
           ]);
 
           done();

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -76,12 +76,12 @@ describe('test reporters', function() {
           });
           reporter.finish();
           assert.deepEqual(stream.read().toString().split('\n'), [
-            `ok 1 phantomjs - [3 ms] - it does stuff`,
+            'ok 1 phantomjs - [3 ms] - it does stuff',
             '    ---',
-            '        Log: |',
-            '            \'some log\'',
+            '        browser log: |',
+            '            some log',
             '    ...',
-            `skip 2 phantomjs - [0 ms] - it is skipped`,
+            'skip 2 phantomjs - [0 ms] - it is skipped',
             '',
             '1..2',
             '# tests 2',
@@ -119,20 +119,20 @@ describe('test reporters', function() {
           });
           reporter.finish();
           assert.deepEqual(stream.read().toString().split('\n'), [
-            `ok 1 phantomjs - [3 ms] - it does stuff`,
+            'ok 1 phantomjs - [3 ms] - it does stuff',
             '    ---',
-            '        Log: |',
-            '            \'some log\'',
+            '        browser log: |',
+            '            some log',
             '    ...',
-            `not ok 2 phantomjs - [5 ms] - it fails`,
+            'not ok 2 phantomjs - [5 ms] - it fails',
             '    ---',
             '        message: >',
             '            it crapped out',
-            '        Log: |',
-            '            \'I am a log\'',
-            '            \'Useful information\'',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
             '    ...',
-            `skip 3 phantomjs - [0 ms] - it is skipped`,
+            'skip 3 phantomjs - [0 ms] - it is skipped',
             '',
             '1..3',
             '# tests 3',
@@ -167,8 +167,8 @@ describe('test reporters', function() {
           });
           reporter.finish();
           assert.deepEqual(stream.read().toString().split('\n'), [
-            `ok 1 phantomjs - [3 ms] - it does stuff`,
-            `skip 2 phantomjs - [0 ms] - it is skipped`,
+            'ok 1 phantomjs - [3 ms] - it does stuff',
+            'skip 2 phantomjs - [0 ms] - it is skipped',
             '',
             '1..2',
             '# tests 2',
@@ -206,16 +206,16 @@ describe('test reporters', function() {
           });
           reporter.finish();
           assert.deepEqual(stream.read().toString().split('\n'), [
-            `ok 1 phantomjs - [50 ms] - it does stuff`,
-            `not ok 2 phantomjs - [5 ms] - it fails`,
+            'ok 1 phantomjs - [50 ms] - it does stuff',
+            'not ok 2 phantomjs - [5 ms] - it fails',
             '    ---',
             '        message: >',
             '            it crapped out',
-            '        Log: |',
-            '            \'I am a log\'',
-            '            \'Useful information\'',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
             '    ...',
-            `skip 3 phantomjs - [0 ms] - it is skipped`,
+            'skip 3 phantomjs - [0 ms] - it is skipped',
             '',
             '1..3',
             '# tests 3',
@@ -238,7 +238,7 @@ describe('test reporters', function() {
         });
         reporter.finish();
         assert.deepEqual(stream.read().toString().split('\n'), [
-          `ok 1 phantomjs - [1 ms]`,
+          'ok 1 phantomjs - [1 ms]',
           '',
           '1..1',
           '# tests 1',
@@ -412,7 +412,6 @@ describe('test reporters', function() {
       assert.match(output, /it didnt work/);
       assert.match(output, /<error message="it crapped out">/);
       assert.match(output, /CDATA\[Source:\nError: it crapped out/);
-
       assertXmlIsValid(output);
     });
 
@@ -433,7 +432,7 @@ describe('test reporters', function() {
       var output = stream.read().toString();
       assert.match(output, /it didnt work/);
       assert.match(output, /<error message="Assertion Failed">/);
-      assert.match(output, /CDATA\[Expected:\n    bar\n\nResult:\n    foo\n\nSource:\nError: it crapped out/);
+      assert.match(output, /CDATA\[Expected:\n {4}bar\n\nResult:\n {4}foo\n\nSource:\nError: it crapped out/);
 
       assertXmlIsValid(output);
     });
@@ -455,7 +454,7 @@ describe('test reporters', function() {
       var output = stream.read().toString();
       assert.match(output, /it didnt work/);
       assert.match(output, /<error message="Assertion Failed">/);
-      assert.match(output, /CDATA\[Expected:\n    bar\n\nResult:\n    NOT foo\n\nSource:\nError: it crapped out/);
+      assert.match(output, /CDATA\[Expected:\n {4}bar\n\nResult:\n {4}NOT foo\n\nSource:\nError: it crapped out/);
 
       assertXmlIsValid(output);
     });
@@ -625,7 +624,7 @@ describe('test reporters', function() {
       assert.match(output, /##teamcity\[testFinished name='phantomjs - it handles undefined errors' duration='42']/);
     });
 
-    it('uses comparisonFailure type for comparison errors', function () {
+    it('uses comparisonFailure type for comparison errors', function() {
       var reporter = new TeamcityReporter(false, stream);
 
       reporter.report('firefox', {
@@ -646,13 +645,13 @@ describe('test reporters', function() {
 
     it('generates teamcity lines', function() {
       [
-        ['testStarted', {bar: 'baz'}, `##teamcity[testStarted bar='baz']\n`],
-        ['testIgnored', {bar: 'baz', runDuration: 42}, `##teamcity[testIgnored bar='baz' runDuration='42']\n`],
+        ['testStarted', {bar: 'baz'}, '##teamcity[testStarted bar=\'baz\']\n'],
+        ['testIgnored', {bar: 'baz', runDuration: 42}, '##teamcity[testIgnored bar=\'baz\' runDuration=\'42\']\n'],
       ].forEach(([type, options, expected]) =>
         assert.equal(TeamcityReporter.teamcityLine(type, options), expected));
     });
 
-    it('negates expected for negative assertions', function () {
+    it('negates expected for negative assertions', function() {
       var reporter = new TeamcityReporter(false, stream);
 
       reporter.report('firefox', {

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -422,7 +422,7 @@ describe('browser test runner', function() {
       let eventName = 'testEvent';
       let eventFn = function() {
         return 'testing additionalBrowserSocketEvents.';
-      }
+      };
       let custom_browser_socket_events = {};
       custom_browser_socket_events[eventName] = eventFn;
 

--- a/tests/utils/log-entry_tests.js
+++ b/tests/utils/log-entry_tests.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const LogEntry = require('../../lib/utils/log-entry');
+const expect = require('chai').expect;
+
+describe('log-entry', function() {
+  it('display correct output from toString() with no testContext', function() {
+    const logEntry = new LogEntry('log', 'text');
+    expect(logEntry.toString()).to.equal('LOG: text');
+  });
+
+  it('display correct output from toString() with testContext', function() {
+    const testContext = {
+      name: 'testName',
+      state: 'complete'
+    };
+    const logEntry = new LogEntry('log', 'text', testContext);
+    expect(logEntry.toString()).to.equal(`testContext: ${testContext}\nLOG: text`);
+  });
+});


### PR DESCRIPTION
This change improves the formatting of browser console log & include `console.group` as methods to interrupt from the browser console.

Before:
```
[11:43:41 AM] not ok 1 Chrome 73.0 - [9028 ms] - Acceptance | some test name
    ---
        stack: >
                at Test.test.finish (https://localhost:4444/assets/test-support.js:118724:7)
                at https://localhost:4444/assets/test-support.js:31859:19
                at processTaskQueue (https://localhost:4444/assets/test-support.js:31221:24)
                at https://localhost:4444/assets/test-support.js:31225:8
        message: >
            Test is not isolated (async execution is extending beyond the duration of the test).
            More information has been printed to the console. Please use that information to help in debugging.


        negative: >
            false
        Log: |
            { type: 'log',
              text:
               '\'Error\\n    at Backburner._later (https://localhost:4444/assets/vendor-static.js:27205:38)\\n    at Backburner.later (https://localhost:4444/assets/vendor-static.js:27015:25)\\n    at Function.next (https://localhost:4444/assets/vendor-static.js:16043:29)\\n    at Object.testTyping (https://localhost:4444/assets/tests.js:236632:17)\'\n' }
    ...
```

After:
```
[12:42:18 PM] not ok 1 Chrome 73.0 - [9221 ms] - Acceptance | some test name
    ---
        stack: >
                at Test.test.finish (https://localhost:4444/assets/test-support.js:118724:7)
                at https://localhost:4444/assets/test-support.js:31859:19
                at processTaskQueue (https://localhost:4444/assets/test-support.js:31221:24)
                at https://localhost:4444/assets/test-support.js:31225:8
        message: >
            Test is not isolated (async execution is extending beyond the duration of the test).
            More information has been printed to the console. Please use that information to help in debugging.


        negative: >
            false
        browser log: |
            GROUP: Acceptance | some test name
            GROUP: Scheduled async
            LOG: Error
                at Backburner._later (https://localhost:4444/assets/vendor-static.js:27205:38)
                at Backburner.later (https://localhost:4444/assets/vendor-static.js:27015:25)
                at Function.next (https://localhost:4444/assets/vendor-static.js:16043:29)
                at Object.testTyping (https://localhost:4444/assets/tests.js:236632:17)
```
