### PR TITLE
Remove testing on node 6 from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
       - libgconf-2-4
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "http://github.com/testem/testem/issues"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": ">= 7.*"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Remove testing on node 6 from travis-ci since it's no longer supported.