### PR TITLE
fix: Make sure that multi-word launcher names are not confused

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -325,7 +325,13 @@ class Config {
         if (this.appMode === 'dev' || this.get('ignore_missing_launchers')) {
           log.warn('Launcher "' + name + '" is not recognized.');
         } else {
-          err = new Error('Launcher ' + name + ' not found. Not installed? Available: ' + Object.keys(available).join(', '));
+          err = new Error(
+            'Launcher ' +
+            name +
+            ' not found. Not installed? Available: ' +
+            Object.keys(available).map(elm => `"${elm}"`).join(', ') +
+            '.'
+          );
         }
       } else {
         launchers.push(launcher);

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -227,7 +227,13 @@ describe('ci mode app', function() {
         var app = new App(config, function(exitCode, err) {
           expect(exitCode).to.eq(1);
 
-          expect(err.message).to.eq('Launcher ' + browser + ' not found. Not installed? Available: ' + Object.keys(launchers).join(', '));
+          expect(err.message).to.eq(
+            'Launcher ' +
+            browser +
+            ' not found. Not installed? Available: ' +
+            Object.keys(launchers).map(elm => `"${elm}"`).join(', ') +
+            '.'
+          );
           done();
         });
         app.start();


### PR DESCRIPTION
- Without this fix we can get confusing messages like: `Launcher Chrome not found. Not installed? Available: chrome dev, safari`, which can read like three browsers "chorme", "dev" and "safari".
- By adding surrounding quotes the message reads better and is less ambiguous.
- Also added a full stop to make the message consistent with the others.
- Example of the message now: `Launcher IE not found. Not installed? Available: "chrome", "headless chrome", "safari".`
- Improves #1838