### PR TITLE
[BugFix] On browserRelogin, clear timeouts if socket is not null & log.warn instead of error for reconnection from unknown browser

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -281,7 +281,11 @@ module.exports = class App extends EventEmitter {
       return;
     }
 
-    browser.tryAttach(browserName, id, socket);
+    if (browser.socket !== null) {
+      browser.clearTimeouts();
+    } else {
+      browser.tryAttach(browserName, id, socket);
+    }
   }
 
   addRunner(runner) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -277,7 +277,8 @@ module.exports = class App extends EventEmitter {
     });
 
     if (!browser) {
-      throw new Error(`Relogin from an unknown browser ${browserName} with id ${id}`);
+      log.warn(`Relogin from an unknown browser ${browserName} with id ${id}`);
+      return;
     }
 
     browser.tryAttach(browserName, id, socket);

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -87,6 +87,15 @@ module.exports = class BrowserTestRunner {
     }, this.launcher.config.get('browser_start_timeout') * 1000);
   }
 
+  clearTimeouts() {
+    if (this.startTimer) {
+      clearTimeout(this.startTimer);
+    }
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+    }
+  }
+
   tryAttach(browser, id, socket) {
     if (id !== this.launcherId) {
       return false;
@@ -97,13 +106,7 @@ module.exports = class BrowserTestRunner {
 
     log.info('tryAttach', browser, id);
 
-    if (this.startTimer) {
-      clearTimeout(this.startTimer);
-    }
-    if (this.pendingTimer) {
-      clearTimeout(this.pendingTimer);
-    }
-
+    this.clearTimeouts();
     this.pending = false;
     this.socket = socket;
     this.browser = browser;

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -319,13 +319,13 @@ describe('App', function() {
       ];
     });
 
-    it('calls tryAttach for an existing browser with existing socket', function() {
-      app.onBrowserRelogin('fakeBrowser', 1, {});
-      expect(tryAttachCalled).to.be.true();
+    it('does not call tryAttach for an existing browser with existing socket', function() {
+      app.onBrowserRelogin('fakeBrowser', 2, {});
+      expect(tryAttachCalled).to.be.false();
     });
 
     it('calls tryAttach for an existing browser with null socket', function() {
-      app.onBrowserRelogin('fakeBrowser', 2, {});
+      app.onBrowserRelogin('fakeBrowser', 1, {});
       expect(tryAttachCalled).to.be.true();
     });
   });

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -328,15 +328,5 @@ describe('App', function() {
       app.onBrowserRelogin('fakeBrowser', 2, {});
       expect(tryAttachCalled).to.be.true();
     });
-
-    it('throws error for an existing browser with undefined socket', function() {
-      expect(() => app.onBrowserRelogin('fakeBrowser', 3, {})).to.throw('Relogin from an unknown browser fakeBrowser with id 3');
-      expect(tryAttachCalled).to.be.false();
-    });
-
-    it('throws error for an non-existent browser id', function() {
-      expect(() => app.onBrowserRelogin('fakeBrowser', 4, {})).to.throw('Relogin from an unknown browser fakeBrowser with id 4');
-      expect(tryAttachCalled).to.be.false();
-    });
   });
 });


### PR DESCRIPTION
**Problem:**

1. On browserRelogin event, there are times where the socket is not null. When we call tryAttach() on an existing socket, eventListeners attached from `tryAttach()` will be duplicated. 

2. When there is an unknown browser reconnecting, app.js will throw an error and the run will fail. This could happen if a previous run's browser for some reason did not terminate. 

**Solutions:**
1. On browserRelogin, clear timeouts if socket is not null. This will prevent socket events duplication.

2. `log.warn` instead of throwing an error for reconnection from unknown browser. This way, the current run won't be punished for dangling browsers from previous runs.