### PR TITLE
Add Headless Firefox to known browsers

### DIFF
--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -71,6 +71,40 @@ function headlessBraveArgs(browserTmpDir, url) {
     '--window-size=1440,900'].concat(braveArgs(browserTmpDir, url));
 }
 
+function firefoxPaths() {
+  return [
+    'C:\\Program Files\\Mozilla Firefox\\firefox.exe',
+    'C:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe',
+    process.env.HOME + '/Applications/Firefox.app/Contents/MacOS/firefox',
+    '/Applications/Firefox.app/Contents/MacOS/firefox'
+  ];
+}
+
+function firefoxSetup(browserTmpDir, config, done) {
+  // use user.js instead of prefs.js http://kb.mozillazine.org/User.js_file
+  let perfJS = path.join(browserTmpDir, 'user.js');
+
+  if (config.get('firefox_user_js')) {
+    return fs.readFile(config.get('firefox_user_js'), (err, content) => {
+      if (err) {
+        return done(err);
+      }
+
+      fs.writeFile(perfJS, content, done);
+    });
+  }
+
+  // using user.js to suppress the check default browser popup
+  // and the welcome start page
+  let prefs = [
+    'user_pref("browser.shell.checkDefaultBrowser", false);',
+    'user_pref("browser.cache.disk.smart_size.first_run", false);',
+    'user_pref("datareporting.policy.dataSubmissionEnabled", false);',
+    'user_pref("datareporting.policy.dataSubmissionPolicyNotifiedTime", "1481830156314");'
+  ];
+  fs.writeFile(perfJS, prefs.join(os.EOL), done);
+}
+
 // Return the catalogue of the browsers that Testem supports for the platform. Each 'browser object'
 // will contain these fields:
 //
@@ -85,40 +119,26 @@ module.exports = function knownBrowsers(platform, config) {
   let browsers = [
     {
       name: 'Firefox',
-      possiblePath: [
-        'C:\\Program Files\\Mozilla Firefox\\firefox.exe',
-        'C:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe',
-        process.env.HOME + '/Applications/Firefox.app/Contents/MacOS/firefox',
-        '/Applications/Firefox.app/Contents/MacOS/firefox'
-      ],
+      possiblePath: firefoxPaths(),
       possibleExe: 'firefox',
 
       args(config, url) {
         return ['-profile', this.browserTmpDir(), url];
       },
       setup(config, done) {
-        // use user.js instead of prefs.js http://kb.mozillazine.org/User.js_file
-        let perfJS = path.join(this.browserTmpDir(), 'user.js');
+        firefoxSetup(this.browserTmpDir(), config, done);
+      }
+    },
+    {
+      name: 'Headless Firefox',
+      possiblePath: firefoxPaths(),
+      possibleExe: 'firefox',
 
-        if (config.get('firefox_user_js')) {
-          return fs.readFile(config.get('firefox_user_js'), (err, content) => {
-            if (err) {
-              return done(err);
-            }
-
-            fs.writeFile(perfJS, content, done);
-          });
-        }
-
-        // using user.js to suppress the check default browser popup
-        // and the welcome start page
-        let prefs = [
-          'user_pref("browser.shell.checkDefaultBrowser", false);',
-          'user_pref("browser.cache.disk.smart_size.first_run", false);',
-          'user_pref("datareporting.policy.dataSubmissionEnabled", false);',
-          'user_pref("datareporting.policy.dataSubmissionPolicyNotifiedTime", "1481830156314");'
-        ];
-        fs.writeFile(perfJS, prefs.join(os.EOL), done);
+      args(config, url) {
+        return ['-profile', '--headless', this.browserTmpDir(), url];
+      },
+      setup(config, done) {
+        firefoxSetup(this.browserTmpDir(), config, done);
       }
     },
     {

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -75,7 +75,7 @@ describe('knownBrowsers', function() {
         }
 
         browsers = knownBrowsers('any', config);
-        firefox = findBrowser(browsers, 'Firefox');
+        firefox = findBrowser(browsers, browserName || 'Firefox');
       }
 
       beforeEach(function() {
@@ -173,6 +173,22 @@ describe('knownBrowsers', function() {
         it('constructs correct args with browser_args', function() {
           expect(firefox.args.call(launcher, config, url)).to.deep.eq([
             '--testem', '-profile', browserTmpDir, url
+          ]);
+        });
+      });
+
+      describe('headless browser_args', function() {
+        beforeEach(function() {
+          setup('Headless Firefox');
+        });
+
+        afterEach(function() {
+          setup();
+        });
+
+        it('constructs correct args with browser_args', function() {
+          expect(firefox.args.call(launcher, config, url)).to.deep.eq([
+            '--testem', '-profile', '--headless', browserTmpDir, url
           ]);
         });
       });


### PR DESCRIPTION
Add support for launching Firefox in headless mode.

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode