### PR TITLE
Scope testem assets with a prefix

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -177,7 +177,7 @@ class Server extends EventEmitter {
       }
       next();
     });
-    app.use(express.static(`${__dirname}/../../public`));
+    app.use('/testem', express.static(`${__dirname}/../../public/testem`));
   }
 
   injectMiddleware(app) {


### PR DESCRIPTION
Testem uses an express [`serve-static`](https://github.com/expressjs/serve-static) middleware to serve the assets. It's mounted on the app root, meaning every request is first processed with the `express.static` middleware and only after that with the middlewares defined in the config, e.g., proxy middleware.

This ends up in a bunch of extra `fs.stat` calls which bloat the server response time. You can check that by enabling the `DEBUG=send` environment variable and making a request to the server.

```js
const testemConfig = {
    middleware: [
        (app) => app.use('/render-tests', serveStatic(path.join(__dirname, 'render-tests')))
    ]
};
```

Considering the configuration above, all requests with the `/render-tests` prefix are used for lookup files in the `testem/public/` folder first, which should be avoided.

```shell
send stat "/mnt/ramdisk/mapbox-gl-js/node_modules/testem/public/render-tests/background-color/default/expected.png" +90ms
send stat "/mnt/ramdisk/mapbox-gl-js/test/integration/render-tests/background-color/default/expected.png" +1ms
send pipe "/mnt/ramdisk/mapbox-gl-js/test/integration/render-tests/background-color/default/expected.png" +0ms
```

This PR scopes all requests to the `/testem` prefix to the testem's `/public/testem` dir, which fixes that issue.