### PR TITLE
fix: Provide more context when launcher is not available

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -325,7 +325,7 @@ class Config {
         if (this.appMode === 'dev' || this.get('ignore_missing_launchers')) {
           log.warn('Launcher "' + name + '" is not recognized.');
         } else {
-          err = new Error('Launcher ' + name + ' not found. Not installed?');
+          err = new Error('Launcher ' + name + ' not found. Not installed? Available: ' + Object.keys(available).join(', '));
         }
       } else {
         launchers.push(launcher);

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -223,12 +223,15 @@ describe('ci mode app', function() {
       reporter: new FakeReporter()
     });
     config.read(function() {
-      var app = new App(config, function(exitCode, err) {
-        expect(exitCode).to.eq(1);
-        expect(err.message).to.eq('Launcher ' + browser + ' not found. Not installed?');
-        done();
+      config.getAvailableLaunchers((err, launchers) => {
+        var app = new App(config, function(exitCode, err) {
+          expect(exitCode).to.eq(1);
+
+          expect(err.message).to.eq('Launcher ' + browser + ' not found. Not installed? Available: ' + Object.keys(launchers).join(', '));
+          done();
+        });
+        app.start();
       });
-      app.start();
     });
   });
 


### PR DESCRIPTION
- Add information which launchers are available
- Helps with #1837
- Example of new error message:
```
Launcher IE not found. Not installed? Available: safari
```