### PR TITLE
Replace @cypress/request with native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "@cypress/request": "^3.0.10",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
     "chai": "^6.2.2",

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -1,7 +1,10 @@
 const Server = require('../lib/server');
 const Config = require('../lib/config');
 const path = require('path');
-const request = require('@cypress/request');
+const { once } = require('node:events');
+const { httpRequest, listenPromise, closePromise } = require(
+  './utils/http_test_client',
+);
 const cheerio = require('cheerio');
 const fs = require('fs');
 const expect = require('chai').expect;
@@ -17,7 +20,7 @@ describe('Server', function() {
   let port = 63571;
 
   describe('http', function() {
-    before(function(done) {
+    before(async function() {
       config = new Config('dev', {
         port: port,
         socket_heartbeat_timeout: 6,
@@ -63,238 +66,197 @@ describe('Server', function() {
       baseUrl = 'http://localhost:' + port + '/';
 
       server = new Server(config);
+      const started = once(server, 'server-start');
       server.start();
-      server.once('server-start', function() {
-        done();
-      });
+      await started;
     });
     after(function() {
       return server.stop();
     });
 
     describe('routing and redirects', function() {
-      it('redirects to an id', function(done) {
-        request(baseUrl, { followRedirect: false }, function(err, res) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(302);
-          expect(res.headers.location).to.match(/^\/[0-9]+$/);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('redirects to an id', async function() {
+        const { res } = await httpRequest(baseUrl, { followRedirect: false });
+        expect(res.statusCode).to.eq(302);
+        expect(res.headers.location).to.match(/^\/[0-9]+$/);
+        expectMiddlewareHeaders(res);
       });
 
-      it('serves the homepage after redirect', function(done) {
-        request(baseUrl, { followRedirect: true }, function(err, res) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(200);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('serves the homepage after redirect', async function() {
+        const { res } = await httpRequest(baseUrl, { followRedirect: true });
+        expect(res.statusCode).to.eq(200);
+        expectMiddlewareHeaders(res);
       });
 
-      it('serves the homepage for a numeric browser id directly', function(done) {
-        request(baseUrl + '1234', function(err, res) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(200);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('serves the homepage for a numeric browser id directly', async function() {
+        const { res } = await httpRequest(baseUrl + '1234');
+        expect(res.statusCode).to.eq(200);
+        expectMiddlewareHeaders(res);
       });
 
-      it('serves the homepage for tap id (-1) directly', function(done) {
-        request(baseUrl + '-1', function(err, res) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(200);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('serves the homepage for tap id (-1) directly', async function() {
+        const { res } = await httpRequest(baseUrl + '-1');
+        expect(res.statusCode).to.eq(200);
+        expectMiddlewareHeaders(res);
       });
     });
 
     describe('test page rendering', function() {
-      it('gets scripts for the home page', function(done) {
-        request(baseUrl, function(err, res, text) {
-          let $ = cheerio.load(text);
-          let srcs = $('script')
-            .map(function() {
-              return $(this).attr('src');
-            })
-            .get();
-          expect(srcs).to.deep.equal([
-            '//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine.js',
-            '/testem.js',
-            '//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine-html.js',
-            'web' + path.sep + 'hello.js',
-            'web' + path.sep + 'hello_tst.js',
-          ]);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('gets scripts for the home page', async function() {
+        const { res, text } = await httpRequest(baseUrl);
+        let $ = cheerio.load(text);
+        let srcs = $('script')
+          .map(function() {
+            return $(this).attr('src');
+          })
+          .get();
+        expect(srcs).to.deep.equal([
+          '//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine.js',
+          '/testem.js',
+          '//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine-html.js',
+          'web' + path.sep + 'hello.js',
+          'web' + path.sep + 'hello_tst.js',
+        ]);
+        expectMiddlewareHeaders(res);
       });
 
-      it('serves custom test page', function(done) {
+      it('serves custom test page', async function() {
         config.set('test_page', 'web/tests.html');
-        assertUrlReturnsFileContents(baseUrl, 'tests/web/tests.html', done);
+        await assertUrlReturnsFileContents(baseUrl, 'tests/web/tests.html');
       });
 
-      it('renders custom test page as template', function(done) {
+      it('renders custom test page as template', async function() {
         config.set('test_page', 'web/tests_template.mustache');
-        request(baseUrl, function(err, res, text) {
-          expect(text).to.equal(
-            [
-              '<!doctype html>',
-              '<html>',
-              '<head>',
-              '    <script src="web/hello.js"></script>',
-              '    <script src="web/hello_tst.js" data-foo="true" data-bar></script>',
-              '</head>',
-              '',
-            ].join(os.EOL),
-          );
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest(baseUrl);
+        expect(text).to.equal(
+          [
+            '<!doctype html>',
+            '<html>',
+            '<head>',
+            '    <script src="web/hello.js"></script>',
+            '    <script src="web/hello_tst.js" data-foo="true" data-bar></script>',
+            '</head>',
+            '',
+          ].join(os.EOL),
+        );
+        expectMiddlewareHeaders(res);
       });
 
-      it('renders the first test page by default when multiple are provided', function(done) {
+      it('renders the first test page by default when multiple are provided', async function() {
         config.set('test_page', [
           'web/tests_template.mustache',
           'web/tests.html',
         ]);
-        request(baseUrl, function(err, res, text) {
-          expect(text).to.equal(
-            [
-              '<!doctype html>',
-              '<html>',
-              '<head>',
-              '    <script src="web/hello.js"></script>',
-              '    <script src="web/hello_tst.js" data-foo="true" data-bar></script>',
-              '</head>',
-              '',
-            ].join(os.EOL),
-          );
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest(baseUrl);
+        expect(text).to.equal(
+          [
+            '<!doctype html>',
+            '<html>',
+            '<head>',
+            '    <script src="web/hello.js"></script>',
+            '    <script src="web/hello_tst.js" data-foo="true" data-bar></script>',
+            '</head>',
+            '',
+          ].join(os.EOL),
+        );
+        expectMiddlewareHeaders(res);
       });
 
-      it('URL-encodes test_page path that starts with a slash', function(done) {
+      it('URL-encodes test_page path that starts with a slash', async function() {
         config.set('test_page', '/my/custom-page.html');
-        request(
-          baseUrl + '1234',
-          { followRedirect: false },
-          function(err, res) {
-            expect(err).to.be.null();
-            expect(res.statusCode).to.eq(302);
-            expect(res.headers.location).to.include('%2F');
-            done();
-          },
-        );
+        const { res } = await httpRequest(baseUrl + '1234', {
+          followRedirect: false,
+        });
+        expect(res.statusCode).to.eq(302);
+        expect(res.headers.location).to.include('%2F');
       });
     });
 
     describe('testem.js', function() {
-      it('gets testem.js', function(done) {
-        request(baseUrl + '/testem.js', done);
+      it('gets testem.js', async function() {
+        await httpRequest(baseUrl + '/testem.js');
       });
 
-      it('gets testem.js with expected content', function(done) {
-        request(baseUrl + 'testem.js', function(err, res, text) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(200);
-          expect(res.headers['content-type']).to.match(/javascript/);
-          expect(text).to.include('TestemConfig');
-          expect(text).to.include('testem_client.js');
-          done();
-        });
+      it('gets testem.js with expected content', async function() {
+        const { res, text } = await httpRequest(baseUrl + 'testem.js');
+        expect(res.statusCode).to.eq(200);
+        expect(res.headers['content-type']).to.match(/javascript/);
+        expect(text).to.include('TestemConfig');
+        expect(text).to.include('testem_client.js');
       });
     });
 
     describe('static file serving', function() {
-      it('gets src file', function(done) {
-        assertUrlReturnsFileContents(
+      it('gets src file', async function() {
+        await assertUrlReturnsFileContents(
           baseUrl + 'web/hello.js',
           'tests/web/hello.js',
-          done,
         );
       });
 
-      it('gets bundled files', function(done) {
-        assertUrlReturnsFileContents(
+      it('gets bundled files', async function() {
+        await assertUrlReturnsFileContents(
           baseUrl + 'testem/connection.html',
           'public/testem/connection.html',
-          done,
         );
       });
 
-      it('gets a file using a POST request', function(done) {
-        request.post(baseUrl + 'web/hello.js', function(err, res, text) {
-          expect(text).to.equal(
-            fs.readFileSync('tests/web/hello.js').toString(),
-          );
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('gets a file using a POST request', async function() {
+        const { res, text } = await httpRequest.post(baseUrl + 'web/hello.js');
+        expect(text).to.equal(
+          fs.readFileSync('tests/web/hello.js').toString(),
+        );
+        expectMiddlewareHeaders(res);
       });
 
-      it('lists directories', function(done) {
-        request(baseUrl + 'data', function(err, res, text) {
-          expect(text).to.match(/<a href="blah.txt">blah.txt<\/a>/);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('lists directories', async function() {
+        const { res, text } = await httpRequest(baseUrl + 'data');
+        expect(text).to.match(/<a href="blah.txt">blah.txt<\/a>/);
+        expectMiddlewareHeaders(res);
       });
 
-      it('returns 404 for a non-existent file', function(done) {
-        request(baseUrl + 'web/does-not-exist.js', function(err, res, text) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(404);
-          expect(text).to.match(/Not found/);
-          done();
-        });
+      it('returns 404 for a non-existent file', async function() {
+        const { res, text } = await httpRequest(
+          baseUrl + 'web/does-not-exist.js',
+        );
+        expect(res.statusCode).to.eq(404);
+        expect(text).to.match(/Not found/);
       });
 
-      it('serves local content with browser ids', function(done) {
-        assertUrlReturnsFileContents(
+      it('serves local content with browser ids', async function() {
+        await assertUrlReturnsFileContents(
           baseUrl + '1234' + '/web/hello.js',
           'tests/web/hello.js',
-          done,
         );
       });
 
-      it('serves local content with tap id', function(done) {
-        assertUrlReturnsFileContents(
+      it('serves local content with tap id', async function() {
+        await assertUrlReturnsFileContents(
           baseUrl + '-1' + '/web/hello.js',
           'tests/web/hello.js',
-          done,
         );
       });
 
-      it('serves local content with any negative numeric id', function(done) {
-        assertUrlReturnsFileContents(
+      it('serves local content with any negative numeric id', async function() {
+        await assertUrlReturnsFileContents(
           baseUrl + '-5' + '/web/hello.js',
           'tests/web/hello.js',
-          done,
         );
       });
 
-      it('serves a non-numeric single-segment path as a static file', function(done) {
+      it('serves a non-numeric single-segment path as a static file', async function() {
         // A single slug like /data should fall through the numeric /:id guard
         // and be served via the /*file catch-all route as a directory listing.
-        request(baseUrl + 'data', function(err, res) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(200);
-          done();
-        });
+        const { res } = await httpRequest(baseUrl + 'data');
+        expect(res.statusCode).to.eq(200);
       });
 
-      it('accepts other http methods', function(done) {
-        request.del(baseUrl + '-1' + '/web/hello.js', function(err, res) {
-          expect(err).to.be.null();
-          expect(res.statusCode).to.eq(200);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('accepts other http methods', async function() {
+        const { res } = await httpRequest.del(
+          baseUrl + '-1' + '/web/hello.js',
+        );
+        expect(res.statusCode).to.eq(200);
+        expectMiddlewareHeaders(res);
       });
     });
 
@@ -305,38 +267,31 @@ describe('Server', function() {
     });
 
     describe('route config', function() {
-      it('routes server paths to local paths', function(done) {
-        assertUrlReturnsFileContents(
+      it('routes server paths to local paths', async function() {
+        await assertUrlReturnsFileContents(
           baseUrl + 'direct-test/test.js',
           'tests/web/direct/test.js',
-          done,
         );
       });
 
-      it('allows fallback paths', function(done) {
-        let expectedCallbacks = 2;
-        let cb = function() {
-          if (--expectedCallbacks === 0) {
-            done();
-          }
-        };
-        assertUrlReturnsFileContents(
-          baseUrl + 'fallback-test/test.js',
-          'tests/web/direct/test.js',
-          cb,
-        );
-        assertUrlReturnsFileContents(
-          baseUrl + 'fallback-test/test2.js',
-          'tests/web/fallback/test2.js',
-          cb,
-        );
+      it('allows fallback paths', async function() {
+        await Promise.all([
+          assertUrlReturnsFileContents(
+            baseUrl + 'fallback-test/test.js',
+            'tests/web/direct/test.js',
+          ),
+          assertUrlReturnsFileContents(
+            baseUrl + 'fallback-test/test2.js',
+            'tests/web/fallback/test2.js',
+          ),
+        ]);
       });
     });
 
     describe('proxies', function() {
       let api1, api2, api3, api4, wsapi_server, wssapi_server;
 
-      beforeEach(function(done) {
+      beforeEach(async function() {
         api1 = http.createServer(function(req, res) {
           res.writeHead(200, { 'Content-Type': 'text/plain' });
           res.end('API');
@@ -367,110 +322,86 @@ describe('Server', function() {
         wsapi_server = http.createServer();
         wssapi_server = https.createServer(options);
 
-        api1.listen(13372, function() {
-          api2.listen(13373, function() {
-            api3.listen(13374, function() {
-              api4.listen(13375, function() {
-                wsapi_server.listen(13376, function() {
-                  wssapi_server.listen(13377, function() {
-                    done();
-                  });
-                });
-              });
-            });
-          });
-        });
+        await listenPromise(api1, 13372);
+        await listenPromise(api2, 13373);
+        await listenPromise(api3, 13374);
+        await listenPromise(api4, 13375);
+        await listenPromise(wsapi_server, 13376);
+        await listenPromise(wssapi_server, 13377);
       });
 
-      afterEach(function(done) {
-        api1.close(function() {
-          api2.close(function() {
-            api3.close(function() {
-              api4.close(function() {
-                wsapi_server.close(function() {
-                  wssapi_server.close(function() {
-                    done();
-                  });
-                });
-              });
-            });
-          });
-        });
+      afterEach(async function() {
+        await closePromise(api1);
+        await closePromise(api2);
+        await closePromise(api3);
+        await closePromise(api4);
+        await closePromise(wsapi_server);
+        await closePromise(wssapi_server);
       });
 
-      it('proxies get request to api1', function(done) {
-        request.get(baseUrl + 'api1/hello', function(err, res, text) {
-          expect(text).to.equal('API');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('proxies get request to api1', async function() {
+        const { res, text } = await httpRequest.get(baseUrl + 'api1/hello');
+        expect(text).to.equal('API');
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies get request with deep subpath to api1', function(done) {
-        request.get(baseUrl + 'api1/foo/bar/baz', function(err, res, text) {
-          expect(text).to.equal('API');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+      it('proxies get request with deep subpath to api1', async function() {
+        const { res, text } = await httpRequest.get(
+          baseUrl + 'api1/foo/bar/baz',
+        );
+        expect(text).to.equal('API');
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies get request to api2', function(done) {
+      it('proxies get request to api2', async function() {
         let options = {
           url: baseUrl + 'api2/hello',
           headers: {
             'Content-Type': 'application/json',
           },
         };
-        request.get(options, function(err, res, text) {
-          expect(text).to.equal('API - 2');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest.get(options);
+        expect(text).to.equal('API - 2');
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies post request to api1', function(done) {
+      it('proxies post request to api1', async function() {
         let options = {
           url: baseUrl + 'api1/hello',
           headers: {
             Accept: 'application/json',
           },
         };
-        request.post(options, function(err, res, text) {
-          expect(text).to.equal('API');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest.post(options);
+        expect(text).to.equal('API');
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies get request to api3', function(done) {
+      it('proxies get request to api3', async function() {
         let options = {
           url: baseUrl + 'api3/test',
           headers: {
             Accept: 'application/json',
           },
         };
-        request.get(options, function(err, res, text) {
-          expect(text).to.equal('{"API":3}');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest.get(options);
+        expect(text).to.equal('{"API":3}');
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies post request to api3', function(done) {
+      it('proxies post request to api3', async function() {
         let options = {
           url: baseUrl + 'api3/test',
           headers: {
             Accept: 'application/json',
           },
         };
-        request.post(options, function(err, res, text) {
-          expect(text).to.equal('{"API":3}');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest.post(options);
+        expect(text).to.equal('{"API":3}');
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies post request to api4', function(done) {
+      it('proxies post request to api4', async function() {
         let options = {
           url: baseUrl + 'api4/test',
           headers: {
@@ -478,17 +409,12 @@ describe('Server', function() {
           },
           body: '{test: \'some value\'}',
         };
-        request.post(options, function(err, res, text) {
-          if (err) {
-            return done(err);
-          }
-          expect(text).to.equal('{test: \'some value\'}');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest.post(options);
+        expect(text).to.equal('{test: \'some value\'}');
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies get html request to api3', function(done) {
+      it('proxies get html request to api3', async function() {
         let options = {
           url: baseUrl + 'api3/test',
           headers: {
@@ -496,79 +422,108 @@ describe('Server', function() {
               'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
           },
         };
-        request.get(options, function(err, res, text) {
-          expect(text).to.equal('Not found: /api3/test');
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest.get(options);
+        expect(text).to.equal('Not found: /api3/test');
+        expectMiddlewareHeaders(res);
       });
 
-      it('returns an error when a requst can not be proxied', function(done) {
+      it('returns an error when a requst can not be proxied', async function() {
         let options = {
           url: baseUrl + 'api-error/test',
         };
-        request.get(options, function(err, res, text) {
-          expect(res.statusCode).to.eq(500);
-          expect(text).to.match(/ECONNREFUSED/);
-          expectMiddlewareHeaders(res);
-          done();
-        });
+        const { res, text } = await httpRequest.get(options);
+        expect(res.statusCode).to.eq(500);
+        expect(text).to.match(/ECONNREFUSED/);
+        expectMiddlewareHeaders(res);
       });
 
-      it('proxies WebSocket to wsapi (ws → ws)', function(done) {
+      it('proxies WebSocket to wsapi (ws → ws)', async function() {
         const wsMsg = 'Hello over wsapi: 341bcb0e-db49-468d-924b-135645cafb90';
         const wsPingMsg =
           'Ping over wsapi: bb161729-414d-4861-8090-db3bbbe728d3';
         const wsapi = new ws.Server({ server: wsapi_server });
-        wsapi.on('connection', function(socket) {
-          socket.on('message', function(message) {
-            expect(message.toString()).to.equal(wsMsg);
-            done();
-          });
-          socket.on('ping', function(data) {
-            expect(data.toString()).to.equal(wsPingMsg);
-          }); // + autoPong by server
-        });
-        const wsClient = new ws.WebSocket('ws://localhost:' + port + '/wsapi');
-
-        wsClient.on('open', function() {
-          wsClient.on('pong', function(data) {
-            expect(data.toString()).to.equal(wsPingMsg);
-            wsClient.send(wsMsg, { binary: false }, function() {
-              wsClient.close();
+        const wsapiPromise = new Promise(function (resolve, reject) {
+          wsapi.on('connection', function(socket) {
+            socket.on('message', function(message) {
+              try {
+                expect(message.toString()).to.equal(wsMsg);
+                resolve();
+              } catch (e) {
+                reject(e);
+              }
+            });
+            socket.on('ping', function(data) {
+              expect(data.toString()).to.equal(wsPingMsg);
             });
           });
-          wsClient.ping(wsPingMsg);
         });
+        const wsClient = new ws.WebSocket('ws://localhost:' + port + '/wsapi');
+        wsClient.on('error', function () {
+          wsapi.close();
+        });
+
+        const openPromise = new Promise(function (resolve, reject) {
+          wsClient.on('open', function() {
+            wsClient.on('pong', function(data) {
+              expect(data.toString()).to.equal(wsPingMsg);
+              wsClient.send(wsMsg, { binary: false }, function() {
+                wsClient.close();
+              });
+            });
+            wsClient.ping(wsPingMsg);
+            resolve();
+          });
+          wsClient.on('error', reject);
+        });
+        await openPromise;
+        await wsapiPromise;
+        wsapi.close();
       });
 
-      it('proxies WebSocket to wssapi (ws → wss)', function(done) {
+      it('proxies WebSocket to wssapi (ws → wss)', async function() {
         const wssMsg =
           'Hello over wssapi: 5a120d3f-be82-408f-99ec-be92e7cd8ab7';
         const wssPingMsg =
           'Ping over wssapi: 19c0c2eb-52a3-4be3-83d1-f93eb35479ca';
         const wssapi = new ws.Server({ server: wssapi_server });
-        wssapi.on('connection', function(socket) {
-          socket.on('message', function(message) {
-            expect(message.toString()).to.equal(wssMsg);
-            done();
+        const wssapiPromise = new Promise(function (resolve, reject) {
+          wssapi.on('connection', function(socket) {
+            socket.on('message', function(message) {
+              try {
+                expect(message.toString()).to.equal(wssMsg);
+                resolve();
+              } catch (e) {
+                reject(e);
+              }
+            });
+            socket.on('ping', function(data) {
+              expect(data.toString()).to.equal(wssPingMsg);
+            });
           });
-          socket.on('ping', function(data) {
-            expect(data.toString()).to.equal(wssPingMsg);
-          }); // + autoPong by server
         });
         const wssClient = new ws.WebSocket(
           'ws://localhost:' + port + '/wssapi',
-        ); // ws → wss !
-        wssClient.on('open', function() {
-          wssClient.on('pong', function(data) {
-            expect(data.toString()).to.equal(wssPingMsg);
-            wssClient.send(wssMsg, { binary: false }, function() {
-              wssClient.close();
-            });
-          });
-          wssClient.ping(wssPingMsg);
+        );
+        wssClient.on('error', function () {
+          wssapi.close();
         });
+
+        const openPromise = new Promise(function (resolve, reject) {
+          wssClient.on('open', function() {
+            wssClient.on('pong', function(data) {
+              expect(data.toString()).to.equal(wssPingMsg);
+              wssClient.send(wssMsg, { binary: false }, function() {
+                wssClient.close();
+              });
+            });
+            wssClient.ping(wssPingMsg);
+            resolve();
+          });
+          wssClient.on('error', reject);
+        });
+        await openPromise;
+        await wssapiPromise;
+        wssapi.close();
       });
     });
   });
@@ -576,7 +531,7 @@ describe('Server', function() {
   describe('a wildcard proxy', function() {
     let api;
 
-    before(function(done) {
+    before(async function() {
       config = new Config('dev', {
         port: port,
         cwd: 'tests',
@@ -594,37 +549,28 @@ describe('Server', function() {
       });
 
       server = new Server(config);
+      const started = once(server, 'server-start');
       server.start();
-
-      server.once('server-start', function() {
-        api.listen(13372, function() {
-          done();
-        });
-      });
+      await started;
+      await listenPromise(api, 13372);
     });
-    after(function() {
-      return server
-        .stop()
-        .then(() => new Promise((resolve) => api.close(resolve)));
+    after(async function() {
+      await server.stop();
+      await closePromise(api);
     });
 
-    it('does not proxy testem files', function(done) {
-      request.get(baseUrl + 'foo/bar', function(err, res, text) {
-        expect(text).to.equal('proxied');
-
-        request.get(
-          baseUrl + 'testem/connection.html',
-          function(err, res, text) {
-            expect(text).to.not.equal('proxied');
-            done();
-          },
-        );
-      });
+    it('does not proxy testem files', async function() {
+      const { text: t1 } = await httpRequest.get(baseUrl + 'foo/bar');
+      expect(t1).to.equal('proxied');
+      const { text: t2 } = await httpRequest.get(
+        baseUrl + 'testem/connection.html',
+      );
+      expect(t2).to.not.equal('proxied');
     });
   });
 
   describe('https', function() {
-    before(function(done) {
+    before(async function() {
       config = new Config('dev', {
         port: port,
         key: 'tests/fixtures/certs/localhost.key',
@@ -638,22 +584,21 @@ describe('Server', function() {
       baseUrl = 'https://localhost:' + port + '/';
 
       server = new Server(config);
-      server.once('server-start', function() {
-        done();
-      });
+      const started = once(server, 'server-start');
       server.start();
+      await started;
     });
     after(function() {
       return server.stop();
     });
 
-    it('gets the home page', function(done) {
-      request({ url: baseUrl, strictSSL: false }, done);
+    it('gets the home page', async function() {
+      await httpRequest({ url: baseUrl, strictSSL: false });
     });
   });
 
   describe('https with pfx certificate', function() {
-    before(function(done) {
+    before(async function() {
       config = new Config('dev', {
         port: port,
         pfx: 'tests/fixtures/certs/localhost.pfx',
@@ -662,31 +607,29 @@ describe('Server', function() {
       baseUrl = 'https://localhost:' + port + '/';
 
       server = new Server(config);
-      server.once('server-start', function() {
-        done();
-      });
+      const started = once(server, 'server-start');
       server.start();
+      await started;
     });
     after(function() {
       return server.stop();
     });
 
-    it('gets the home page over https via pfx certificate', function(done) {
-      request({ url: baseUrl, strictSSL: false }, done);
+    it('gets the home page over https via pfx certificate', async function() {
+      await httpRequest({ url: baseUrl, strictSSL: false });
     });
   });
 
   describe('auto port assignment', function() {
-    before(function(done) {
+    before(async function() {
       config = new Config('dev', {
         port: 0,
         cwd: 'tests',
       });
       server = new Server(config);
-      server.once('server-start', function() {
-        done();
-      });
+      const started = once(server, 'server-start');
       server.start();
+      await started;
     });
     after(function() {
       return server.stop();
@@ -699,7 +642,7 @@ describe('Server', function() {
   });
 
   describe('unsafe directory handling', function() {
-    before(function(done) {
+    before(async function() {
       // Intentionally construct a path with forward slashes so that we can guard
       // against a regression on this issue: https://github.com/testem/testem/issues/1286
       var forwardSlashCwd = __dirname.split(path.sep).join('/');
@@ -713,34 +656,33 @@ describe('Server', function() {
       baseUrl = 'http://localhost:' + port + '/';
 
       server = new Server(config);
+      const started = once(server, 'server-start');
       server.start();
-      server.once('server-start', function() {
-        done();
-      });
+      await started;
     });
     after(function() {
       return server.stop();
     });
 
-    it('handles a request for safe content', function(done) {
-      request(baseUrl + 'web/hello.js', function(err, res) {
-        expect(res.statusCode).to.eq(200);
-        done();
-      });
+    it('handles a request for safe content', async function() {
+      const { res } = await httpRequest(baseUrl + 'web/hello.js');
+      expect(res.statusCode).to.eq(200);
     });
 
-    it('rejects a request for unsafe content', function(done) {
-      request(baseUrl + '../public/.eslintrc.js', function(err, res) {
-        expect(res.statusCode).to.eq(403);
-        done();
-      });
+    it('rejects a request for unsafe content', async function() {
+      // WHATWG URL / fetch join collapses ".." in the path; use encoding so
+      // the request path is still a traversal to ../public/... on the server.
+      const { res } = await httpRequest(
+        baseUrl + '%2E%2E%2Fpublic%2F.eslintrc.js',
+      );
+      expect(res.statusCode).to.eq(403);
     });
   });
 
   describe('routes["/"] config', function() {
     let routesServer, routesBaseUrl;
 
-    before(function(done) {
+    before(async function() {
       const routesConfig = new Config('dev', {
         port: port,
         cwd: 'tests',
@@ -748,28 +690,26 @@ describe('Server', function() {
       });
       routesBaseUrl = 'http://localhost:' + port + '/';
       routesServer = new Server(routesConfig);
+      const started = once(routesServer, 'server-start');
       routesServer.start();
-      routesServer.once('server-start', done);
+      await started;
     });
 
     after(function() {
       return routesServer.stop();
     });
 
-    it('serves static file instead of the default runner when routes["/"] is set', function(done) {
-      request(routesBaseUrl + '1234', function(err, res, text) {
-        expect(err).to.be.null();
-        expect(res.statusCode).to.eq(200);
-        expect(text).to.include('test.js');
-        done();
-      });
+    it('serves static file instead of the default runner when routes["/"] is set', async function() {
+      const { res, text } = await httpRequest(routesBaseUrl + '1234');
+      expect(res.statusCode).to.eq(200);
+      expect(text).to.include('test.js');
     });
   });
 
   describe('proxy with trailing slash URL key', function() {
     let trailingApi;
 
-    before(function(done) {
+    before(async function() {
       config = new Config('dev', {
         port: port,
         cwd: 'tests',
@@ -789,35 +729,30 @@ describe('Server', function() {
       });
 
       server = new Server(config);
+      const started = once(server, 'server-start');
       server.start();
-
-      server.once('server-start', function() {
-        trailingApi.listen(13378, function() {
-          done();
-        });
-      });
+      await started;
+      await listenPromise(trailingApi, 13378);
     });
 
-    after(function() {
-      return server
-        .stop()
-        .then(() => new Promise((resolve) => trailingApi.close(resolve)));
+    after(async function() {
+      await server.stop();
+      await closePromise(trailingApi);
     });
 
-    it('proxies requests when the proxy URL key has a trailing slash', function(done) {
-      request.get(baseUrl + 'api-trailing/hello', function(err, res, text) {
-        expect(err).to.be.null();
-        expect(res.statusCode).to.eq(200);
-        expect(text).to.equal('proxied');
-        done();
-      });
+    it('proxies requests when the proxy URL key has a trailing slash', async function() {
+      const { res, text } = await httpRequest.get(
+        baseUrl + 'api-trailing/hello',
+      );
+      expect(res.statusCode).to.eq(200);
+      expect(text).to.equal('proxied');
     });
   });
 
   describe('proxy with multiple wildcards in URL key', function() {
     let wildcardApi;
 
-    before(function(done) {
+    before(async function() {
       config = new Config('dev', {
         port: port,
         cwd: 'tests',
@@ -838,66 +773,54 @@ describe('Server', function() {
       });
 
       server = new Server(config);
+      const started = once(server, 'server-start');
       server.start();
-
-      server.once('server-start', function() {
-        wildcardApi.listen(13379, function() {
-          done();
-        });
-      });
+      await started;
+      await listenPromise(wildcardApi, 13379);
     });
 
-    after(function() {
-      return server
-        .stop()
-        .then(() => new Promise((resolve) => wildcardApi.close(resolve)));
+    after(async function() {
+      await server.stop();
+      await closePromise(wildcardApi);
     });
 
-    it('proxies requests when the proxy URL key contains multiple wildcards', function(done) {
-      request.get(baseUrl + 'api1/v2/resource', function(err, res, text) {
-        expect(err).to.be.null();
-        expect(res.statusCode).to.eq(200);
-        expect(text).to.equal('proxied');
-        done();
-      });
+    it('proxies requests when the proxy URL key contains multiple wildcards', async function() {
+      const { res, text } = await httpRequest.get(
+        baseUrl + 'api1/v2/resource',
+      );
+      expect(res.statusCode).to.eq(200);
+      expect(text).to.equal('proxied');
     });
   });
 
   describe('server start error', function() {
-    it('rejects and emits server-error when port is already in use', function(done) {
+    it('rejects and emits server-error when port is already in use', async function() {
       const occupiedConfig = new Config('dev', { port: 0, cwd: 'tests' });
       const occupiedServer = new Server(occupiedConfig);
 
-      occupiedServer.start().then(function() {
-        const occupiedPort = occupiedConfig.get('port');
-        const conflictConfig = new Config('dev', {
-          port: occupiedPort,
-          cwd: 'tests',
-        });
-        const conflictServer = new Server(conflictConfig);
-        let errorEmitted = false;
-
-        conflictServer.on('server-error', function() {
-          errorEmitted = true;
-        });
-
-        conflictServer
-          .start()
-          .then(function() {
-            return occupiedServer.stop().then(function() {
-              done(new Error('Expected start() to reject on port conflict'));
-            });
-          })
-          .catch(function(err) {
-            expect(err.code).to.eq('EADDRINUSE');
-            expect(errorEmitted).to.eq(true);
-            return occupiedServer.stop();
-          })
-          .then(function() {
-            done();
-          })
-          .catch(done);
+      await occupiedServer.start();
+      const occupiedPort = occupiedConfig.get('port');
+      const conflictConfig = new Config('dev', {
+        port: occupiedPort,
+        cwd: 'tests',
       });
+      const conflictServer = new Server(conflictConfig);
+      let errorEmitted = false;
+
+      conflictServer.on('server-error', function() {
+        errorEmitted = true;
+      });
+
+      try {
+        await conflictServer.start();
+      } catch (err) {
+        expect(err.code).to.eq('EADDRINUSE');
+        expect(errorEmitted).to.eq(true);
+        await occupiedServer.stop();
+        return;
+      }
+      await occupiedServer.stop();
+      throw new Error('Expected start() to reject on port conflict');
     });
   });
 
@@ -929,12 +852,9 @@ function expectMiddlewareHeaders(res) {
   expect(res.headers['x-testem-middleware']).to.eq('success');
 }
 
-function assertUrlReturnsFileContents(url, file, done) {
-  request(url, function(err, res, text) {
-    expect(err).to.be.null();
-    expect(res.statusCode).to.eq(200);
-    expectMiddlewareHeaders(res);
-    expect(text).to.equal(fs.readFileSync(file).toString());
-    done();
-  });
+async function assertUrlReturnsFileContents(url, file) {
+  const { res, text } = await httpRequest(url);
+  expect(res.statusCode).to.eq(200);
+  expectMiddlewareHeaders(res);
+  expect(text).to.equal(fs.readFileSync(file).toString());
 }

--- a/tests/utils/http_test_client.js
+++ b/tests/utils/http_test_client.js
@@ -1,0 +1,89 @@
+const { fetch, Agent } = require('undici');
+
+const insecureFetchAgent = new Agent({ connect: { rejectUnauthorized: false } });
+
+/**
+ * @returns {Promise<{ res: { statusCode: number, headers: Record<string, string> }, text: string }>}
+ */
+async function httpRequest(urlOrOpts, maybeOpts) {
+  let url;
+  const opt = {};
+  if (typeof urlOrOpts === 'string') {
+    url = urlOrOpts;
+    if (maybeOpts && typeof maybeOpts === 'object') {
+      Object.assign(opt, maybeOpts);
+    }
+  } else {
+    url = urlOrOpts.url;
+    Object.assign(opt, urlOrOpts);
+    delete opt.url;
+  }
+  const init = {
+    method: opt.method || 'GET',
+    headers: opt.headers,
+    body: opt.body,
+    redirect: opt.followRedirect === false ? 'manual' : 'follow',
+  };
+  if (opt.strictSSL === false) {
+    init.dispatcher = insecureFetchAgent;
+  }
+  const response = await fetch(url, init);
+  const text = await response.text();
+  const headers = {};
+  response.headers.forEach(function (v, k) {
+    headers[k.toLowerCase()] = v;
+  });
+  return {
+    res: { statusCode: response.status, headers },
+    text,
+  };
+}
+
+httpRequest.get = function (urlOrOpts, maybeOpts) {
+  if (typeof urlOrOpts === 'string') {
+    return httpRequest(urlOrOpts, { ...maybeOpts, method: 'GET' });
+  }
+  return httpRequest({ ...urlOrOpts, method: 'GET' });
+};
+
+httpRequest.post = function (urlOrOpts, maybeOpts) {
+  if (typeof urlOrOpts === 'string') {
+    return httpRequest(urlOrOpts, { ...maybeOpts, method: 'POST' });
+  }
+  return httpRequest({ ...urlOrOpts, method: 'POST' });
+};
+
+httpRequest.del = function (urlOrOpts, maybeOpts) {
+  if (typeof urlOrOpts === 'string') {
+    return httpRequest(urlOrOpts, { ...maybeOpts, method: 'DELETE' });
+  }
+  return httpRequest({ ...urlOrOpts, method: 'DELETE' });
+};
+
+function listenPromise(server, port) {
+  return new Promise(function (resolve, reject) {
+    server
+      .listen(port, function () {
+        resolve();
+      })
+      .on('error', reject);
+  });
+}
+
+function closePromise(server) {
+  return new Promise(function (resolve, reject) {
+    server.close(function (err) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+module.exports = {
+  httpRequest,
+  listenPromise,
+  closePromise,
+};

--- a/tests/utils/http_test_client_tests.js
+++ b/tests/utils/http_test_client_tests.js
@@ -1,0 +1,221 @@
+const { expect } = require('chai');
+const http = require('http');
+const https = require('https');
+const path = require('path');
+const fs = require('fs');
+const {
+  httpRequest,
+  listenPromise,
+  closePromise,
+} = require('./http_test_client');
+
+describe('http_test_client', function() {
+  describe('listenPromise', function() {
+    it('resolves when the server is listening on the port', async function() {
+      const s = http.createServer();
+      const p = 0;
+      await listenPromise(s, p);
+      expect(s.listening).to.equal(true);
+      const addr = s.address();
+      expect(addr.port).to.be.greaterThan(0);
+      await closePromise(s);
+    });
+
+    it('rejects when listen fails (port already in use)', async function() {
+      const a = http.createServer();
+      const b = http.createServer();
+      await listenPromise(a, 0);
+      const port = a.address().port;
+      try {
+        await listenPromise(b, port);
+        expect.fail('expected listen to reject');
+      } catch (err) {
+        expect(err.code).to.equal('EADDRINUSE');
+      } finally {
+        await closePromise(a);
+      }
+    });
+  });
+
+  describe('closePromise', function() {
+    it('resolves when the server closes', async function() {
+      const s = http.createServer();
+      await listenPromise(s, 0);
+      await closePromise(s);
+      expect(s.listening).to.equal(false);
+    });
+  });
+
+  describe('httpRequest', function() {
+    it('performs a GET and returns status, lowercased headers, and body', async function() {
+      const s = http.createServer(function (req, res) {
+        res.setHeader('X-Custom-Example', 'ok');
+        res.setHeader('Content-Type', 'text/plain');
+        res.writeHead(200);
+        res.end('hello');
+      });
+      await listenPromise(s, 0);
+      const port = s.address().port;
+      try {
+        const { res, text } = await httpRequest(
+          'http://127.0.0.1:' + port + '/',
+        );
+        expect(res.statusCode).to.equal(200);
+        expect(res.headers['content-type']).to.match(/text\/plain/);
+        expect(res.headers['x-custom-example']).to.equal('ok');
+        expect(text).to.equal('hello');
+      } finally {
+        await closePromise(s);
+      }
+    });
+
+    it('uses followRedirect: false to leave a 3xx and expose Location', async function() {
+      const s = http.createServer(function (req, res) {
+        if (req.url === '/from') {
+          res.writeHead(302, { Location: '/to' });
+          res.end();
+        } else {
+          res.writeHead(200);
+          res.end('arrived');
+        }
+      });
+      await listenPromise(s, 0);
+      const port = s.address().port;
+      const base = 'http://127.0.0.1:' + port;
+      try {
+        const { res, text } = await httpRequest(base + '/from', {
+          followRedirect: false,
+        });
+        expect(res.statusCode).to.equal(302);
+        expect(res.headers.location).to.equal('/to');
+        expect(text).to.equal('');
+      } finally {
+        await closePromise(s);
+      }
+    });
+
+    it('follows redirects by default and returns the final body', async function() {
+      const s = http.createServer(function (req, res) {
+        if (req.url === '/from') {
+          res.writeHead(302, { Location: '/to' });
+          res.end();
+        } else {
+          res.writeHead(200);
+          res.end('final');
+        }
+      });
+      await listenPromise(s, 0);
+      const port = s.address().port;
+      const base = 'http://127.0.0.1:' + port;
+      try {
+        const { res, text } = await httpRequest(base + '/from');
+        expect(res.statusCode).to.equal(200);
+        expect(text).to.equal('final');
+      } finally {
+        await closePromise(s);
+      }
+    });
+  });
+
+  describe('httpRequest.get', function() {
+    it('sends a GET for a string URL and for an object with url and headers', async function() {
+      const s = http.createServer(function (req, res) {
+        if (req.url === '/h') {
+          expect(req.headers['x-req-test']).to.equal('1');
+        }
+        res.writeHead(200);
+        res.end('get-ok');
+      });
+      await listenPromise(s, 0);
+      const port = s.address().port;
+      const base = 'http://127.0.0.1:' + port;
+      try {
+        const a = await httpRequest.get(base + '/');
+        expect(a.text).to.equal('get-ok');
+        const b = await httpRequest.get({
+          url: base + '/h',
+          headers: { 'X-Req-Test': '1' },
+        });
+        expect(b.text).to.equal('get-ok');
+      } finally {
+        await closePromise(s);
+      }
+    });
+  });
+
+  describe('httpRequest.post', function() {
+    it('sends a POST with body', async function() {
+      const s = http.createServer(function (req, res) {
+        let b = '';
+        req.on('data', function (c) {
+          b += c;
+        });
+        req.on('end', function() {
+          res.writeHead(200);
+          res.end('echo:' + b);
+        });
+      });
+      await listenPromise(s, 0);
+      const port = s.address().port;
+      const base = 'http://127.0.0.1:' + port;
+      try {
+        const { text } = await httpRequest.post({
+          url: base + '/',
+          body: 'payload',
+        });
+        expect(text).to.equal('echo:payload');
+      } finally {
+        await closePromise(s);
+      }
+    });
+  });
+
+  describe('httpRequest.del', function() {
+    it('sends a DELETE', async function() {
+      const s = http.createServer(function (req, res) {
+        if (req.method === 'DELETE') {
+          res.writeHead(200);
+          res.end('deleted');
+        } else {
+          res.writeHead(405);
+          res.end();
+        }
+      });
+      await listenPromise(s, 0);
+      const port = s.address().port;
+      const base = 'http://127.0.0.1:' + port;
+      try {
+        const { res, text } = await httpRequest.del(base + '/d');
+        expect(res.statusCode).to.equal(200);
+        expect(text).to.equal('deleted');
+      } finally {
+        await closePromise(s);
+      }
+    });
+  });
+
+  describe('httpRequest with strictSSL: false', function() {
+    it('fetches a self-signed HTTPS server without verify errors', async function() {
+      const key = fs.readFileSync(
+        path.join(__dirname, '../fixtures/certs/localhost.key'),
+      );
+      const cert = fs.readFileSync(
+        path.join(__dirname, '../fixtures/certs/localhost.cert'),
+      );
+      const s = https.createServer({ key, cert }, function (req, res) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('tls-ok');
+      });
+      await listenPromise(s, 0);
+      const port = s.address().port;
+      const url = 'https://127.0.0.1:' + port + '/';
+      try {
+        const { res, text } = await httpRequest({ url, strictSSL: false });
+        expect(res.statusCode).to.equal(200);
+        expect(text).to.equal('tls-ok');
+      } finally {
+        await closePromise(s);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Replaces `@cypress/request` with unidici and native fetch from nodejs. This reduces one dependency and avoids dropping nodejs 20 support.