### PR TITLE
chore(examples): bump tape example devDependencies

### DIFF
--- a/examples/tape_example/package.json
+++ b/examples/tape_example/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "esbuild-plugins-node-modules-polyfill": "^1.8.1",
-    "esbuild": "^0.25.1",
+    "esbuild": "^0.27.7",
     "fresh-tape": "^5.9.1"
   },
   "scripts": {


### PR DESCRIPTION
Same change: esbuild ^0.27.7, esbuild-plugins-node-modules-polyfill ^1.8.1, fresh-tape ^5.9.1 in examples/tape_example.