### PR TITLE
FIX: Don't proxy testem file requests

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -136,9 +136,9 @@ class Server extends EventEmitter {
 
     this.injectMiddleware(app);
 
-    this.configureProxy(app);
-
     app.use('/testem', express.static(`${__dirname}/../../public/testem`));
+
+    this.configureProxy(app);
 
     app.get('/', (req, res) => {
       res.redirect(`/${String(Math.floor(Math.random() * 10000))}`);


### PR DESCRIPTION
Fixes a regression in 72c3314778c0e41d16a3175775942531213f1a15. That change made wildcard proxies (e.g. `/*/`) catch requests for testem files (e.g. `/testem/connection.html`)

Moving `configureProxy()` before the static serve line fixes it, while maintaining the middleware fix from the other commit.