### PR TITLE
Downgrade dev dependencies to fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "request": "^2.51.0",
     "saucie": "^3.3.3",
     "shelljs": "^0.8.2",
-    "sinon": "^15.0.0",
+    "sinon": "10.0.0",
     "sinon-chai": "^3.2.0",
     "socket.io-client": "^4.1.2",
     "tape": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "chai": "^4.0.2",
     "chai-files": "^1.2.0",
     "chai-shallow-deep-equal": "^1.4.4",
-    "cheerio": "^1.0.0-rc.2",
+    "cheerio": "1.0.0-rc.12",
     "dirty-chai": "^2.0.0",
     "eslint": "^8.12.0",
     "eslint-plugin-chai-expect": "^3.0.0",


### PR DESCRIPTION
Downgrade dev dependencies to fix CI, but its probably time to cut a new major and remove support for NodeJS versions < 18 as those aren't supported anymore

<img width="795" alt="image" src="https://github.com/user-attachments/assets/1b7ee824-aca1-4e8b-b2b6-51a8171fd11d">
From: https://nodejs.org/en/about/previous-releases#release-schedule.