### PR TITLE
Add browser-relogin event

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -226,6 +226,7 @@ module.exports = class App extends EventEmitter {
     this.server = new Server(this.config);
     this.server.on('file-requested', this.onFileRequested.bind(this));
     this.server.on('browser-login', this.onBrowserLogin.bind(this));
+    this.server.on('browser-relogin', this.onBrowserRelogin.bind(this));
     this.server.on('server-error', this.onServerError.bind(this));
 
     return this.server.start().asCallback(callback);
@@ -263,6 +264,20 @@ module.exports = class App extends EventEmitter {
 
       browser = new BrowserTestRunner(launcher, this.reporter, this.runnerIndex++, singleRun, this.config);
       this.addRunner(browser);
+    }
+
+    browser.tryAttach(browserName, id, socket);
+  }
+
+  onBrowserRelogin(browserName, id, socket) {
+    let browser = find(this.runners, runner => {
+      // a browser relogin can happen if a client socket was disconnected, which may not be reflected in runner.socket's connected state
+      // or if the socket was nulled by 'onDisconnect'
+      return runner.launcherId === id && (runner.socket || runner.socket === null);
+    });
+
+    if (!browser) {
+      throw new Error(`Relogin from an unknown browser ${browserName} with id ${id}`);
     }
 
     browser.tryAttach(browserName, id, socket);

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -104,7 +104,7 @@ class Server extends EventEmitter {
         },
       })
     );
-    
+
     var serveStaticFile = (req, res) => {
       this.serveStaticFile(req.params[0], req, res);
     };
@@ -381,8 +381,13 @@ class Server extends EventEmitter {
 
   onClientConnected(client) {
     client.once('browser-login', (browserName, id) => {
-      log.info(`New client connected: ${browserName} ${id}`);
+      log.info(`New client connected: ${browserName} ${id} ${client.id}`);
       this.emit('browser-login', browserName, id, client);
+    });
+
+    client.once('browser-relogin', (browserName, id) => {
+      log.info(`Client reconnected: ${browserName} ${id} ${client.id}`);
+      this.emit('browser-relogin', browserName, id, client);
     });
   }
 }

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -182,7 +182,7 @@ function initSocket(id) {
     syncConnectStatus();
   });
   socket.on('reconnect', function() {
-    this.emit('browser-login', getBrowserName(navigator.userAgent), id);
+    this.emit('browser-relogin', getBrowserName(navigator.userAgent), id);
   });
   socket.on('disconnect', function() {
     connectStatus = 'disconnected';

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -285,4 +285,58 @@ describe('App', function() {
       app.start();
     });
   });
+
+  describe('onBrowserRelogin', function() {
+    let tryAttachCalled;
+
+    beforeEach(function() {
+      config = new Config('dev', {}, {
+        reporter: new FakeReporter()
+      });
+      app = new App(config);
+      tryAttachCalled = false;
+      app.runners = [
+        {
+          launcherId: 1,
+          socket: {},
+          tryAttach: () => {
+            tryAttachCalled = true;
+          }
+        },
+        {
+          launcherId: 2,
+          socket: null,
+          tryAttach: () => {
+            tryAttachCalled = true;
+          }
+        },
+        {
+          launcherId: 3,
+          tryAttach: () => {
+            tryAttachCalled = true;
+          }
+        }
+      ];
+    });
+
+    it('calls tryAttach for an existing browser with existing socket', function() {
+      app.onBrowserRelogin('fakeBrowser', 1, {});
+      expect(tryAttachCalled).to.be.true();
+    });
+
+    it('calls tryAttach for an existing browser with null socket', function() {
+      app.onBrowserRelogin('fakeBrowser', 2, {});
+      expect(tryAttachCalled).to.be.true();
+    });
+
+    it('throws error for an existing browser with undefined socket', function() {
+      expect(() => app.onBrowserRelogin('fakeBrowser', 3, {})).to.throw('Relogin from an unknown browser fakeBrowser with id 3');
+      expect(tryAttachCalled).to.be.false();
+    });
+
+    it('throws error for an non-existent browser id', function() {
+      expect(() => app.onBrowserRelogin('fakeBrowser', 4, {})).to.throw('Relogin from an unknown browser fakeBrowser with id 4');
+      expect(tryAttachCalled).to.be.false();
+    });
+  });
 });


### PR DESCRIPTION
_**Problem:**_
The recently added reconnect event handler in #1340 introduced a bug that would cause browser timeout errors due.

This is due the code to find existing browserTestRunner in `onBrowserLogin()` that checks for:
`(!runner.socket || !runner.socket.connected);`

The original assumption was the browserTestRunner would have `runner.socket.connected === false` when a reconnection happens, but that is not the case. Instead, `runner.socket.connected === true` and a new browserTestRunner will be created. This leaves the existing browserTestRunner to hang around, causing a browser timeout error.

**Solution:**
Add a new `browser-relogin` event that is fired on socket reconnection. This event check's existing browserTestRunner whether it had a `runner.socket` or if `runner.socket === null` which is set by `onDisconnect()`.
This allows reuse of existing browserTestRunner.

- [x] Add tests (no tests currently for onBrowserLogin or onBrowserRelogin)