### PR TITLE
Add testStarted event to reporters, include launcherId in testdata

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -172,7 +172,9 @@ module.exports = class BrowserTestRunner {
 
       this.currentTestContext = testData;
       this.currentTestContext.state = 'executing';
-      this.reporter.testStarted(this.launcher.name, testData);
+      if (this.reporter.testStarted) {
+        this.reporter.testStarted(this.launcher.name, testData);
+      }
     }
   }
 

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -287,8 +287,8 @@ module.exports = class BrowserTestRunner {
       this.reportResults(new Error(this.exitRequested
         ? 'Browser exited on request from test driver'
         : 'Browser exited unexpectedly'),
-        code,
-        browserProcess);
+      code,
+      browserProcess);
     }, 1000);
   }
 

--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -142,6 +142,7 @@ module.exports = class BrowserTestRunner {
     }
 
     let tap = new BrowserTapConsumer(socket);
+    tap.on('tests-start', this.onTestsStart.bind(this));
     tap.on('test-result', this.onTestResult.bind(this));
     tap.on('all-test-results', this.onAllTestResults.bind(this));
     tap.on('all-test-results', () => {
@@ -165,8 +166,13 @@ module.exports = class BrowserTestRunner {
 
   onTestsStart(testData) {
     if (testData) {
+      Object.assign(testData, {
+        launcherId: this.launcherId,
+      });
+
       this.currentTestContext = testData;
       this.currentTestContext.state = 'executing';
+      this.reporter.testStarted(this.launcher.name, testData);
     }
   }
 
@@ -281,8 +287,8 @@ module.exports = class BrowserTestRunner {
       this.reportResults(new Error(this.exitRequested
         ? 'Browser exited on request from test driver'
         : 'Browser exited unexpectedly'),
-      code,
-      browserProcess);
+        code,
+        browserProcess);
     }, 1000);
   }
 

--- a/lib/utils/reporter.js
+++ b/lib/utils/reporter.js
@@ -67,6 +67,14 @@ class Reporter {
     }
   }
 
+  testStarted(name, data) {
+    this.reporters.forEach(reporter => {
+      if (reporter.testStarted) {
+        reporter.testStarted(name, data);
+      }
+    });
+  }
+
   close() {
     this.finish();
 


### PR DESCRIPTION
Adds
- launcherId to the test data (useful when you launch multiple browsers)
- wires up the testStarted event to reporters