### PR TITLE
chore(examples): upgrade webpack example to webpack 5

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -1,8 +1,10 @@
 {
   "devDependencies": {
+    "buffer": "^6.0.3",
+    "process": "^0.11.10",
     "fresh-tape": "^5.9.1",
-    "webpack": "^4.47.0",
-    "webpack-cli": "^4.10.0"
+    "webpack": "^5.106.2",
+    "webpack-cli": "^7.0.2"
   },
   "scripts": {
     "test": "node ../../testem.js ci -P 10"

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack');
+
 module.exports = {
   mode: 'production',
   entry: './tests/hello_test.js',
@@ -5,7 +7,17 @@ module.exports = {
     path: __dirname,
     filename: 'test-bundle.js'
   },
-  node: {
-    fs: 'empty'
-  }
+  resolve: {
+    fallback: {
+      fs: false,
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser')
+    }
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+      process: 'process/browser'
+    })
+  ]
 };


### PR DESCRIPTION
Same change: webpack 5, webpack-cli 7, config + buffer/process fallbacks in examples/webpack.