### PR TITLE
Accept .cjs files as configs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -125,7 +125,7 @@ class Config {
       if (callback) {
         callback.call(this);
       }
-    } else if (configFile.match(/\.js$/)) {
+    } else if (configFile.match(/\.c?js$/)) {
       this.readJS(configFile, callback);
     } else if (configFile.match(/\.json$/)) {
       this.readJSON(configFile, callback);


### PR DESCRIPTION
Hi @johanneswuerbach, thanks a lot for this awesome project! 

We're using it in [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js), which we're now converting to `"type": "module"` and native ESM for development, and the only thing blocking us is Testem not accepting `.cjs` files as configs alongside `.js`. 

If a project is configured with `"type": "module"` in its `package.json`, in Node v12+, all `.js` files inside are treated as ES modules, except files with the `.cjs` extension which are resolved as CommonJS. Since Testem doesn't support using ES modules as configs, this is a quick patch to at least support loading `.cjs`, unblocking migration to ESM.

I wasn't sure such a tiny change needs an update to unit tests, but let me know if I should do it. Thank you!

Edit: looks like some of the CI tests failed for a reason unrelated to the change.