### PR TITLE
QUnit.todo Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ By default, the TAP reporter outputs _console logs_ (distinct from pass/fail inf
 }
 ```
 
+For improved ergonomics, TAP reporter does not actually strictly adhere to the SPEC by default, reporting 'skip' as a possible status instead of as a directive. To strictly follow the spec use:
+
+```json
+{
+  "tap_strict_spec_compliance": true
+}
+```
+
 ## Other Test Reporters
 
 Testem has other test reporters besides TAP: `dot`, `xunit` and `teamcity`. You can use the `-R` to specify them

--- a/examples/qunit_lazy/package.json
+++ b/examples/qunit_lazy/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "qunitjs": "^1.20.0"
+    "qunit": "^2.2"
   },
   "scripts": {
     "test": "node ../../testem.js ci -P 10"

--- a/examples/qunit_lazy/test.html
+++ b/examples/qunit_lazy/test.html
@@ -2,9 +2,9 @@
 <html>
 <head>
 <title>Test'em</title>
-<link rel="stylesheet" href="/node_modules/qunitjs/qunit/qunit.css">
+<link rel="stylesheet" href="/node_modules/qunit/qunit/qunit.css">
 <script src="/testem.js"></script>
-<script src="/node_modules/qunitjs/qunit/qunit.js"></script>
+<script src="/node_modules/qunit/qunit/qunit.js"></script>
 <script src="hello.js"></script>
 <script src="tests.js"></script>
 <script>

--- a/examples/qunit_lazy/tests.js
+++ b/examples/qunit_lazy/tests.js
@@ -5,3 +5,13 @@ QUnit.test('says hello world', function(assert){
 QUnit.test('says hello to person', function(assert){
     assert.equal(hello('Bob'), 'hello Bob', 'should equal hello Bob');
 });
+
+QUnit.todo('failing todo', function(assert){
+    assert.ok(false, 'should be true');
+});
+
+// This will cause integration tests to fail because QUnit will report passing todos
+// as failures (since you should just mark them as a normal test if they pass).
+// QUnit.todo('passing todo', function(assert){
+//     assert.ok(true, 'should be true');
+// });

--- a/lib/reporters/dev/test_results.js
+++ b/lib/reporters/dev/test_results.js
@@ -25,7 +25,7 @@ var TestResults = Backbone.Model.extend({
     total++;
     if (result.pending) {
       pending++;
-    } else if (result.failed === 0) {
+    } else if ((result.failed === 0 && !result.todo) || (result.failed > 0 && result.todo)) {
       passed++;
     } else {
       failed++;

--- a/lib/reporters/dot_reporter.js
+++ b/lib/reporters/dot_reporter.js
@@ -12,6 +12,7 @@ module.exports = class DotReporter {
     this.total = 0;
     this.pass = 0;
     this.skipped = 0;
+    this.todo = 0;
     this.results = [];
     this.startTime = new Date();
     this.endTime = null;
@@ -30,8 +31,10 @@ module.exports = class DotReporter {
     this.total++;
     if (data.skipped) {
       this.skipped++;
-    } else if (data.passed) {
+    } else if (data.passed && !data.todo) {
       this.pass++;
+    } else if (!data.passed && data.todo) {
+      this.todo++;
     }
   }
 
@@ -43,8 +46,10 @@ module.exports = class DotReporter {
       this.currentLineChars = 0;
       this.out.write('\n  ');
     }
-    if (result.passed) {
+    if (result.passed && !result.todo) {
       this.out.write('.');
+    } else if (!result.passed && result.todo) {
+      this.out.write('T');
     } else if (result.skipped) {
       this.out.write('*');
     } else {

--- a/lib/reporters/tap_reporter.js
+++ b/lib/reporters/tap_reporter.js
@@ -8,6 +8,7 @@ module.exports = class TapReporter {
     this.silent = silent;
     this.quietLogs = !!config.get('tap_quiet_logs');
     this.failsOnly = !!config.get('tap_failed_tests_only');
+    this.strictSpecCompliance = !!config.get('tap_strict_spec_compliance');
     this.stoppedOnError = null;
     this.id = 1;
     this.total = 0;
@@ -63,7 +64,7 @@ module.exports = class TapReporter {
    */
   display(prefix, result) {
     if (this.willDisplay(result)) {
-      this.out.write(displayutils.resultString(this.id++, prefix, result, this.quietLogs));
+      this.out.write(displayutils.resultString(this.id++, prefix, result, this.quietLogs, this.strictSpecCompliance));
     }
   }
 

--- a/lib/reporters/tap_reporter.js
+++ b/lib/reporters/tap_reporter.js
@@ -14,6 +14,7 @@ module.exports = class TapReporter {
     this.total = 0;
     this.pass = 0;
     this.skipped = 0;
+    this.todo = 0;
     this.results = [];
     this.errors = [];
     this.logs = [];
@@ -26,10 +27,13 @@ module.exports = class TapReporter {
     });
     this.display(prefix, data);
     this.total++;
+
     if (data.skipped) {
       this.skipped++;
-    } else if (data.passed) {
+    } else if (data.passed && !data.todo) {
       this.pass++;
+    } else if (!data.passed && data.todo) {
+      this.todo++;
     }
   }
 
@@ -39,10 +43,11 @@ module.exports = class TapReporter {
       '# tests ' + this.total,
       '# pass  ' + this.pass,
       '# skip  ' + this.skipped,
-      '# fail  ' + (this.total - this.pass - this.skipped)
+      '# todo  ' + this.todo,
+      '# fail  ' + (this.total - this.pass - this.skipped - this.todo)
     ];
 
-    if (this.pass + this.skipped === this.total) {
+    if (this.pass + this.skipped + this.todo === this.total) {
       lines.push('');
       lines.push('# ok');
     }

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -174,6 +174,12 @@ module.exports = class BrowserTestRunner {
     let errItems = (result.items || [])
       .filter(item => !item.passed);
 
+    let error = errItems[0];
+
+    if (!error && result.todo && result.passed) {
+      error = { message: 'expected todo to not pass' };
+    }
+
     this.reporter.report(this.browser, {
       passed: !result.failed && !result.skipped,
       name: result.name,
@@ -181,7 +187,7 @@ module.exports = class BrowserTestRunner {
       todo: result.todo,
       runDuration: result.runDuration,
       logs: this.logs,
-      error: errItems[0],
+      error: error,
       launcherId: this.launcherId,
       failed: result.failed,
       pending: result.pending,

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -178,6 +178,7 @@ module.exports = class BrowserTestRunner {
       passed: !result.failed && !result.skipped,
       name: result.name,
       skipped: result.skipped,
+      todo: result.todo,
       runDuration: result.runDuration,
       logs: this.logs,
       error: errItems[0],

--- a/lib/utils/displayutils.js
+++ b/lib/utils/displayutils.js
@@ -3,7 +3,7 @@
 // Method to format test results.
 const strutils = require('./strutils');
 
-function resultDisplay(id, prefix, result) {
+function resultDisplay(id, prefix, result, strictSpecCompliance) {
   let parts = [];
 
   if (prefix) {
@@ -17,7 +17,27 @@ function resultDisplay(id, prefix, result) {
   }
 
   let line = parts.join(' - ');
-  let output = (result.skipped ? 'skip ' : (result.passed ? 'ok ' : 'not ok ')) + id + ' ' + line;
+
+  let status;
+  let directive;
+
+  if (result.skipped) {
+    if (strictSpecCompliance) {
+      status = 'ok';
+      directive = 'skip';
+    } else {
+      status = 'skip';
+    }
+  } else if (result.passed) {
+    status = 'ok';
+  } else {
+    status = 'not ok';
+  }
+
+  let output = status + ' ' + id + ' ' + line;
+  if (directive) {
+    output += ' # ' + directive;
+  }
 
   return output;
 }
@@ -43,8 +63,8 @@ function yamlDisplay(err, logs) {
   ].join('\n'));
 }
 
-function resultString(id, prefix, result, quietLogs) {
-  let string = resultDisplay(id, prefix, result) + '\n';
+function resultString(id, prefix, result, quietLogs, strictSpecCompliance) {
+  let string = resultDisplay(id, prefix, result, strictSpecCompliance) + '\n';
   if (result.error || (!quietLogs && result.logs && result.logs.length)) {
     string += yamlDisplay(result.error, result.logs) + '\n';
   }

--- a/lib/utils/displayutils.js
+++ b/lib/utils/displayutils.js
@@ -28,8 +28,23 @@ function resultDisplay(id, prefix, result, strictSpecCompliance) {
     } else {
       status = 'skip';
     }
-  } else if (result.passed) {
+  } else if (result.passed && !result.todo) {
     status = 'ok';
+  } else if (!result.passed && result.todo) {
+    if (strictSpecCompliance) {
+      status = 'not ok';
+      directive = 'todo';
+    } else {
+      status = 'todo';
+    }
+  } else if (result.passed && result.todo) {
+    if (strictSpecCompliance) {
+      status = 'ok';
+      directive = 'bonus';
+    } else {
+      // Not expected to pass
+      status = 'not ok';
+    }
   } else {
     status = 'not ok';
   }

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -36,6 +36,7 @@ class Reporter {
     this.total = 0;
     this.passed = 0;
     this.skipped = 0;
+    this.todo = 0;
 
     if (path) {
       this.reportFile = new ReportFile(path);
@@ -79,15 +80,17 @@ class Reporter {
   }
 
   hasPassed() {
-    return this.total <= ((this.passed || 0) + (this.skipped || 0));
+    return this.total <= ((this.passed || 0) + (this.skipped || 0) + (this.todo || 0));
   }
 
   report(name, result) {
     this.total++;
     if (result.skipped) {
       this.skipped++;
-    } else if (result.passed) {
+    } else if (result.passed && !result.todo) {
       this.passed++;
+    } else if (!result.passed && result.todo) {
+      this.todo++;
     }
 
     this.reporters.forEach(reporter => {

--- a/public/testem/qunit_adapter.js
+++ b/public/testem/qunit_adapter.js
@@ -24,6 +24,7 @@ function qunitAdapter() {
     failed: 0,
     passed: 0,
     skipped: 0,
+    todo: 0,
     total: 0,
     tests: []
   };
@@ -91,6 +92,7 @@ function qunitAdapter() {
     currentTest.failed = params.failed;
     currentTest.passed = params.passed;
     currentTest.skipped = params.skipped;
+    currentTest.todo = params.todo;
     currentTest.total = params.total;
     currentTest.runDuration = params.runtime;
     currentTest.testId = params.testId;
@@ -99,7 +101,7 @@ function qunitAdapter() {
 
     if (currentTest.skipped) {
       results.skipped++;
-    } else if (currentTest.failed > 0) {
+    } else if (results.failed > 0 && !results.todo) {
       results.failed++;
     } else {
       results.passed++;

--- a/tests/app_tests.js
+++ b/tests/app_tests.js
@@ -301,31 +301,34 @@ describe('App', function() {
           socket: {},
           tryAttach: () => {
             tryAttachCalled = true;
-          }
+          },
+          clearTimeouts: () => { }
         },
         {
           launcherId: 2,
           socket: null,
           tryAttach: () => {
             tryAttachCalled = true;
-          }
+          },
+          clearTimeouts: () => { }
         },
         {
           launcherId: 3,
           tryAttach: () => {
             tryAttachCalled = true;
-          }
+          },
+          clearTimeouts: () => { }
         }
       ];
     });
 
     it('does not call tryAttach for an existing browser with existing socket', function() {
-      app.onBrowserRelogin('fakeBrowser', 2, {});
+      app.onBrowserRelogin('fakeBrowser', 1, {});
       expect(tryAttachCalled).to.be.false();
     });
 
     it('calls tryAttach for an existing browser with null socket', function() {
-      app.onBrowserRelogin('fakeBrowser', 1, {});
+      app.onBrowserRelogin('fakeBrowser', 2, {});
       expect(tryAttachCalled).to.be.true();
     });
   });

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -332,37 +332,37 @@ describe('test reporters', function() {
     });
 
     context('willDisplay', function() {
-      it.only('silent only, no result', function() {
+      it('silent only, no result', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(true, stream, config);
         assert.equal(reporter.willDisplay(), false);
       });
-      it.only('silent only, has result with no error', function() {
+      it('silent only, has result with no error', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(true, stream, config);
         assert.equal(reporter.willDisplay({}), false);
       });
-      it.only('silent only, has result with error', function() {
+      it('silent only, has result with error', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(true, stream, config);
         assert.equal(reporter.willDisplay({error: true}), false);
       });
-      it.only('not silent, no result', function() {
+      it('not silent, no result', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay(), false);
       });
-      it.only('not silent, result w/error', function() {
+      it('not silent, result w/error', function() {
         config = new Config('ci', {});
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay(), false);
       });
-      it.only('not silent, tap_failed_tests_only, no error', function() {
+      it('not silent, tap_failed_tests_only, no error', function() {
         config = new Config('ci', { tap_failed_tests_only: true });
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay({error: false}), false);
       });
-      it.only('not silent, tap_failed_tests_only, has error', function() {
+      it('not silent, tap_failed_tests_only, has error', function() {
         config = new Config('ci', { tap_failed_tests_only: true });
         var reporter = new TapReporter(false, stream, config);
         assert.equal(reporter.willDisplay({error: true}), true);

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -331,6 +331,97 @@ describe('test reporters', function() {
       });
     });
 
+    context('with strict spec compliance', function() {
+      beforeEach(function() {
+        config = new Config('ci', { tap_strict_spec_compliance: true });
+      });
+
+      context('without errors', function() {
+        it('writes out TAP', function() {
+          var reporter = new TapReporter(false, stream, config);
+          reporter.report('phantomjs', {
+            name: 'it does stuff',
+            passed: true,
+            logs: ['some log'],
+            runDuration: 3,
+          });
+          reporter.report('phantomjs', {
+            name: 'it is skipped',
+            skipped: true,
+            logs: [],
+            runDuration: 0,
+          });
+          reporter.finish();
+          assert.deepEqual(stream.read().toString().split('\n'), [
+            'ok 1 phantomjs - [3 ms] - it does stuff',
+            '    ---',
+            '        browser log: |',
+            '            some log',
+            '    ...',
+            'ok 2 phantomjs - [0 ms] - it is skipped # skip',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# skip  1',
+            '# fail  0',
+            '',
+            '# ok',
+            ''
+          ]);
+        });
+      });
+
+      context('with errors', function() {
+        it('writes out TAP with failure info', function() {
+          var reporter = new TapReporter(false, stream, config);
+          reporter.report('phantomjs', {
+            name: 'it does stuff',
+            passed: true,
+            logs: ['some log'],
+            runDuration: 3,
+          });
+          reporter.report('phantomjs', {
+            name: 'it fails',
+            passed: false,
+            error: { message: 'it crapped out' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.report('phantomjs', {
+            name: 'it is skipped',
+            skipped: true,
+            logs: [],
+            runDuration: 0,
+          });
+          reporter.finish();
+          assert.deepEqual(stream.read().toString().split('\n'), [
+            'ok 1 phantomjs - [3 ms] - it does stuff',
+            '    ---',
+            '        browser log: |',
+            '            some log',
+            '    ...',
+            'not ok 2 phantomjs - [5 ms] - it fails',
+            '    ---',
+            '        message: >',
+            '            it crapped out',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            'ok 3 phantomjs - [0 ms] - it is skipped # skip',
+            '',
+            '1..3',
+            '# tests 3',
+            '# pass  1',
+            '# skip  1',
+            '# fail  1',
+            ''
+          ]);
+        });
+      });
+    });
+
     context('willDisplay', function() {
       it('silent only, no result', function() {
         config = new Config('ci', {});

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -87,6 +87,7 @@ describe('test reporters', function() {
             '# tests 2',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
             '# fail  0',
             '',
             '# ok',
@@ -138,6 +139,7 @@ describe('test reporters', function() {
             '# tests 3',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
             '# fail  1',
             ''
           ]);
@@ -174,6 +176,7 @@ describe('test reporters', function() {
             '# tests 2',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
             '# fail  0',
             '',
             '# ok',
@@ -221,6 +224,56 @@ describe('test reporters', function() {
             '# tests 3',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
+            '# fail  1',
+            ''
+          ]);
+        });
+      });
+
+      context('with todos', function() {
+        it('writes out TAP with failure info', function() {
+          var reporter = new TapReporter(false, stream, config);
+          reporter.report('phantomjs', {
+            name: 'it is a failing todo',
+            passed: false,
+            todo: true,
+            error: { message: 'it crapped out' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.report('phantomjs', {
+            name: 'it is a passing todo',
+            passed: true,
+            todo: true,
+            error: { message: 'expected todo to not pass' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.finish();
+          assert.deepEqual(stream.read().toString().split('\n'), [
+            'todo 1 phantomjs - [5 ms] - it is a failing todo',
+            '    ---',
+            '        message: >',
+            '            it crapped out',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            'not ok 2 phantomjs - [5 ms] - it is a passing todo',
+            '    ---',
+            '        message: >',
+            '            expected todo to not pass',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  0',
+            '# skip  0',
+            '# todo  1',
             '# fail  1',
             ''
           ]);
@@ -244,6 +297,7 @@ describe('test reporters', function() {
           '# tests 1',
           '# pass  1',
           '# skip  0',
+          '# todo  0',
           '# fail  0',
           '',
           '# ok',
@@ -279,6 +333,7 @@ describe('test reporters', function() {
             '# tests 2',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
             '# fail  0',
             '',
             '# ok',
@@ -324,6 +379,56 @@ describe('test reporters', function() {
             '# tests 3',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
+            '# fail  1',
+            ''
+          ]);
+        });
+      });
+
+      context('with todos', function() {
+        it('writes out TAP with failure info', function() {
+          var reporter = new TapReporter(false, stream, config);
+          reporter.report('phantomjs', {
+            name: 'it is a failing todo',
+            passed: false,
+            todo: true,
+            error: { message: 'it crapped out' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.report('phantomjs', {
+            name: 'it is a passing todo',
+            passed: true,
+            todo: true,
+            error: { message: 'expected todo to not pass' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.finish();
+          assert.deepEqual(stream.read().toString().split('\n'), [
+            'todo 1 phantomjs - [5 ms] - it is a failing todo',
+            '    ---',
+            '        message: >',
+            '            it crapped out',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            'not ok 2 phantomjs - [5 ms] - it is a passing todo',
+            '    ---',
+            '        message: >',
+            '            expected todo to not pass',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  0',
+            '# skip  0',
+            '# todo  1',
             '# fail  1',
             ''
           ]);
@@ -364,6 +469,7 @@ describe('test reporters', function() {
             '# tests 2',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
             '# fail  0',
             '',
             '# ok',
@@ -415,6 +521,56 @@ describe('test reporters', function() {
             '# tests 3',
             '# pass  1',
             '# skip  1',
+            '# todo  0',
+            '# fail  1',
+            ''
+          ]);
+        });
+      });
+
+      context('with todos', function() {
+        it('writes out TAP with failure info', function() {
+          var reporter = new TapReporter(false, stream, config);
+          reporter.report('phantomjs', {
+            name: 'it is a failing todo',
+            passed: false,
+            todo: true,
+            error: { message: 'it crapped out' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.report('phantomjs', {
+            name: 'it is a passing todo',
+            passed: true,
+            todo: true,
+            error: { message: 'expected todo to not pass' },
+            logs: ['I am a log', 'Useful information'],
+            runDuration: 5,
+          });
+          reporter.finish();
+          assert.deepEqual(stream.read().toString().split('\n'), [
+            'not ok 1 phantomjs - [5 ms] - it is a failing todo # todo',
+            '    ---',
+            '        message: >',
+            '            it crapped out',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            'ok 2 phantomjs - [5 ms] - it is a passing todo # bonus',
+            '    ---',
+            '        message: >',
+            '            expected todo to not pass',
+            '        browser log: |',
+            '            I am a log',
+            '            Useful information',
+            '    ...',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  0',
+            '# skip  0',
+            '# todo  1',
             '# fail  1',
             ''
           ]);
@@ -525,6 +681,35 @@ describe('test reporters', function() {
         var output = stream.read().toString();
         assert.match(output, / {2}\*/);
         assert.match(output, /1 tests complete \([0-9]+ ms\)/);
+      });
+    });
+
+    context('with todo', function() {
+      it('writes out summary', function() {
+        var stream = new PassThrough();
+        var reporter = new DotReporter(false, stream);
+        reporter.report('phantomjs', {
+          name: 'it is a failing todo',
+          passed: false,
+          todo: true,
+          error: {
+            actual: 'Seven',
+            expected: 7,
+            message: 'This should be a number',
+            stack: 'trace'
+          }
+        });
+        reporter.report('phantomjs', {
+          name: 'it is a passing todo',
+          passed: true,
+          todo: true,
+          error: { message: 'expected todo to not pass' },
+          logs: []
+        });
+        reporter.finish();
+        var output = stream.read().toString();
+        assert.match(output, / {2}TF/);
+        assert.match(output, /2 tests complete \([0-9]+ ms\)/);
       });
     });
 

--- a/tests/fixtures/todo/test.html
+++ b/tests/fixtures/todo/test.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<title>Test Page</title>
+<script src="/testem.js"></script>
+<script src="//code.jquery.com/qunit/qunit-2.9.2.js"></script>
+<script>
+Testem.hookIntoTestFramework();
+</script>
+<script src="test.js"></script>
+<link rel="stylesheet" href="//code.jquery.com/qunit/qunit-2.9.2.css"/>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/tests/fixtures/todo/test.js
+++ b/tests/fixtures/todo/test.js
@@ -1,0 +1,10 @@
+/* globals QUnit */
+'use strict';
+
+QUnit.todo('failing todo', function(assert) {
+  assert.ok(false, 'should be true');
+});
+
+QUnit.todo('passing todo', function(assert) {
+  assert.ok(true, 'should be true');
+});

--- a/tests/fixtures/todo/testem.json
+++ b/tests/fixtures/todo/testem.json
@@ -1,0 +1,6 @@
+{
+  "test_page": "test.html",
+  "src_files": [
+    "*.js"
+  ]
+}


### PR DESCRIPTION
Currently includes #1398 and #1399. Should be rebased once those are merged.

---

Supersedes #1101

Includes support for TAP, Dot, and dev reporters. May not work properly with other options.
