### PR TITLE
expose cwd and config_dir via program options

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -35,6 +35,8 @@ program
   .option('-P, --parallel [num]', 'number of browsers to run in parallel, defaults to 1', Number)
   .option('-b, --bail_on_uncaught_error', 'Bail on any uncaught errors')
   .option('-R, --reporter [reporter]', 'Test reporter to use [tap|dot|xunit|teamcity]')
+  .option('--cwd [path]', 'directory to use as root')
+  .option('--config_dir [path]', 'directory to use as root for resolving configs, if different than cwd')
   .action(act(env => {
     env.__proto__ = program;
     progOptions = env;


### PR DESCRIPTION
This allows you to have a programatic build of your test assets and pass into the testem binary where the build location actually is.

Note: I only exposed `config_dir` because I needed the config to still stay in `process.cwd()`. I think it might make more sense to always search for config in `process.cwd()` but that's obviously a change that would need a major bump so I'm not necessarily proposing it right now.