### PR TITLE
Replace lodash per-method dependencies with lodash v4.17.21

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -5,7 +5,7 @@ const Bluebird = require('bluebird');
 const Path = require('path');
 const log = require('npmlog');
 const StyledString = require('styled_string');
-const find = require('lodash.find');
+const _ = require('lodash');
 
 const Server = require('./server');
 const BrowserTestRunner = require('./runners/browser_test_runner');
@@ -251,7 +251,7 @@ module.exports = class App extends EventEmitter {
   }
 
   onBrowserLogin(browserName, id, socket) {
-    let browser = find(this.runners, runner => {
+    let browser = _.find(this.runners, runner => {
       return runner.launcherId === id && (!runner.socket || !runner.socket.connected);
     });
 
@@ -270,7 +270,7 @@ module.exports = class App extends EventEmitter {
   }
 
   onBrowserRelogin(browserName, id, socket) {
-    let browser = find(this.runners, runner => {
+    let browser = _.find(this.runners, runner => {
       // a browser relogin can happen if a client socket was disconnected, which may not be reflected in runner.socket's connected state
       // or if the socket was nulled by 'onDisconnect'
       return runner.launcherId === id && (runner.socket || runner.socket === null);

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,7 @@ const Chars = require('./utils/chars');
 const pad = require('./utils/strutils').pad;
 const isa = require('./utils/isa');
 const fileExists = require('./utils/fileutils').fileExists;
-const uniqBy = require('lodash.uniqby');
+const _ = require('lodash');
 
 const knownBrowsers = require('./utils/known-browsers');
 const globAsync = Bluebird.promisify(glob);
@@ -408,7 +408,7 @@ class Config {
         return {src: f, attrs: attrs};
       })));
     }, [])
-      .then(result => uniqBy(result, 'src'))
+      .then(result => _.uniqBy(result, 'src'))
       .asCallback(callback);
   }
 

--- a/lib/launcher-factory.js
+++ b/lib/launcher-factory.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Launcher = require('./launcher');
-const extend = require('lodash.assignin');
+const _ = require('lodash');
 
 function getUniqueId() {
   return process.hrtime().join('');
@@ -16,7 +16,7 @@ module.exports = class LauncherFactory {
 
   create(options) {
     const id = getUniqueId();
-    const settings = extend({ id }, this.settings, options);
+    const settings = _.assignIn({ id }, this.settings, options);
     return new Launcher(this.name, settings, this.config);
   }
 };

--- a/lib/process-ctl.js
+++ b/lib/process-ctl.js
@@ -6,7 +6,7 @@ const Bluebird = require('bluebird');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
 const spawnargs = require('spawn-args');
-const extend = require('lodash.assignin');
+const _ = require('lodash');
 
 const envWithLocalPath = require('./utils/env-with-local-path');
 const fileutils = require('./utils/fileutils');
@@ -32,7 +32,7 @@ module.exports = class ProcessCtl extends EventEmitter {
       env: envWithLocalPath(this.config)
     };
 
-    return extend({}, defaults, options);
+    return _.assignIn({}, defaults, options);
   }
 
   _spawn(exe, args, options) {

--- a/lib/utils/add-to-PATH.js
+++ b/lib/utils/add-to-PATH.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const cloneDeep = require('lodash.clonedeep');
+const _ = require('lodash');
 const isWin = require('./is-win')();
 let PATH = 'PATH';
 let delimiter = ':';
@@ -17,7 +17,7 @@ if (isWin) {
 }
 
 module.exports = function addToPATH(path) {
-  let env = cloneDeep(process.env);
+  let env = _.cloneDeep(process.env);
   env[PATH] = [path, env[PATH]].join(delimiter);
 
   return env;

--- a/lib/utils/browser-args.js
+++ b/lib/utils/browser-args.js
@@ -2,7 +2,7 @@
 
 const capitalize = require('./capitalize');
 const log = require('npmlog');
-const castArray = require('lodash.castarray');
+const _ = require('lodash');
 
 function Validation() {
   this.knownBrowser = null;
@@ -22,7 +22,7 @@ function hasOldBrowserArgsFormat(args) {
 // Lodash's castArray function will turn `undefined` into `[undefined]`, but we want an empty array in that case.
 function safeCastArray(value) {
   if (value) {
-    return castArray(value);
+    return _.castArray(value);
   } else {
     return [];
   }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,9 @@
     "glob": "^7.0.4",
     "http-proxy": "^1.13.1",
     "js-yaml": "^3.2.5",
+    "lodash": "^4.17.21",
     "lodash.assignin": "^4.1.0",
-    "lodash.castarray": "^4.4.0",
     "lodash.clonedeep": "^4.4.1",
-    "lodash.find": "^4.5.1",
-    "lodash.uniqby": "^4.7.0",
     "mkdirp": "^3.0.1",
     "mustache": "^4.2.0",
     "node-notifier": "^10.0.0",
@@ -91,6 +89,5 @@
   "bin": {
     "testem": "./testem.js"
   },
-  "main": "./lib/api.js",
-  "optionalDependencies": {}
+  "main": "./lib/api.js"
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "http-proxy": "^1.13.1",
     "js-yaml": "^3.2.5",
     "lodash": "^4.17.21",
-    "lodash.assignin": "^4.1.0",
     "lodash.clonedeep": "^4.4.1",
     "mkdirp": "^3.0.1",
     "mustache": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "http-proxy": "^1.13.1",
     "js-yaml": "^3.2.5",
     "lodash": "^4.17.21",
-    "lodash.clonedeep": "^4.4.1",
     "mkdirp": "^3.0.1",
     "mustache": "^4.2.0",
     "node-notifier": "^10.0.0",

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Bluebird = require('bluebird');
-const find = require('lodash.find');
+const _ = require('lodash');
 const tmp = require('tmp');
 const path = require('path');
 const os = require('os');
@@ -36,7 +36,7 @@ function createConfig() {
 }
 
 function findBrowser(browsers, browserName) {
-  return find(browsers, function(browser) {
+  return _.find(browsers, function(browser) {
     return browser.name === browserName;
   });
 }


### PR DESCRIPTION
This pull-request seeks to address the security concerns highlighted in #1813 by removing the per-method lodash dependencies and using the full-featured lodash package instead. A few details:

- Running tests with `npm test` locally resulted in a complete success for all tests
- Running tests with `npm run integration` locally resulted in some errors of type `Error: operation timed out after 46759 ms, 3 tries with error: Cmd: npm run test --  -p 0 --launch "Headless Firefox" failed with exit code: 1`
- Using `npm run lint` results in a huge amount of errors with message `Expected linebreaks to be 'LF' but found 'CRLF'`; this happens by linting the original master page as well though