### PR TITLE
core: if the socket disconnects, reconnect with browser-login event with the new socket

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -68,6 +68,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
 
     custom_browser_socket_events    [Object]  an object containing keys corresponding to event names that point to handler functions, which are to be added to the browser socket
     browser_disconnect_timeout   [Number]  timeout to error after disconnect in seconds (10s)
+    browser_reconnect_limit      [Number]  number of browser reconnects to allow (3)
     browser_start_timeout        [Number]  timeout to error after browser start in seconds (30s)
     browser_paths:               [Object]  hash of browsers (keys) to an string of their binary paths (values)
     browser_exes:                [Object]  hash of browsers (keys) to an string of their binary names (values)

--- a/lib/config.js
+++ b/lib/config.js
@@ -502,6 +502,7 @@ Config.prototype.defaults = {
   bail_on_uncaught_error: true,
   browser_start_timeout: 30,
   browser_disconnect_timeout: 10,
+  browser_reconnect_limit: 3,
   client_decycle_depth: 5,
   socket_heartbeat_timeout() {
     let browserDisconnectTimeout = this.get('browser_disconnect_timeout');

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -18,6 +18,7 @@ module.exports = class BrowserTestRunner {
     this.singleRun = singleRun;
     this.logs = [];
     this.currentTestContext = {};
+    this.disconnectCount = 0;
 
     this.pendingTimer = undefined;
     this.onProcessExitTimer = undefined;
@@ -88,7 +89,10 @@ module.exports = class BrowserTestRunner {
 
   tryAttach(browser, id, socket) {
     if (id !== this.launcherId) {
-      return;
+      return false;
+    } else if (this.disconnectCount > this.launcher.config.get('browser_reconnect_limit')) {
+      log.info(`socket reconnection limit has been exceeded, not attaching new socket for browser ${browser} and id ${id}`);
+      return false;
     }
 
     log.info('tryAttach', browser, id);
@@ -140,6 +144,8 @@ module.exports = class BrowserTestRunner {
     tap.on('all-test-results', () => {
       this.socket.emit('tap-all-test-results');
     });
+
+    return true;
   }
 
   name() {
@@ -241,7 +247,8 @@ module.exports = class BrowserTestRunner {
     if (this.finished) { return; }
 
     this.pending = true;
-    let timeout  = this.launcher.config.get('browser_disconnect_timeout');
+    this.disconnectCount += 1;
+    const timeout = this.launcher.config.get('browser_disconnect_timeout');
     this.pendingTimer = setTimeout(() => {
       if (this.finished) {
         return;

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -181,6 +181,9 @@ function initSocket(id) {
     connectStatus = 'connected';
     syncConnectStatus();
   });
+  socket.on('reconnect', function() {
+    this.emit('browser-login', getBrowserName(navigator.userAgent), id);
+  });
   socket.on('disconnect', function() {
     connectStatus = 'disconnected';
     syncConnectStatus();

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -361,12 +361,45 @@ describe('browser test runner', function() {
     });
   });
 
+  describe('tryAttach', function() {
+    let reporter, launcher, runner, socket;
+
+    beforeEach(function() {
+      reporter = new FakeReporter();
+      let config = new Config('ci', {
+        reporter: reporter,
+        browser_disconnect_timeout: 0.1,
+        browser_reconnect_limit: 0
+      });
+      launcher = new Launcher('ci', { protocol: 'browser' }, config);
+      runner = new BrowserTestRunner(launcher, reporter, null, null, config);
+      socket = new FakeSocket();
+    });
+
+    it('exceeding browser reconnect limit should not allow browser reconnect', function(done) {
+      let didReattach = true;
+      launcher.settings.exe = 'node';
+      launcher.settings.args = [path.join(__dirname, '../fixtures/processes/just-running.js')];
+      runner.start(function() {
+        expect(didReattach).to.eq(false);
+        done();
+      });
+
+      runner.tryAttach('browser', launcher.id, socket);
+      runner.onDisconnect();
+      didReattach = runner.tryAttach('browser', launcher.id, socket);
+    });
+  });
+
   describe('onDisconnect', function() {
     let reporter, launcher, runner, socket;
 
     beforeEach(function() {
       reporter = new FakeReporter();
-      let config = new Config('ci', { reporter: reporter, browser_disconnect_timeout: 0.1 });
+      let config = new Config('ci', {
+        reporter: reporter,
+        browser_disconnect_timeout: 0.1
+      });
       launcher = new Launcher('ci', { protocol: 'browser' }, config);
       runner = new BrowserTestRunner(launcher, reporter, null, null, config);
       socket = new FakeSocket();


### PR DESCRIPTION
**core: if the socket disconnects, reconnect with browser-login event with the new socket**

**Scenario:**
Sometimes, socketio disconnects. This emits a `disconnect` event, causing testem to call `onDisconnect`.
`onDisconnect` sets up a timeout with the value from `browser_disconnect_timeout`, which will always expire and report an `Browser timeout exceeded: <x>s` error. The disconnect timeout doesn't seem useful, since nothing is done in between.

**Change:**
Reconnect the browser socket. This improves the resilience from socket disconnecting. 
eg. Help with issues like #1021