### PR TITLE
Actually support MS Edge out-of-box

### DIFF
--- a/lib/utils/known-browsers.js
+++ b/lib/utils/known-browsers.js
@@ -45,6 +45,30 @@ function headlessChromeArgs(browserTmpDir, url) {
     '--window-size=1440,900'].concat(chromeArgs(browserTmpDir, url));
 }
 
+function edgeArgs(browserTmpDir, url) {
+  return [
+    `--app=${url}`,
+    '--user-data-dir=' + browserTmpDir,
+    '--no-default-browser-check',
+    '--no-first-run',
+    '--ignore-certificate-errors',
+    '--test-type',
+    '--disable-renderer-backgrounding',
+    '--disable-background-timer-throttling',
+    url
+  ];
+}
+
+function headlessEdgeArgs(browserTmpDir, url) {
+  return [
+    '--headless=new', // "new" value is required by Edge
+    '--disable-gpu',
+    '--disable-software-rasterizer',
+    '--mute-audio',
+    '--remote-debugging-port=0',
+    '--window-size=1440,900'].concat(edgeArgs(browserTmpDir, url));
+}
+
 function braveWinPaths(homeDir, name) {
   return [
     homeDir + '\\Local Settings\\Application Data\\BraveSoftware\\' + name + '\\Application\\brave.exe',
@@ -253,7 +277,7 @@ module.exports = function knownBrowsers(platform, config) {
         'microsoft-edge'
       ],
       args(config, url) {
-        return chromeArgs(this.browserTmpDir(), url);
+        return edgeArgs(this.browserTmpDir(), url);
       }
     },
     {
@@ -263,7 +287,7 @@ module.exports = function knownBrowsers(platform, config) {
         'microsoft-edge'
       ],
       args(config, url) {
-        return headlessChromeArgs(this.browserTmpDir(), url);
+        return headlessEdgeArgs(this.browserTmpDir(), url);
       }
     },
     {


### PR DESCRIPTION
- update known-browsers with edgeArgs and headlessEdgeArgs to fully support MS Edge with zero user config
- implement "app=" browser config switch in edgeArgs to launch test page in edge
- add "new" value to --headless switch for Headless Edge

Hey folks, right now, testem does not work with MS Edge out-of-the-box. I contract with a company which does not support Chrome or Firefox, and I need to launch ember-cli qunit tests in MS Edge locally and on a ci server. However, as this repo currently stands, local Edge does not navigate to the test html page after a browser instance is launched, either headless or with a UI. Edge is also not properly configured to work in headless mode. I know I could probably create a complex node-based solution to launch Edge separately and work around this shortcoming, but testem _claims_ to support *all major browsers* out-of-the-box.

After working this for several days, I have determined that Edge needs an "--app={url}" switch passing the full test page url in order to work. I looked for any possible way to pass an `--app=http://localhost:7357/354104210191250/tests/index.html?hidepassed` (of course the url is dynamic) switch to Edge in my local config, but was defeated at every step by the code. Altering `known-browsers` to actually support Edge with an `edgeArgs` object seems to be the most direct solution, and it makes good on your promise to support _all_ major browsers. Neither testem's config files, nor `before_tests` hook has the full test page url available as a parameter to pass to Edge as a command line switch. To fix headless Edge, Edge's switches need `--headless=new` passed-in, since the Chrome implementation `--headless` (with no value) does not work in Edge.

I'm surprised to see testem has been updated to support Brave, which could not be considered a "major browser" at this time, but the same amount of (minimal) customization to support Edge has not been implemented in testem, which clearly is a "major browser."

Please merge this pull request to actually support MS Edge, out-of-the-box, with zero user config.