### PR TITLE
Fix bail_on_uncaught_error

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -248,7 +248,7 @@ module.exports = class BrowserTestRunner {
         error: {}
       });
       this.onAllTestResults();
-      this.onEnd.call(this);
+      this.finish();
     }
   }
 

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -216,6 +216,47 @@ describe('browser test runner', function() {
     });
   });
 
+  describe('onGlobalError with bail_on_uncaught_error===true', function() {
+    let runner, reporter;
+
+    beforeEach(function() {
+      reporter = new FakeReporter();
+      let config = new Config('ci', {
+        parallel: 2,
+        reporter: reporter,
+        bail_on_uncaught_error: true
+      });
+      let launcher = new Launcher('ci', { protocol: 'browser' }, config);
+      runner = new BrowserTestRunner(launcher, reporter);
+    });
+
+    it('causes immediate finish', function() {
+      runner.onGlobalError('something went wrong', 'http://example.com', 123);
+      expect(runner.finished).to.equal(true);
+    });
+  });
+
+  describe('onGlobalError with bail_on_uncaught_error===false', function() {
+    let runner, reporter;
+
+    beforeEach(function() {
+      reporter = new FakeReporter();
+      let config = new Config('ci', {
+        parallel: 2,
+        reporter: reporter,
+        bail_on_uncaught_error: false
+      });
+      let launcher = new Launcher('ci', { protocol: 'browser' }, config);
+      runner = new BrowserTestRunner(launcher, reporter);
+    });
+
+    it('is still running', function() {
+      runner.onGlobalError('something went wrong', 'http://example.com', 123);
+      expect(runner.finished).to.not.equal(true);
+    });
+  });
+
+
   describe('start', function() {
     let reporter, launcher, runner, socket, sandbox;
 


### PR DESCRIPTION
`bail_on_uncaught_error` currently does not cause testem to shut down after a top-level error.  So if a top-level error causes your test suite to be dead, testem will hang forever.

It looks like this feature was broken by  https://github.com/testem/testem/commit/a690bfa41708b9ef2903c34cee214ba70862e88d

Prior to that change, it was sufficient for the error handler to call `onAllTestResults()`, because `onAllTestResults` invoked `finish()`. 

This PR restores the behavior of calling `finish()` when trying to bail.

And the error handler doesn't need to call `onEnd` because that's already called by `onAllTestResults`