### PR TITLE
BUGFIX:Issue 1336 - non string expected cause failure in xunit reporter

### DIFF
--- a/lib/reporters/xunit_reporter.js
+++ b/lib/reporters/xunit_reporter.js
@@ -84,7 +84,7 @@ class XUnitReporter {
         errorMessage = 'Assertion Failed';
 
         errorSection += 'Expected:\n';
-        errorSection += indent(error.expected);
+        errorSection += indent(`${error.expected}`);
         errorSection += '\n\n';
 
         errorSection += 'Result:\n';

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -437,6 +437,28 @@ describe('test reporters', function() {
       assertXmlIsValid(output);
     });
 
+    it('outputs assertion error with non string expected', function() {
+      var reporter = new XUnitReporter(false, stream, config);
+      reporter.report('phantomjs', {
+        name: 'it didnt work',
+        passed: false,
+        error: {
+          message: undefined,
+          actual: 'foo',
+          expected: false,
+          negative: false,
+          stack: (new Error('it crapped out')).stack
+        }
+      });
+      reporter.finish();
+      var output = stream.read().toString();
+      assert.match(output, /it didnt work/);
+      assert.match(output, /<error message="Assertion Failed">/);
+      assert.match(output, /CDATA\[Expected:\n {4}false\n\nResult:\n {4}foo\n\nSource:\nError: it crapped out/);
+
+      assertXmlIsValid(output);
+    });
+
     it('outputs negative assertion error', function() {
       var reporter = new XUnitReporter(false, stream, config);
       reporter.report('phantomjs', {


### PR DESCRIPTION
This is the fix to https://github.com/testem/testem/issues/1336.

When non strings are given to the indent function the error `TypeError: text.split is not a function` is thrown. This focuses on the specific bug and casts the inputs to strings.