### PR TITLE
Add Brave to known browsers

### DIFF
--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -44,6 +44,32 @@ function headlessChromeArgs(browserTmpDir, url) {
     '--window-size=1440,900'].concat(chromeArgs(browserTmpDir, url));
 }
 
+function braveWinPaths(homeDir, name) {
+  return [
+    homeDir + '\\Local Settings\\Application Data\\BraveSoftware\\' + name + '\\Application\\brave.exe',
+    homeDir + '\\AppData\\Local\\BraveSoftware\\' + name + '\\Application\\brave.exe',
+    'C:\\Program Files\\BraveSoftware\\' + name + '\\Application\\brave.exe',
+    'C:\\Program Files (x86)\\BraveSoftware\\' + name + '\\Application\\brave.exe'
+  ];
+}
+
+function braveOSXPaths(name) {
+  return chromeOSXPaths(name); // brave OSX path is the same as chrome
+}
+
+function braveArgs(browserTmpDir, url) {
+  return chromeArgs(browserTmpDir, url);
+}
+
+function headlessBraveArgs(browserTmpDir, url) {
+  return [
+    '--headless',
+    '--disable-gpu',
+    '--mute-audio',
+    '--remote-debugging-port=0',
+    '--window-size=1440,900'].concat(braveArgs(browserTmpDir, url));
+}
+
 // Return the catalogue of the browsers that Testem supports for the platform. Each 'browser object'
 // will contain these fields:
 //
@@ -92,6 +118,26 @@ module.exports = function knownBrowsers(platform, config) {
           'user_pref("datareporting.policy.dataSubmissionPolicyNotifiedTime", "1481830156314");'
         ];
         fs.writeFile(perfJS, prefs.join('\n'), done);
+      }
+    },
+    {
+      name: 'Brave',
+      possiblePath: braveWinPaths(userHomeDir, 'Brave-Browser').concat(braveOSXPaths('Brave Browser')),
+      possibleExe: [
+        'brave'
+      ],
+      args(config, url) {
+        return braveArgs(this.browserTmpDir(), url);
+      }
+    },
+    {
+      name: 'Headless Brave',
+      possiblePath: braveWinPaths(userHomeDir, 'Brave-Browser').concat(braveOSXPaths('Brave Browser')),
+      possibleExe: [
+        'brave'
+      ],
+      args(config, url) {
+        return headlessBraveArgs(this.browserTmpDir(), url);
       }
     },
     {


### PR DESCRIPTION
Resolves #1339

I only tested on MacOS. The Windows path is taken from elsewhere, but I figured it should be correct.