### PR TITLE
Resolve a promise when returned in config

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -131,3 +131,23 @@ Hooks can be defined as a string in which case they run as a shell command or as
     before_tests:         Runs before every run of tests
     after_tests:          Runs after every run of tests
     on_exit:              Runs before suite exits
+
+### Returning a Promise from `testem.js`
+
+If you need to resolve some async values in your configuration you can return a promise from `testem.js`. The resolved value of
+the promise will be passed to testem as configuration.
+
+```javascript 
+'use strict';
+
+async function getFramework() {
+  //do something async here, like generating a list of launchers based on configuration
+  return 'qunit';
+}
+
+module.exports = async function() {
+  return {
+    framework: await getFramework(),
+  }
+};
+```

--- a/lib/config.js
+++ b/lib/config.js
@@ -140,9 +140,19 @@ class Config {
   }
 
   readJS(configFile, callback) {
-    this.fileOptions = require(this.resolveConfigPath(configFile));
-    if (callback) {
-      callback.call(this);
+    let exportedConfig = require(this.resolveConfigPath(configFile));
+    if (typeof exportedConfig === 'function') {
+      Promise.resolve(exportedConfig()).then(obj => {
+        this.fileOptions = obj;
+        if (callback) {
+          callback.call(this);
+        }
+      });
+    } else {
+      this.fileOptions = exportedConfig;
+      if (callback) {
+        callback.call(this);
+      }
     }
   }
 

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -146,6 +146,20 @@ describe('Config', function() {
     });
   });
 
+  describe('resolve promise from js config', function() {
+    let config;
+    beforeEach(function(done) {
+      let progOptions = {
+        file: __dirname + '/custom_configs/testem-promise.js'
+      };
+      config = new Config('dev', progOptions);
+      config.read(done);
+    });
+    it('gets properties from config file', function() {
+      expect(config.get('framework')).to.equal('qunit');
+    });
+  });
+
   describe('getters system', function() {
     it('gives precendence to getters', function(done) {
       let config = new Config('dev', {cwd: 'tests'});

--- a/tests/custom_configs/testem-promise.js
+++ b/tests/custom_configs/testem-promise.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function() {
+  return new Promise(resolve => {
+    resolve({
+      framework: 'qunit',
+    });
+  });
+};


### PR DESCRIPTION
This unlocks doing some async work as part of the configuration. For
example using our browserlist query string and the browserstack API to
generate a list of launchers so we're always testing against our
supporter browser matrix.