### PR TITLE
[DRAFT] [Do Not Merge] Issue #1021: Demonstrate "Browser Timeout Exceeded" issue

### DIFF
--- a/examples/qunit_lazy/package.json
+++ b/examples/qunit_lazy/package.json
@@ -3,7 +3,7 @@
     "qunit": "^2.2"
   },
   "scripts": {
-    "test": "node ../../testem.js ci -P 10"
+    "test": "node ../../testem.js ci"
   },
   "repository": {
     "type": "git",

--- a/examples/qunit_lazy/testem.js
+++ b/examples/qunit_lazy/testem.js
@@ -1,0 +1,11 @@
+module.exports = {
+  framework: "qunit",
+  test_page: "test.html",
+  src_files: ["*.js"],
+  launch_in_ci: ["Chrome"],
+  socket_server_options: {
+    // Uncomment the following line to increase the buffer
+    // size and avoid the websocket disconnection.
+    // maxHttpBufferSize: 1e6 + 100,
+  },
+};

--- a/examples/qunit_lazy/testem.json
+++ b/examples/qunit_lazy/testem.json
@@ -1,7 +1,0 @@
-{
-  "framework": "qunit",
-  "test_page": "test.html",
-  "src_files": [
-    "*.js"
-  ]
-}

--- a/examples/qunit_lazy/tests.js
+++ b/examples/qunit_lazy/tests.js
@@ -1,17 +1,11 @@
-QUnit.test('says hello world', function(assert){
-    assert.equal(hello(), 'hello world', 'should equal hello world');
-});
+QUnit.test("demo failing socket", function (assert) {
+  let tooLargePayload = "";
+  while (tooLargePayload.length < 1e6) {
+    tooLargePayload += "x";
+  }
+  console.log("trigger websocket disconnect");
 
-QUnit.test('says hello to person', function(assert){
-    assert.equal(hello('Bob'), 'hello Bob', 'should equal hello Bob');
+  // Comment out the next line and CI will pass
+  console.log(tooLargePayload);
+  assert.equal(true, true, "this test should pass");
 });
-
-QUnit.todo('failing todo', function(assert){
-    assert.ok(false, 'should be true');
-});
-
-// This will cause integration tests to fail because QUnit will report passing todos
-// as failures (since you should just mark them as a normal test if they pass).
-// QUnit.todo('passing todo', function(assert){
-//     assert.ok(true, 'should be true');
-// });


### PR DESCRIPTION
Demonstration of https://github.com/testem/testem/issues/1021, see: https://github.com/testem/testem/issues/1021#issuecomment-2383518797

To reproduce, check out this fork and:

  * (root) `npm install`
  * `cd examples/lazy_qunit`
  * `npm install`
  * `npm test`

After about 10-ish seconds you should see something like:

```
not ok 1 Chrome - [undefined ms] - error
    ---
        message: >
            Error: Browser timeout exceeded: 10s
            Error while executing test: demo failing socket
            Stderr:
             .............

        browser log: |
            {"type":"error","text":"Error: Browser timeout exceeded: 10s"}
            {"type":"error","text":"Error while executing test: demo failing socket"}

1..1
# tests 1
# pass  0
# skip  0
# todo  0
# fail  1
```