### PR TITLE
Upgrade execa to v9.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 npm-debug.log
 npm-debug.log.*
 testem.log
+package-lock.json
+examples/*/package-lock.json

--- a/bin/run-integration.js
+++ b/bin/run-integration.js
@@ -61,7 +61,7 @@ function shellExec(cmd, runOpts) {
     return shell.exec(cmd, runOpts, function(exitCode, output) {
       if (exitCode !== 0) {
         return callback(new Error(
-          'Cmd: ' + cmd + ' failed with exit code: ' + exitCode + '\n' + output
+          'Cmd: ' + cmd + ' in directory: ' + path.basename(runOpts.cwd) + ' failed with exit code: ' + exitCode + '\n' + output
         ));
       }
       callback(null, output);

--- a/lib/process-ctl.js
+++ b/lib/process-ctl.js
@@ -1,7 +1,7 @@
 
 
 const log = require('npmlog');
-const execa = require('execa');
+const execa = require('execa').execa;
 const Bluebird = require('bluebird');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
@@ -11,6 +11,7 @@ const _ = require('lodash');
 const envWithLocalPath = require('./utils/env-with-local-path');
 const fileutils = require('./utils/fileutils');
 const Process = require('./utils/process');
+const isWin = require('./utils/is-win')();
 
 const fileExists = fileutils.fileExists;
 const executableExists = fileutils.executableExists;
@@ -37,7 +38,20 @@ module.exports = class ProcessCtl extends EventEmitter {
 
   _spawn(exe, args, options) {
     log.info('spawning: ' + exe + ' - ' + util.inspect(args));
-    let p  = new Process(this.name, { killTimeout: this.killTimeout }, execa(exe, args, options));
+
+    // promise should always succeed, Process will uses .on('error') to handle errors
+    let process = execa(exe, args, Object.assign({ reject: false }, options));
+
+    process.then(result => {
+      if (result.failed && result.exitCode !== 0 &&
+        result.shortMessage.includes(isWin ? 'is not recognized' : 'ENOENT'))
+      {
+        this.emit('processError', new Error(result.shortMessage), result.stdout, result.stderr);
+      }
+      return Promise.resolve(result);
+    });
+
+    let p  = new Process(this.name, { killTimeout: this.killTimeout }, process);
     this.emit('processStarted', p);
     return Bluebird.resolve(p);
   }

--- a/lib/runners/process_test_runner.js
+++ b/lib/runners/process_test_runner.js
@@ -21,6 +21,7 @@ class ProcessTestRunner {
         this.process = testProcess;
         this.process.once('processExit', this.onProcessExit.bind(this));
         this.process.once('processError', this.onProcessError.bind(this));
+        return Promise.resolve(testProcess);
       }).catch(reject);
     }).asCallback(onFinish);
   }

--- a/lib/utils/fileutils.js
+++ b/lib/utils/fileutils.js
@@ -1,7 +1,7 @@
 
 
 const fs = require('fs');
-const execa = require('execa');
+const execa = require('execa').execa;
 const Bluebird = require('bluebird');
 const log = require('npmlog');
 
@@ -15,9 +15,14 @@ exports.fileExists = function fileExists(path) {
 
 exports.executableExists = function executableExists(exe, options) {
   let cmd = isWin ? 'where' : 'which';
-  let test = execa(cmd, [exe], options);
+  let test = execa(cmd, [exe], Object.assign({ reject: false }, options));
 
-  test.on('error', error => log.error('Error spawning "' + cmd + exe + '"', error));
-
-  return test.then(result => result.code === 0, () => false);
+  return test.then(result => {
+    if (result.exitCode === 0) {
+      return true;
+    } else if (!result.exitCode) {
+      log.error('Error spawning "' + cmd + ' ' + exe + '"', result);
+    }
+    return false;
+  });
 };

--- a/lib/utils/is-win.js
+++ b/lib/utils/is-win.js
@@ -1,5 +1,3 @@
-
-
 function test(platform) {
   return /^win/.test(platform);
 }

--- a/lib/utils/process.js
+++ b/lib/utils/process.js
@@ -1,6 +1,4 @@
-
-
-const execa = require('execa');
+const execa = require('execa').execa;
 const log = require('npmlog');
 const Bluebird = require('bluebird');
 const EventEmitter = require('events').EventEmitter;
@@ -29,6 +27,15 @@ module.exports = class Process extends EventEmitter {
 
     this.process.on('close', this.onClose.bind(this));
     this.process.on('error', this.onError.bind(this));
+
+    this.process.then(result => {
+      if (result.failed && result.exitCode !== 0 &&
+        result.shortMessage.includes(isWin ? 'is not recognized' : 'ENOENT'))
+      {
+        this.onError(new Error(result.shortMessage), this.stdout, this.stderr);
+      }
+      return Promise.resolve(result);
+    });
   }
 
   onKillTimeout() {
@@ -48,7 +55,7 @@ module.exports = class Process extends EventEmitter {
 
   onError(error) {
     log.warn(this.name + ' errored', error);
-    this.process = null;
+    // this.process = null;
     this.exitCode = 1;
     this.emit('processError', error, this.stdout, this.stderr);
   }
@@ -132,14 +139,18 @@ function kill(p, sig) {
       args.push('/f');
     }
 
-    execa(command, args).then(result => {
+    const killProcess = execa(command, args, { reject: false });
+
+    killProcess.on('error', err => {
+      log.error(err);
+    });
+
+    killProcess.then(result => {
       // Processes without windows can't be killed without /F, detect and force
       // kill them directly
       if (result.stderr.indexOf('can only be terminated forcefully') !== -1) {
         kill(p, 'SIGKILL');
       }
-    }).catch(err => {
-      log.error(err);
     });
   } else {
     p.kill(sig);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commander": "^2.6.0",
     "compression": "^1.7.4",
     "consolidate": "^0.16.0",
-    "execa": "^1.0.0",
+    "execa": "^9.6.1",
     "express": "^4.10.7",
     "fireworm": "^0.7.2",
     "glob": "^7.0.4",

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -9,12 +9,12 @@ var assert = require('chai').assert;
 var expect = require('chai').expect;
 var path = require('path');
 var http = require('http');
-var execa = require('execa');
+var execa = require('execa').execa;
 var Bluebird = require('bluebird');
 
 var FakeReporter = require('../support/fake_reporter');
 
-var isWin = /^win/.test(process.platform);
+var isWin = require('../../lib/utils/is-win')();
 
 function makeTestReporter() {
   return new TestReporter(true, undefined, new Config('ci', {}));
@@ -147,7 +147,7 @@ describe('ci mode app', function() {
           launcher.on('processStarted', function(process) {
             setTimeout(function() {
               if (isWin) {
-                execa('taskkill /pid ' + process.pid + ' /T');
+                execa('taskkill /pid ' + process.pid + ' /T', [], { reject: false });
               } else {
                 process.kill();
               }

--- a/tests/process-ctl_tests.js
+++ b/tests/process-ctl_tests.js
@@ -8,7 +8,7 @@ const expect = require('chai').expect;
 const ProcessCtl = require('../lib/process-ctl');
 const Config = require('../lib/config');
 
-const isWin = /^win/.test(process.platform);
+const isWin = require('../lib/utils/is-win')();
 const isNodeLt012 = require('./support/is-node-lt-012');
 const config = new Config('ci', {}, {});
 

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -7,6 +7,7 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const Bluebird = require('bluebird');
 const path = require('path');
+const isWin = require('../../lib/utils/is-win')();
 
 const Config = require('../../lib/config');
 const Launcher = require('../../lib/launcher.js');
@@ -320,8 +321,13 @@ describe('browser test runner', function() {
           passed: 0,
           testContext: {}
         });
-        expect(reporter.results[0].result.error.message).to.match(/ENOENT/);
-        expect(reporter.results[0].result.logs[0].text).to.match(/ENOENT/);
+        if (isWin) {
+          expect(reporter.results[0].result.error.message).to.match(/is not recognized/);
+          expect(reporter.results[0].result.logs.at(-1).text).to.match(/is not recognized/);
+        } else {
+          expect(reporter.results[0].result.error.message).to.match(/ENOENT/);
+          expect(reporter.results[0].result.logs[0].text).to.match(/ENOENT/);
+        }
         done();
       });
     });

--- a/tests/runners/process_test_runner_tests.js
+++ b/tests/runners/process_test_runner_tests.js
@@ -8,6 +8,7 @@ var Launcher = require('../../lib/launcher.js');
 var ProcessTestRunner = require('../../lib/runners/process_test_runner');
 
 var FakeReporter = require('../support/fake_reporter');
+const isWin = require('../../lib/utils/is-win')();
 
 describe('ProcessTestRunner', function() {
   var reporter, config;
@@ -113,22 +114,42 @@ describe('ProcessTestRunner', function() {
     var runner = new ProcessTestRunner(launcher, reporter);
 
     runner.start(function() {
-      var expectedMessage = runner.lastErr + '\n';
+      let expectedMessage = '';
+      let expectedLogs = [];
+
+      if (runner.lastErr) {
+        expectedMessage = runner.lastErr.toString();
+      }
 
       if (runner.lastStderr) {
         expectedMessage += 'Stderr: \n ' + runner.lastStderr + '\n';
       }
 
-      var expectedLogs = [{
-        text: runner.lastErr.toString(),
-        type: 'error'
-      }];
-
-      if (runner.lastStderr) {
+      if (isWin) {
+        expectedMessage = 'Non-zero exit code: 1';
+        /* eslint-disable quotes */
+        const expectedStdErr =
+          `'nope-not-existing' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n`;
+        /* eslint-enable quotes */
+        const expectedTexts = [ expectedMessage, expectedStdErr ];
+        expectedTexts.forEach(expectedText => {
+          expectedLogs.push({
+            text: expectedText,
+            type: 'error'
+          });
+        });
+        expectedMessage = expectedTexts.join('\nStderr: \n ');
+      } else {
         expectedLogs.push({
-          text: runner.lastStderr,
+          text: expectedMessage,
           type: 'error'
         });
+        if (runner.lastStderr) {
+          expectedLogs.push({
+            text: runner.lastStderr,
+            type: 'error'
+          });
+        }
       }
 
       expect(reporter.results).to.deep.equal([{
@@ -140,7 +161,7 @@ describe('ProcessTestRunner', function() {
           passed: 0,
           testContext: {},
           error: {
-            message: expectedMessage
+            message: expectedMessage + '\n'
           }
         }
       }]);

--- a/tests/runners/tap_process_test_runner_tests.js
+++ b/tests/runners/tap_process_test_runner_tests.js
@@ -6,6 +6,7 @@ var path = require('path');
 var Config = require('../../lib/config');
 var Launcher = require('../../lib/launcher.js');
 var TapProcessTestRunner = require('../../lib/runners/tap_process_test_runner');
+const isWin = require('../../lib/utils/is-win')();
 
 var FakeReporter = require('../support/fake_reporter');
 
@@ -378,15 +379,21 @@ describe('tap process test runner', function() {
       runner.start(function() {
         var total = reporter.total;
         var pass = reporter.pass;
-        expect(pass).to.equal(0);
-        expect(total).to.equal(1);
+        if (isWin) {
+          expect(pass).to.equal(0);
+          expect(total).to.equal(0);
+          expect(reporter.results.length).to.equal(0);
+        } else {
+          expect(pass).to.equal(0);
+          expect(total).to.equal(1);
 
-        var results = reporter.results;
-        var failingTest = results[0];
-        expect(failingTest.result.failed).to.equal(1);
-        expect(failingTest.result.launcherId).to.equal(launcher.id);
-        expect(failingTest.result.name).to.equal('error');
-        expect(failingTest.result.error.message).to.match(/ENOENT/);
+          var results = reporter.results;
+          var failingTest = results[0];
+          expect(failingTest.result.failed).to.equal(1);
+          expect(failingTest.result.launcherId).to.equal(launcher.id);
+          expect(failingTest.result.name).to.equal('error');
+          expect(failingTest.result.error.message).to.match(/ENOENT/);
+        }
         done();
       });
     });

--- a/tests/strutils_tests.js
+++ b/tests/strutils_tests.js
@@ -8,7 +8,7 @@ const indent = strutils.indent;
 const template = strutils.template;
 const assert = require('chai').assert;
 
-const isWin = /^win/.test(process.platform);
+const isWin = require('../lib/utils/is-win')();
 
 describe('splitLines', function() {
   it('splits on newline', function() {

--- a/tests/ui/appview_tests.js
+++ b/tests/ui/appview_tests.js
@@ -6,7 +6,7 @@ var Config = require('../../lib/config');
 var screen = require('./fake_screen');
 var expect = require('chai').expect;
 
-var isWin = /^win/.test(process.platform);
+var isWin = require('../../lib/utils/is-win')();
 
 describe('AppView', !isWin ? function() {
 

--- a/tests/ui/error_messages_panel_tests.js
+++ b/tests/ui/error_messages_panel_tests.js
@@ -5,7 +5,7 @@ var screen = require('./fake_screen');
 var ErrorMessagesPanel = require('../../lib/reporters/dev/error_messages_panel');
 var Chars = require('../../lib/utils/chars');
 
-var isWin = /^win/.test(process.platform);
+var isWin = require('../../lib/utils/is-win')();
 
 describe('ErrorMessagesPanel', !isWin ? function() {
   var panel;

--- a/tests/ui/fake_screen_tests.js
+++ b/tests/ui/fake_screen_tests.js
@@ -3,7 +3,7 @@
 var expect = require('chai').expect;
 var screen = require('./fake_screen');
 
-var isWin = /^win/.test(process.platform);
+var isWin = require('../../lib/utils/is-win')();
 
 describe('FakeScreen', !isWin ? function() {
   beforeEach(function() {

--- a/tests/ui/runner_tabs_tests.js
+++ b/tests/ui/runner_tabs_tests.js
@@ -9,7 +9,7 @@ var Chars = require('../../lib/utils/chars');
 var RunnerTab = runnertabs.RunnerTab;
 var RunnerTabs = runnertabs.RunnerTabs;
 
-var isWin = /^win/.test(process.platform);
+var isWin = require('../../lib/utils/is-win')();
 
 describe('RunnerTab', !isWin ? function() {
   var tab, runner, appview, results;

--- a/tests/ui/scrollable_text_panel_tests.js
+++ b/tests/ui/scrollable_text_panel_tests.js
@@ -3,7 +3,7 @@
 var expect = require('chai').expect;
 var screen = require('./fake_screen');
 var ScrollableTextPanel = require('../../lib/reporters/dev/scrollable_text_panel');
-var isWin = /^win/.test(process.platform);
+var isWin = require('../../lib/utils/is-win')();
 
 describe('ScrollableTextPanel', !isWin ? function() {
 

--- a/tests/ui/split_log_panel_tests.js
+++ b/tests/ui/split_log_panel_tests.js
@@ -8,7 +8,7 @@ const screen = require('./fake_screen');
 const SplitLogPanel = require('../../lib/reporters/dev/split_log_panel');
 const Chars = require('../../lib/utils/chars');
 const TestResults = require('../../lib/reporters/dev/test_results');
-const isWin = /^win/.test(process.platform);
+const isWin = require('../../lib/utils/is-win')();
 
 describe('SplitLogPanel', !isWin ? function() {
 

--- a/tests/ui/view_tests.js
+++ b/tests/ui/view_tests.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const View = require('../../lib/reporters/dev/view');
 const Backbone = require('backbone');
 const sinon = require('sinon');
-const isWin = /^win/.test(process.platform);
+const isWin = require('../../lib/utils/is-win')();
 
 describe('view', !isWin ? function() {
   let view;


### PR DESCRIPTION
Fixes #1937 

See passing tests: https://github.com/Gaurav0/testem/pull/6

`execa` does not call `process.on('error', ...)` any more.
`execa` reports a failure if a process has any exit code other than zero
`execa` cannot reliably determine if a process failed to run normally but has a nonzero exit code or it failed to run in an exceptional way.

if a process failed to spawn or did not start because:
  - it was not found
  - it does not have permissions to run

`execa` fails just as it would if the process spawned but exited with a non-zero exit code. I have resorted to error message parsing to make the tests pass.