### PR TITLE
chore(examples): bump jshint example to ^2.13.6

### DIFF
--- a/examples/jshint/package.json
+++ b/examples/jshint/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "jshint": "^2.9.1"
+    "jshint": "^2.13.6"
   },
   "scripts": {
     "test": "node ../../testem.js ci -P 10"


### PR DESCRIPTION
Same change: jshint ^2.13.6 in examples/jshint.