### PR TITLE
chore(examples): upgrade node_tap example to tap 21.x

### DIFF
--- a/examples/node_tap_example/package.json
+++ b/examples/node_tap_example/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "tap": "^5.1.1"
+    "tap": "^21.7.1"
   },
   "scripts": {
     "test": "node ../../testem.js ci -P 10 --launch tap"


### PR DESCRIPTION
Same change: bump tap to ^21.7.1 in examples/node_tap_example.