### PR TITLE
Adding chrome_stderr_info_only option to config

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -73,6 +73,7 @@ Chrome, Chrome Canary, Chromium, Firefox, IE, Opera, PhantomJS, Safari, Safari T
     browser_paths:               [Object]  hash of browsers (keys) to an string of their binary paths (values)
     browser_exes:                [Object]  hash of browsers (keys) to an string of their binary names (values)
     browser_args:                [Object]  hash of browsers (keys) to an array of their custom arguments (values) or an object with a mode and arguments
+    chrome_stderr_info_only:     [Boolean] only display console logs from Chrome's stderr when true
     client_decycle_depth         [Number]  number of times to recurse while decycling objects within the client (5)
     config_dir:                  [Path]    directory to use as root for resolving configs, if different than cwd
     css_files:                   [Array]   string or array of additional stylesheets to include

--- a/lib/runners/to-result.js
+++ b/lib/runners/to-result.js
@@ -35,12 +35,38 @@ module.exports = function toResult(launcherId, err, code, runnerProcess, config,
   }
 
   if (runnerProcess && runnerProcess.stderr) {
+    const stderr = runnerProcess.stderr;
     logs.push({
       type: 'error',
-      text: runnerProcess.stderr
+      text: stderr
     });
+    message += 'Stderr: \n ';
 
-    message += 'Stderr: \n ' + runnerProcess.stderr + '\n';
+    if (runnerProcess.name !== 'Chrome' || !config.get('chrome_stderr_info_only')) {
+      message += `${stderr} \n`;
+    } else {
+      // Only add stderr entries from INFO class of logs. Examples of chrome logs:
+      // [0414/233637.067608:INFO:cpu_info.cc(53)] Available number of cores: 16
+      // [0414/011733.473770:INFO:CONSOLE(965)] "image-media-file-reader-waiter: Error
+      //     at TestWaiterImpl.beginAsync (https://localhost:4444/assets/vendor.js:211718:19)
+      //     at waitForPromise (https://localhost:4444/assets/vendor.js:211984:22)
+      // [0414/233637.201815:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/assets/index.html
+      const stderrArray = runnerProcess.stderr.split('\n');
+      const chromeLogPrefixRegex = /\[\d{4}\/\d{6}.\d{6}:\w*:.*\(\d*\)\].*/;
+      let infoLogPrefer = false;
+
+      stderrArray.forEach(stderr => {
+        const containsChromeLogPrefex = chromeLogPrefixRegex.test(stderr);
+        if (containsChromeLogPrefex && stderr.includes('INFO:')) {
+          message += `${stderr} \n`;
+          infoLogPrefer = true;
+        } else if (containsChromeLogPrefex) {
+          infoLogPrefer = false;
+        } else if (infoLogPrefer) {
+          message += `${stderr} \n`;
+        }
+      });
+    }
   }
 
   if (runnerProcess && runnerProcess.stdout) {

--- a/lib/runners/to-result.js
+++ b/lib/runners/to-result.js
@@ -43,7 +43,7 @@ module.exports = function toResult(launcherId, err, code, runnerProcess, config,
     message += 'Stderr: \n ';
 
     if (runnerProcess.name !== 'Chrome' || !config.get('chrome_stderr_info_only')) {
-      message += `${stderr} \n`;
+      message += `${stderr}\n`;
     } else {
       // Only add stderr entries from INFO class of logs. Examples of chrome logs:
       // [0414/233637.067608:INFO:cpu_info.cc(53)] Available number of cores: 16

--- a/tests/runners/to-result_tests.js
+++ b/tests/runners/to-result_tests.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const toResult = require('../../lib/runners/to-result');
+const assert = require('chai').assert;
+
+const Config = require('../../lib/config');
+const dummyChromeStderrOutput = `
+[0414/010630.566144:INFO:cpu_info.cc(53)] Available number of cores: 32
+[0414/010630.566233:VERBOSE1:zygote_main_linux.cc(217)] ZygoteMain: initializing 0 fork delegates
+[0414/010630.574976:VERBOSE1:webrtc_internals.cc(120)] Could not get the download directory.
+
+DevTools listening on ws://127.0.0.1:37715/devtools/browser/ad696654-9a10-4236-b4d5-a44fa17f988f
+[0414/010630.582057:VERBOSE1:breakpad_linux.cc(2070)] Non Browser crash dumping enabled for: renderer
+[0414/010630.582186:VERBOSE1:simple_index_file.cc(599)] Simple Cache Index is being restored from disk.
+[0414/010630.601512:ERROR:paint_controller.cc(548)] PaintController::FinishCycle() completed
+[0414/010725.025511:INFO:CONSOLE(965)] "Hello World"
+[0414/010725.038506:INFO:CONSOLE(965)] "Error while processing route: random.route Cannot read property 'attributes' of undefined TypeError: Cannot read property 'attributes' of undefined
+    at Class._normalizeProjection (https://localhost:4444/assets/vendor.js:100:36)
+    at Class._normalizeProjections (https://localhost:4444/assets/vendor.js:120:14)`;
+const infoOnlyChromeStderr = `
+ [0414/010630.566144:INFO:cpu_info.cc(53)] Available number of cores: 32
+[0414/010725.025511:INFO:CONSOLE(965)] "Hello World"
+[0414/010725.038506:INFO:CONSOLE(965)] "Error while processing route: random.route Cannot read property 'attributes' of undefined TypeError: Cannot read property 'attributes' of undefined
+    at Class._normalizeProjection (https://localhost:4444/assets/vendor.js:100:36)
+    at Class._normalizeProjections (https://localhost:4444/assets/vendor.js:120:14)
+`;
+
+describe.only('toResult', function() {
+  describe('for Chrome', function() {
+    it('only info logs are displayed when chrome_stderr_info_only is true', function() {
+      const config = new Config('ci', {
+        chrome_stderr_info_only: true,
+      });
+      const browserProcess = {
+        name: 'Chrome',
+        stderr: dummyChromeStderrOutput,
+      };
+      const result = toResult(1, new Error('some error'), 0, browserProcess, config);
+
+      assert(result.error.message, `Error: some error\nStderr:\n${infoOnlyChromeStderr}`);
+    });
+
+    it('all logs are displayed when chrome_stderr_info_only is false', function() {
+      const config = new Config('ci', {
+        chrome_stderr_info_only: false,
+      });
+      const browserProcess = {
+        name: 'Chrome',
+        stderr: dummyChromeStderrOutput,
+      };
+      const result = toResult(1, new Error('some error'), 0, browserProcess, config);
+
+      assert(result.error.message, `Error: some error\nStderr:\n${dummyChromeStderrOutput}`);
+    });
+  });
+  describe('for other browsers', function() {
+    it('all logs are displayed when chrome_stderr_info_only is true', function() {
+      const config = new Config('ci', {
+        chrome_stderr_info_only: true,
+      });
+      const browserProcess = {
+        name: 'Firefox',
+        stderr: dummyChromeStderrOutput,
+      };
+      const result = toResult(1, new Error('some error'), 0, browserProcess, config);
+
+      assert(result.error.message, `Error: some error\nStderr:\n${dummyChromeStderrOutput}`);
+    });
+
+    it('all logs are displayed when chrome_stderr_info_only is false', function() {
+      const config = new Config('ci', {
+        chrome_stderr_info_only: false,
+      });
+      const browserProcess = {
+        name: 'Firefox',
+        stderr: dummyChromeStderrOutput,
+      };
+      const result = toResult(1, new Error('some error'), 0, browserProcess, config);
+
+      assert(result.error.message, `Error: some error\nStderr:\n${dummyChromeStderrOutput}`);
+    });
+  });
+});

--- a/tests/runners/to-result_tests.js
+++ b/tests/runners/to-result_tests.js
@@ -25,7 +25,7 @@ const infoOnlyChromeStderr = `
     at Class._normalizeProjections (https://localhost:4444/assets/vendor.js:120:14)
 `;
 
-describe.only('toResult', function() {
+describe('toResult', function() {
   describe('for Chrome', function() {
     it('only info logs are displayed when chrome_stderr_info_only is true', function() {
       const config = new Config('ci', {


### PR DESCRIPTION
Adding chrome_stderr_info_only option to config

This option will disregard all non INFO: chrome debug logs when stderr dumped to the reporter.
This removes a significant number of debug logs from chrome's stderr, which can be found in `chrome_debug.log`, from reporter output.

eg:
Before
```
        message: >
            Error: Browser exited on request from test driver
            Error while executing test: Integration | Component | blah: some test name.
            Non-zero exit code: null
            Stderr: 
             [0414/010630.566144:INFO:cpu_info.cc(53)] Available number of cores: 32
            [0414/010630.566233:VERBOSE1:zygote_main_linux.cc(217)] ZygoteMain: initializing 0 fork delegates
            [0414/010630.574976:VERBOSE1:webrtc_internals.cc(120)] Could not get the download directory.
            
            DevTools listening on ws://127.0.0.1:37715/devtools/browser/ad696654-9a10-4236-b4d5-a44fa17f988f
            [0414/010630.582057:VERBOSE1:breakpad_linux.cc(2070)] Non Browser crash dumping enabled for: renderer
            [0414/010630.582186:VERBOSE1:simple_index_file.cc(599)] Simple Cache Index is being restored from disk.
            [0414/010630.601512:ERROR:paint_controller.cc(548)] PaintController::FinishCycle() completed
            [0414/010630.613861:VERBOSE1:proxy_resolution_service.cc(1060)] PAC support disabled because there is no system implementation
            [0414/010630.614242:VERBOSE1:proxy_resolution_service.cc(1060)] PAC support disabled because there is no system implementation
            [0414/010630.614724:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/3595812828355783/tests/index.html?hidepassed=true&dockcontainer&split=3&loadBalance&partition=1&browser=13&filter=!%2Ffastboot-ssr%2F
            [0414/010630.618893:VERBOSE1:simple_index_file.cc(599)] Simple Cache Index is being restored from disk.
            [0414/010630.628193:ERROR:command_buffer_proxy_impl.cc(124)] ContextResult::kTransientFailure: Failed to send GpuChannelMsg_CreateCommandBuffer.
            [0414/010630.628191:WARNING:ipc_message_attachment_set.cc(49)] MessageAttachmentSet destroyed with unconsumed attachments: 0/1
            [0414/010631.717833:ERROR:cert_verify_proc_nss.cc(1011)] CERT_PKIXVerifyCert for localhost failed err=-8172
            [0414/010631.942599:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/assets/static.css
            [0414/010631.942911:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/assets/vendor.css
            [0414/010631.943059:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/assets/app.css
            [0414/010631.943176:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/assets/test-support.css
            [0414/010631.943316:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/assets/lazy-classic.css
            [0414/010631.944260:VERBOSE1:network_delegate.cc(32)] NetworkDelegate::NotifyBeforeURLRequest: https://localhost:4444/testem.js
            [0414/010722.079702:INFO:CONSOLE(965)] "performance.measure could not be executed because of  Failed to execute 'measure' on 'Performance': The mark 'qunit_test_start' does not exist.", source: https://localhost:4444/testem.js (965)
```

After
```
        message: >
            Error: Browser exited on request from test driver
            Error while executing test: Integration | Component | blah: some test name.
            Non-zero exit code: null
            Stderr: 
             [0414/010630.566144:INFO:cpu_info.cc(53)] Available number of cores: 32
            [0414/010722.079702:INFO:CONSOLE(965)] "performance.measure could not be executed because of  Failed to execute 'measure' on 'Performance': The mark 'qunit_test_start' does not exist.", source: https://localhost:4444/testem.js (965)
```