### PR TITLE
Explicitly call the `io()` function to get a socket in latest socket.io

### DIFF
--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -164,7 +164,7 @@ function init() {
 }
 
 function patchEmitterForWildcard(socket) {
-  var emit = io.Manager.prototype.emit;
+  var emit = Object.getPrototypeOf(socket).emit;
 
   function onevent(packet) {
     var args = packet.data || [];
@@ -175,7 +175,7 @@ function patchEmitterForWildcard(socket) {
 }
 
 function initSocket(id) {
-  socket = io.connect({ reconnectionDelayMax: 1000, randomizationFactor: 0 });
+  socket = io().connect({ reconnectionDelayMax: 1000, randomizationFactor: 0 });
   patchEmitterForWildcard(socket);
 
   socket.emit('browser-login', getBrowserName(navigator.userAgent), id);


### PR DESCRIPTION
The recent upgrade from old socket.io v2.x to v4.x brought a change to the behavior of the `io` global created in `connection.html`.  Formerly, importing the client via a `<script>` tag in `public/testem/connection.html` would provide a global `io` that could be treated directly like a `Socket`.  In the latest versions, that global `io` is now only their `lookup()` function, so it is necessary to explicitly instantiate a `Socket` by calling the function.

Fixes #1479.
