### PR TITLE
[WIP] Add hooks necessary for Chrome coverage

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -6,6 +6,7 @@ const Bluebird = require('bluebird');
 
 const LogEntry = require('../utils/log-entry');
 const toResult = require('./to-result');
+const { on } = require('events');
 
 module.exports = class BrowserTestRunner {
   constructor(launcher, reporter, index, singleRun, config) {
@@ -43,6 +44,24 @@ module.exports = class BrowserTestRunner {
           this.process = browserProcess;
           this.process.on('processExit', this.onProcessExit.bind(this));
           this.process.on('processError', this.onProcessError.bind(this));
+
+          const onDevToolsReady = this.launcher.config.get('browser_on_dev_tools_ready');
+          if (onDevToolsReady) {
+            const self = this;
+            function stdoutListener() {
+              if (self.devToolsUrl) {
+                return;
+              }
+
+              const match = this.stderr.match(/DevTools listening on (.+)/);
+              if (match) {
+                self.devToolsUrl = match[1];
+                onDevToolsReady.call(self, self.devToolsUrl);
+              }
+            }
+            this.process.on('errout', stdoutListener);
+          }
+
           this.setupStartTimer();
         }).catch(err => {
           this.onProcessError(err);
@@ -295,11 +314,18 @@ module.exports = class BrowserTestRunner {
     this.reportResults(err, 0, browserProcess);
   }
 
-  finish() {
-    if (this.finished) { return; }
+  async finish() {
+    if (this.finishing || this.finished) { return; }
+
+    this.finishing = true;
 
     clearTimeout(this.pendingTimer);
     clearTimeout(this.onProcessExitTimer);
+
+    const onBeforeFinish = this.launcher.config.get('browser_on_before_finish');
+    if (onBeforeFinish) {
+      await onBeforeFinish.call(this);
+    }
 
     this.finished = true;
 

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -161,6 +161,7 @@ module.exports = class BrowserTestRunner {
     }
 
     let tap = new BrowserTapConsumer(socket);
+    tap.on('tests-start', this.onTestsStart.bind(this));
     tap.on('test-result', this.onTestResult.bind(this));
     tap.on('all-test-results', this.onAllTestResults.bind(this));
     tap.on('all-test-results', () => {
@@ -184,8 +185,12 @@ module.exports = class BrowserTestRunner {
 
   onTestsStart(testData) {
     if (testData) {
+      Object.assign(testData, {
+        launcherId: this.launcherId
+      });
       this.currentTestContext = testData;
       this.currentTestContext.state = 'executing';
+      this.reporter.testStarted(this.launcher.name, testData);
     }
   }
 

--- a/lib/utils/process.js
+++ b/lib/utils/process.js
@@ -25,6 +25,7 @@ module.exports = class Process extends EventEmitter {
         return;
       }
       this.stderr += chunk;
+      this.emit('errout');
     });
 
     this.process.on('close', this.onClose.bind(this));

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -67,6 +67,14 @@ class Reporter {
     }
   }
 
+  testStarted(name, data) {
+    this.reporters.forEach(reporter => {
+      if (reporter.testStarted) {
+        reporter.testStarted(name, data);
+      }
+    });
+  }
+
   close() {
     this.finish();
 

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -37,12 +37,13 @@ class Reporter {
     this.passed = 0;
     this.skipped = 0;
     this.todo = 0;
+    this.config = app.config;
 
     if (path) {
       this.reportFile = new ReportFile(path);
     }
 
-    let config = app.config;
+    let config = this.config;
 
     if (path && config.get('xunit_intermediate_output') && config.get('reporter') === 'xunit') {
       this.reporters = [
@@ -77,6 +78,11 @@ class Reporter {
 
   close() {
     this.finish();
+
+    const afterReporterFinish = this.config.get('after_reporter_finish');
+    if (afterReporterFinish) {
+      afterReporterFinish.call(this);
+    }
 
     if (this.reportFile) {
       return this.reportFile.close();


### PR DESCRIPTION
This adds hooks necessary for gathering coverage data directly from Chrome. It's a bit rough right now and untested but it does work. I'd love to see if we can actually get this to full first-class support.

To make use of this, I have this additional code in my own app:

```js
/* eslint-disable no-undef */
const chromeRemoteInterface = require('chrome-remote-interface');
const fs = require('node:fs');

const { mergeProcessCovs } = require('@bcoe/v8-coverage');

function buildContext({ coverageDir }) {
	const remoteInterfaces = {};

	if (!fs.existsSync(coverageDir)) {
		fs.mkdirSync(coverageDir);
	}

	return {
		remoteInterfaces,

		config: {
			// this here will be the browser runner
			async browser_on_dev_tools_ready() {
				const match = this.devToolsUrl.match(/ws:\/\/(.+):(\d+)\//);
				if (match) {
					const [_, host, port] = match;
					const remoteInterface = await chromeRemoteInterface({ host, port });
					remoteInterfaces[this.launcherId] = remoteInterface;

					const { Profiler } = remoteInterface;
					await Profiler.enable();
					await Profiler.startPreciseCoverage({ callCount: true, detailed: true });
				}
			},

			// this here will be the browser runner
			async browser_on_before_finish() {
				const remoteInterface = remoteInterfaces[this.launcherId];
				if (remoteInterface) {
					// Clear it out so we don't do it twice
					remoteInterfaces[this.launcherId] = null;

					const { Profiler } = remoteInterface;

					const results = await Profiler.takePreciseCoverage();

					const coveragePath = `${coverageDir}/coverage-${this.launcherId}.json`;
					fs.writeFileSync(coveragePath, JSON.stringify(results, null, 2));

					remoteInterface.close();
				}
			},

			// this here will be the internal reporter
			after_reporter_finish() {
				let coverage;

				const pastCoveragePath = `${coverageDir}/past-coverage.json`;
				if (fs.existsSync(pastCoveragePath)) {
					const coverageData = fs.readFileSync(pastCoveragePath);
					coverage = JSON.parse(coverageData);
				}

				for (const id of Object.keys(remoteInterfaces)) {
					const coverageData = fs.readFileSync(`${coverageDir}/coverage-${id}.json`);
					const coverageJson = JSON.parse(coverageData);
					if (coverage) {
						coverage = mergeProcessCovs([coverage, coverageJson]);
					} else {
						coverage = coverageJson;
					}
				}

				const jsonString = JSON.stringify(coverage, null, 2);

				console.log(`Merged ${Object.keys(remoteInterfaces).length} files.`);
				console.log(`Total size: ${jsonString.length}`);
				console.log(`Writing coverage to ${coverageDir}/coverage.json.`);
				fs.writeFileSync(`${coverageDir}/coverage.json`, jsonString, 'utf8');
			},
		},
	};
}

module.exports = { buildContext };
```

Then in my `testem.js`:

```js
const { buildContext } = require('testem-helpers');

const coverageContext = buildContext({ coverageDir: path.join(__dirname, 'coverage') });

module.exports = {
	// other config
	..coverageContext.config,
};
```