### PR TITLE
Add option for strict TAP compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ By default, the TAP reporter outputs _console logs_ (distinct from pass/fail inf
 }
 ```
 
+For improved ergonomics, TAP reporter does not actually strictly adhere to the SPEC by default, reporting 'skip' as a possible status instead of as a directive. To strictly follow the spec use:
+
+```json
+{
+  "tap_strict_spec_compliance": true
+}
+```
+
 ## Other Test Reporters
 
 Testem has other test reporters besides TAP: `dot`, `xunit` and `teamcity`. You can use the `-R` to specify them

--- a/lib/reporters/tap_reporter.js
+++ b/lib/reporters/tap_reporter.js
@@ -8,6 +8,7 @@ module.exports = class TapReporter {
     this.silent = silent;
     this.quietLogs = !!config.get('tap_quiet_logs');
     this.failsOnly = !!config.get('tap_failed_tests_only');
+    this.strictSpecCompliance = !!config.get('tap_strict_spec_compliance');
     this.stoppedOnError = null;
     this.id = 1;
     this.total = 0;
@@ -63,7 +64,7 @@ module.exports = class TapReporter {
    */
   display(prefix, result) {
     if (this.willDisplay(result)) {
-      this.out.write(displayutils.resultString(this.id++, prefix, result, this.quietLogs));
+      this.out.write(displayutils.resultString(this.id++, prefix, result, this.quietLogs, this.strictSpecCompliance));
     }
   }
 

--- a/lib/utils/displayutils.js
+++ b/lib/utils/displayutils.js
@@ -3,7 +3,7 @@
 // Method to format test results.
 const strutils = require('./strutils');
 
-function resultDisplay(id, prefix, result) {
+function resultDisplay(id, prefix, result, strictSpecCompliance) {
   let parts = [];
 
   if (prefix) {
@@ -17,7 +17,27 @@ function resultDisplay(id, prefix, result) {
   }
 
   let line = parts.join(' - ');
-  let output = (result.skipped ? 'skip ' : (result.passed ? 'ok ' : 'not ok ')) + id + ' ' + line;
+
+  let status;
+  let directive;
+
+  if (result.skipped) {
+    if (strictSpecCompliance) {
+      status = 'ok';
+      directive = 'skip';
+    } else {
+      status = 'skip';
+    }
+  } else if (result.passed) {
+    status = 'ok';
+  } else {
+    status = 'not ok';
+  }
+
+  let output = status + ' ' + id + ' ' + line;
+  if (directive) {
+    output += ' # ' + directive;
+  }
 
   return output;
 }
@@ -43,8 +63,8 @@ function yamlDisplay(err, logs) {
   ].join('\n'));
 }
 
-function resultString(id, prefix, result, quietLogs) {
-  let string = resultDisplay(id, prefix, result) + '\n';
+function resultString(id, prefix, result, quietLogs, strictSpecCompliance) {
+  let string = resultDisplay(id, prefix, result, strictSpecCompliance) + '\n';
   if (result.error || (!quietLogs && result.logs && result.logs.length)) {
     string += yamlDisplay(result.error, result.logs) + '\n';
   }

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -301,31 +301,34 @@ describe('App', function() {
           socket: {},
           tryAttach: () => {
             tryAttachCalled = true;
-          }
+          },
+          clearTimeouts: () => { }
         },
         {
           launcherId: 2,
           socket: null,
           tryAttach: () => {
             tryAttachCalled = true;
-          }
+          },
+          clearTimeouts: () => { }
         },
         {
           launcherId: 3,
           tryAttach: () => {
             tryAttachCalled = true;
-          }
+          },
+          clearTimeouts: () => { }
         }
       ];
     });
 
     it('does not call tryAttach for an existing browser with existing socket', function() {
-      app.onBrowserRelogin('fakeBrowser', 2, {});
+      app.onBrowserRelogin('fakeBrowser', 1, {});
       expect(tryAttachCalled).to.be.false();
     });
 
     it('calls tryAttach for an existing browser with null socket', function() {
-      app.onBrowserRelogin('fakeBrowser', 1, {});
+      app.onBrowserRelogin('fakeBrowser', 2, {});
       expect(tryAttachCalled).to.be.true();
     });
   });

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -332,37 +332,37 @@ describe('test reporters', function() {
     });
 
     context('willDisplay', function() {
-      it.only('silent only, no result', function() {
+      it('silent only, no result', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(true, stream, config);
         assert.equal(reporter.willDisplay(), false);
       });
-      it.only('silent only, has result with no error', function() {
+      it('silent only, has result with no error', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(true, stream, config);
         assert.equal(reporter.willDisplay({}), false);
       });
-      it.only('silent only, has result with error', function() {
+      it('silent only, has result with error', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(true, stream, config);
         assert.equal(reporter.willDisplay({error: true}), false);
       });
-      it.only('not silent, no result', function() {
+      it('not silent, no result', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay(), false);
       });
-      it.only('not silent, result w/error', function() {
+      it('not silent, result w/error', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay(), false);
       });
-      it.only('not silent, tap_failed_tests_only, no error', function() {
+      it('not silent, tap_failed_tests_only, no error', function() {
         config = new Config('ci', { tap_failed_tests_only: true });
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay({error: false}), false);
       });
-      it.only('not silent, tap_failed_tests_only, has error', function() {
+      it('not silent, tap_failed_tests_only, has error', function() {
         config = new Config('ci', { tap_failed_tests_only: true });
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay({error: true}), true);

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -331,6 +331,97 @@ describe('test reporters', function() {
       });
     });
 
+    context('with strict spec compliance', function() {
+      beforeEach(function() {
+        config = new Config('ci', { tap_strict_spec_compliance: true });
+      });
+
+      context('without errors', function() {
+        it('writes out TAP', function() {
+          var reporter = new TapReporter(false, stream, config);
+          reporter.report('phantomjs', {
+            name: 'it does stuff',
+            passed: true,
+            logs: ['some log'],
+            runDuration: 3,
+          });
+          reporter.report('phantomjs', {
+            name: 'it is skipped',
+            skipped: true,
+            logs: [],
+            runDuration: 0,
+          });
+          reporter.finish();
+          assert.deepEqual(stream.read().toString().split('\n'), [
+            'ok 1 phantomjs - [3 ms] - it does stuff',
+            '    ---',
+            '        browser log: |',
+            '            some log',
+            '    ...',
+            'ok 2 phantomjs - [0 ms] - it is skipped # skip',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# skip  1',
+            '# fail  0',
+            '',
+            '# ok',
+            ''
+          ]);
+        });
+      });
+
+      context('with errors', function() {
+        it('writes out TAP with failure info', function() {
+          var reporter = new TapReporter(false, stream, config);
+          reporter.report('phantomjs', {
+            name: 'it does stuff',
+            passed: true,
+            logs: ['some log'],
+            runDuration: 3,
+          });
+          reporter.report('phantomjs', {
+            name: 'it fails',
+            passed: false,
+            error: { message: 'it crapped out' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.report('phantomjs', {
+            name: 'it is skipped',
+            skipped: true,
+            logs: [],
+            runDuration: 0,
+          });
+          reporter.finish();
+          assert.deepEqual(stream.read().toString().split('\n'), [
+            'ok 1 phantomjs - [3 ms] - it does stuff',
+            '    ---',
+            '        browser log: |',
+            '            some log',
+            '    ...',
+            'not ok 2 phantomjs - [5 ms] - it fails',
+            '    ---',
+            '        message: >',
+            '            it crapped out',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            'ok 3 phantomjs - [0 ms] - it is skipped # skip',
+            '',
+            '1..3',
+            '# tests 3',
+            '# pass  1',
+            '# skip  1',
+            '# fail  1',
+            ''
+          ]);
+        });
+      });
+    });
+
     context('willDisplay', function() {
       it('silent only, no result', function() {
         config = new Config('ci', {});


### PR DESCRIPTION
Currently includes #1399 so tests will run. Should be rebased once merged.

---

This resolves the debate at https://github.com/testem/testem/pull/1101#discussion_r108010346 by side-stepping the issue.