### PR TITLE
support testem.cjs, for use in ESM / (type=module) projects

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -8,6 +8,9 @@ This document will go into more detail about the Testem configuration file and l
 * `testem.yml`
 * `.testem.yml`
 * `testem.js`
+* `.testem.js`
+* `testem.cjs`
+* `.testem.cjs`
 
 The file is looked for in the user's current directory.
 
@@ -137,7 +140,7 @@ Hooks can be defined as a string in which case they run as a shell command or as
 If you need to resolve some async values in your configuration you can return a promise from `testem.js`. The resolved value of
 the promise will be passed to testem as configuration.
 
-```javascript 
+```javascript
 'use strict';
 
 async function getFramework() {

--- a/lib/config.js
+++ b/lib/config.js
@@ -406,12 +406,12 @@ class Config {
       if (patternUrl.protocol === 'file:') {
         pattern = patternUrl.hostname + patternUrl.path;
       } else if (patternUrl.protocol) {
-        return allThatIWant.concat({src: pattern, attrs: attrs});
+        return allThatIWant.concat({ src: pattern, attrs: attrs });
       }
 
       return globAsync(this.resolvePath(pattern), { ignore: dontWant }).then(files => allThatIWant.concat(files.map(f => {
         f = this.reverseResolvePath(f);
-        return {src: f, attrs: attrs};
+        return { src: f, attrs: attrs };
       })));
     }, [])
       .then(result => _.uniqBy(result, 'src'))

--- a/lib/config.js
+++ b/lib/config.js
@@ -70,7 +70,7 @@ class Config {
 
       // Try all testem.json, testem.yml and testem.js
       // testem.json gets precedence
-      let files = ['testem.json', '.testem.json', '.testem.yml', 'testem.yml', 'testem.js', '.testem.js'];
+      let files = ['testem.json', '.testem.json', '.testem.yml', 'testem.yml', 'testem.js', '.testem.js', 'testem.cjs', '.testem.cjs'];
       return Bluebird.filter(files.map(this.resolveConfigPath.bind(this)), fileExists).then(matched => {
         let configFile = matched[0];
         if (matched.length > 1) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -151,6 +151,9 @@ class Server extends EventEmitter {
     app.get('/testem.js', (req, res) => {
       this.serveTestemClientJs(req, res);
     });
+    app.get('/testem.cjs', (req, res) => {
+      this.serveTestemClientJs(req, res);
+    });
 
     app.all(/^\/(?:-?[0-9]+)(\/.+)$/, serveStaticFile);
     app.all(/^(.+)$/, serveStaticFile);
@@ -171,7 +174,7 @@ class Server extends EventEmitter {
 
   configureExpress(app) {
     app.engine('mustache', Mustache);
-    app.set('view options', {layout: false});
+    app.set('view options', { layout: false });
     app.set('etag', 'strong');
     app.use((req, res, next) => {
       if (this.ieCompatMode) {
@@ -215,7 +218,7 @@ class Server extends EventEmitter {
   configureProxy(app) {
     var proxies = this.config.get('proxies');
     if (proxies) {
-      this.proxy = new httpProxy.createProxyServer({changeOrigin: true});
+      this.proxy = new httpProxy.createProxyServer({ changeOrigin: true });
 
       this.proxy.on('error', (err, req, res) => {
         res && res.status && res.status(500).json(err);
@@ -384,7 +387,7 @@ class Server extends EventEmitter {
         if (stat.isDirectory()) {
           fs.readdir(filePath, (err, files) => {
             var dirListingPage = `${__dirname}/../../views/directorylisting.mustache`;
-            res.render(dirListingPage, {files: files});
+            res.render(dirListingPage, { files: files });
           });
         } else {
           res.sendFile(filePath);

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -151,9 +151,6 @@ class Server extends EventEmitter {
     app.get('/testem.js', (req, res) => {
       this.serveTestemClientJs(req, res);
     });
-    app.get('/testem.cjs', (req, res) => {
-      this.serveTestemClientJs(req, res);
-    });
 
     app.all(/^\/(?:-?[0-9]+)(\/.+)$/, serveStaticFile);
     app.all(/^(.+)$/, serveStaticFile);

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -58,7 +58,7 @@ describe('Config', function() {
   describe('accepts empty config file', function() {
     let config;
     beforeEach(function(done) {
-      let progOptions = {framework: 'mocha', src_files: 'impl.js,tests.js', cwd: __dirname + '/empty'};
+      let progOptions = { framework: 'mocha', src_files: 'impl.js,tests.js', cwd: __dirname + '/empty' };
       config = new Config('dev', progOptions);
       config.read(done);
     });
@@ -116,6 +116,21 @@ describe('Config', function() {
     });
   });
 
+  describe('read cjs config file', function() {
+    let config;
+    beforeEach(function(done) {
+      let progOptions = {
+        file: __dirname + '/testem.cjs'
+      };
+      config = new Config('dev', progOptions);
+      config.read(done);
+    });
+    it('gets properties from config file', function() {
+      expect(config.get('framework')).to.equal('mocha');
+      expect(String(config.get('src_files'))).to.equal('impl.js,tests.js');
+    });
+  });
+
   describe('read js config file', function() {
     let config;
     beforeEach(function(done) {
@@ -162,7 +177,7 @@ describe('Config', function() {
 
   describe('getters system', function() {
     it('gives precendence to getters', function(done) {
-      let config = new Config('dev', {cwd: 'tests'});
+      let config = new Config('dev', { cwd: 'tests' });
       config.getters.cwd = 'cwdGetter';
       config.cwdGetter = function() { return 'setByGetter'; };
       config.read(function() {
@@ -174,7 +189,7 @@ describe('Config', function() {
 
   describe('get test_page', function() {
     it('defaults to config test_page', function(done) {
-      let config = new Config('dev', {test_page: 'default' });
+      let config = new Config('dev', { test_page: 'default' });
       config.read(function() {
         expect(config.get('test_page')[0]).to.equal('default');
         done();
@@ -223,7 +238,7 @@ describe('Config', function() {
   });
 
   it('give precendence to json config file', function(done) {
-    let config = new Config('dev', {cwd: 'tests'});
+    let config = new Config('dev', { cwd: 'tests' });
     config.read(function() {
       expect(config.get('framework')).to.equal('mocha');
       done();
@@ -264,12 +279,12 @@ describe('Config', function() {
   });
 
   it('should getLaunchers should call getAvailable browsers', function(done) {
-    sandbox.stub(config, 'getWantedLaunchers').callsFake(function(n, cb) {return cb(null, n);});
+    sandbox.stub(config, 'getWantedLaunchers').callsFake(function(n, cb) { return cb(null, n); });
 
     sandbox.stub(browserLauncher, 'getAvailableBrowsers').callsFake(function(config, browsers, cb) {
       cb(null, [
-        {name: 'Chrome', exe: 'chrome.exe'},
-        {name: 'Firefox'}
+        { name: 'Chrome', exe: 'chrome.exe' },
+        { name: 'Firefox' }
       ]);
     });
 
@@ -290,7 +305,7 @@ describe('Config', function() {
   });
 
   it('should install custom launchers', function(done) {
-    sandbox.stub(config, 'getWantedLaunchers').callsFake(function(n, cb) {return cb(null, n);});
+    sandbox.stub(config, 'getWantedLaunchers').callsFake(function(n, cb) { return cb(null, n); });
     config.config = {
       launchers: {
         Node: {
@@ -331,11 +346,11 @@ describe('Config', function() {
     });
     it('adds "launch_in_dev" config', function() {
       config.appMode = 'dev';
-      config.config = {launch_in_dev: ['Chrome', 'Firefox']};
+      config.config = { launch_in_dev: ['Chrome', 'Firefox'] };
       expect(config.getWantedLauncherNames()).to.deep.equal(['Chrome', 'Firefox']);
     });
     it('adds "launch_in_ci" config', function() {
-      config.config = {launch_in_ci: ['Chrome', 'Firefox']};
+      config.config = { launch_in_ci: ['Chrome', 'Firefox'] };
       expect(config.getWantedLauncherNames()).to.deep.equal(['Chrome', 'Firefox']);
     });
     it('removes skip param', function() {
@@ -425,7 +440,7 @@ describe('Config', function() {
       });
     });
     it('populates attributes', function(done) {
-      config.set('src_files', [{src: 'config_tests.js', attrs: ['data-foo="true"', 'data-bar']}]);
+      config.set('src_files', [{ src: 'config_tests.js', attrs: ['data-foo="true"', 'data-bar'] }]);
       config.getSrcFiles(function(err, files) {
         expect(files).to.deep.equal([
           fileEntry('config_tests.js', ['data-foo="true"', 'data-bar'])
@@ -435,7 +450,7 @@ describe('Config', function() {
     });
     it('populates attributes for only the desired globs', function(done) {
       config.set('src_files', [
-        {src: 'config_tests.js', attrs: ['data-foo="true"', 'data-bar']},
+        { src: 'config_tests.js', attrs: ['data-foo="true"', 'data-bar'] },
         'ci/*'
       ]);
       config.getSrcFiles(function(err, files) {
@@ -506,7 +521,7 @@ describe('Config', function() {
       });
     });
     it('does not return duplicates when file matches multiple globs', function(done) {
-      let egg = [ {
+      let egg = [{
         'attrs': [],
         'src': 'testem.yml'
       }];
@@ -624,8 +639,8 @@ function mockTopLevelProgOptions() {
   let parentOptions = {
     port: 8081,
     options: [
-      {name: function() { return 'port'; }},
-      {name: function() { return 'launcher'; }}
+      { name: function() { return 'port'; } },
+      { name: function() { return 'launcher'; } }
     ],
     cwd: 'tests'
   };

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -113,10 +113,6 @@ describe('Server', function() {
       request(baseUrl + '/testem.js', done);
     });
 
-    it('gets testem.cjs', function(done) {
-      request(baseUrl + '/testem.cjs', done);
-    });
-
     it('gets src file', function(done) {
       assertUrlReturnsFileContents(baseUrl + 'web/hello.js', 'tests/web/hello.js', done);
     });

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -26,7 +26,7 @@ describe('Server', function() {
         middleware: [middleware],
         src_files: [
           'web/hello.js',
-          {src:'web/hello_tst.js', attrs: ['data-foo="true"', 'data-bar']}
+          { src: 'web/hello_tst.js', attrs: ['data-foo="true"', 'data-bar'] }
         ],
         routes: {
           '/direct-test': 'web/direct',
@@ -111,6 +111,10 @@ describe('Server', function() {
 
     it('gets testem.js', function(done) {
       request(baseUrl + '/testem.js', done);
+    });
+
+    it('gets testem.cjs', function(done) {
+      request(baseUrl + '/testem.cjs', done);
     });
 
     it('gets src file', function(done) {
@@ -221,7 +225,7 @@ describe('Server', function() {
 
       beforeEach(function(done) {
         api1 = http.createServer(function(req, res) {
-          res.writeHead(200, {'Content-Type': 'text/plain'});
+          res.writeHead(200, { 'Content-Type': 'text/plain' });
           res.end('API');
         });
         let options = {
@@ -229,16 +233,16 @@ describe('Server', function() {
           cert: fs.readFileSync('tests/fixtures/certs/localhost.cert')
         };
         api2 = https.createServer(options, function(req, res) {
-          res.writeHead(200, {'Content-Type': 'text/plain'});
+          res.writeHead(200, { 'Content-Type': 'text/plain' });
           res.end('API - 2');
         });
         api3 = http.createServer(function(req, res) {
-          res.writeHead(200, {'Content-Type': 'application/json'});
-          res.end(JSON.stringify({API: 3}));
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ API: 3 }));
         });
 
         api4 = http.createServer(function(req, res) {
-          res.writeHead(200, {'Content-Type': 'application/json'});
+          res.writeHead(200, { 'Content-Type': 'application/json' });
           req.on('data', function(data) {
             res.write(data);
           });
@@ -498,7 +502,7 @@ describe('Server', function() {
         cert: 'tests/fixtures/certs/localhost.cert',
         src_files: [
           'web/hello.js',
-          {src:'web/hello_tst.js', attrs: ['data-foo="true"', 'data-bar']}
+          { src: 'web/hello_tst.js', attrs: ['data-foo="true"', 'data-bar'] }
         ],
         cwd: 'tests'
       });

--- a/tests/testem.cjs
+++ b/tests/testem.cjs
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  framework: 'mocha',
+  src_files: [
+    'impl.js',
+    'tests.js'
+  ]
+};


### PR DESCRIPTION
the default config, `testem.js`, is interpreted as an ES Module, when the package.json type=module is set.

To use testem, we still need a cjs config file -- so support the `.cjs` extension makes sense.

Been testing this over here: https://github.com/NullVoxPopuli/nullui/pull/35

via running:
```bash
~/Development/NullVoxPopuli/testem/testem.js
#                           ^ my clone of this repo
#                                  ^ bin file
```
