### PR TITLE
[CI mode, ember-cli test] enabling WebSocket proxying

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -217,10 +217,17 @@ class Server extends EventEmitter {
       this.proxy = new httpProxy.createProxyServer({changeOrigin: true});
 
       this.proxy.on('error', (err, req, res) => {
-        res.status(500).json(err);
+        res?.status(500).json(err);
       });
 
-      Object.keys(proxies).forEach(url => {
+      Object.keys(proxies).forEach((url) => {
+        if (proxies[url].ws === true) {
+          this.server.on('upgrade', (req, socket, head) => {
+            if (req.url.startsWith(url)) {
+              this.proxy.ws(req, socket, head, proxies[url]);
+            }
+          });
+        }
         app.all(`${url}*`, (req, res, next) => {
           var opts = proxies[url];
           if (this.shouldProxy(req, opts)) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -217,16 +217,18 @@ class Server extends EventEmitter {
       this.proxy = new httpProxy.createProxyServer({changeOrigin: true});
 
       this.proxy.on('error', (err, req, res) => {
-        res?.status(500).json(err);
+        res && res.status && res.status(500).json(err);
       });
 
       Object.keys(proxies).forEach((url) => {
         if (proxies[url].ws === true) {
+          // set up proxy for WebSocket
           this.server.on('upgrade', (req, socket, head) => {
             if (req.url.startsWith(url)) {
               this.proxy.ws(req, socket, head, proxies[url]);
             }
           });
+          return;
         }
         app.all(`${url}*`, (req, res, next) => {
           var opts = proxies[url];


### PR DESCRIPTION
simple patch leveraging WebSocket proxying capabilities of _http-proxy_ by an entry identifying itself as `"ws: true"` in the `testem.json/testem.js` 'proxies' section
(cf. https://github.com/testem/testem?tab=readme-ov-file#api-proxy):

```

…
  "proxies": {
    …
    "/mywsendpoint": {
      …
      ws: true
    },
    …
  }
```

Works with `ember-cli test`, offering equivalent functionality to `ember-cli server --proxy=…` in CI testing mode.