### PR TITLE
Fix appveyor test: failing due to null this.process

### DIFF
--- a/lib/utils/process.js
+++ b/lib/utils/process.js
@@ -110,7 +110,15 @@ module.exports = class Process extends EventEmitter {
         log.error('Error killing process ' + self.name + '.', err);
       });
       self._killTimer = setTimeout(self.onKillTimeout.bind(self), self.killTimeout);
-      kill(self.process, sig);
+
+      // Check for self.process to make sure the process is still available.
+      // Otherwise don't do anything.
+      // See https://github.com/testem/testem/pull/1335 for more information.
+      if (self.process) {
+        kill(self.process, sig);
+      } else {
+        log.info('Process ' + this.name + ' already killed.');
+      }
     });
   }
 };


### PR DESCRIPTION
Appveyor fails on `dev mode app in interactive mode allows to restart a run` test.

Progress so far:
The test invokes 3 browsers, and will restart the run and assert the browsers will be killed.
All the browsers fires the `closed` event that sets `this.process = null`.
But for the node instance, the onKillTimeout is set and expires, which tries to access this.process after it has been set to null.