### PR TITLE
Adding socket_server_options to testem config file

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -101,6 +101,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
     serve_files:                 [Array]   string or array list of files or file patterns to inject into test playground (defaults to `src_files`)
     serve_files_ignore:          [Array]   string or array list of files or file patterns to exclude from test playground (defaults to `src_files_ignore`)
     single_run                   [Boolean] whether or not test is to be single-run
+    socket_server_options        [Object]  options to start socketio and engineio within testem's server. Options can be found here: https://socket.io/docs/server-api/
     stdout_stream                [Stream]  the stdout stream to use (defaults to `process.stdout`)
     tap_quiet_logs               [Boolean] whether to suppress non-failing logs in TAP reporting
     timeout:                     [Number]  timeout for a browser

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -121,7 +121,11 @@ class Server extends EventEmitter {
     } else {
       this.server = http.createServer(this.express);
     }
-    this.io = socketIO(this.server);
+    let ioOptions;
+    if (this.config.get('socket_server_options')) {
+      ioOptions = this.config.get('socket_server_options');
+    }
+    this.io = socketIO(this.server, ioOptions);
 
     let socketHeartbeatTimeout = this.config.get('socket_heartbeat_timeout');
     this.io.set('heartbeat timeout', socketHeartbeatTimeout * 1000);


### PR DESCRIPTION
This allows us to pass custom options to the socket.io/engine.io instance within the testem server.

The options can be found here: https://socket.io/docs/server-api/

Sample use-case: Customize the `upgradeTimeout` to allow for more time for socket connection to establish:
```
  socket_server_options: {
    upgradeTimeout: 30000,
  },
```