### PR TITLE
Fix text overlap in "launchers" command

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -335,8 +335,8 @@ class Config {
       launchers = Object.keys(launchers).map(k => launchers[k]);
       console.log('Have ' + launchers.length + ' launchers available; auto-launch info displayed on the right.');
       console.log(); // newline
-      console.log('Launcher      Type          CI  Dev');
-      console.log('------------  ------------  --  ---');
+      console.log('Launcher         Type          CI  Dev');
+      console.log('---------------  ------------  --  ---');
       console.log(launchers.map(launcher => {
         let protocol = launcher.settings.protocol;
         let kind = protocol === 'browser' ?
@@ -349,7 +349,7 @@ class Config {
         let ci = !launch_in_ci || launch_in_ci.indexOf(launcher.name.toLowerCase()) !== -1 ?
           Chars.mark :
           ' ';
-        return (pad(launcher.name, 14, ' ', 1) +
+        return (pad(launcher.name, 17, ' ', 1) +
           pad(kind, 12, ' ', 1) +
           '  ' + ci + '    ' + dev + '      ');
       }).join('\n'));


### PR DESCRIPTION
The "Headless Chrome" launcher's name was longer than the column allowed, causing the Name to be cut-off.

This fixes the issue by extending the column width by 3 characters.

Before:
![image](https://user-images.githubusercontent.com/6216460/83795557-7e9e7900-a654-11ea-84e2-25f99a1aa609.png)

After:
![image](https://user-images.githubusercontent.com/6216460/83795571-82320000-a654-11ea-9abd-b07cc3f449da.png)
