### PR TITLE
feat(config): load ESM testem.js and testem.mjs configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ To see all command line options for CI
 Configuration File
 ------------------
 
-For the simplest JavaScript projects, the TDD workflow described above will work fine. There are times when you want
-to structure your source files into separate directories, or want to have finer control over what files to include.
-This calls for the `testem.json` configuration file (you can also alternatively use the YAML format with a `testem.yml` file). It looks like
+For the simplest JavaScript projects, the TDD workflow described above will work fine. There are times when you want to structure your source files into separate directories, or want to have finer control over what files to include.
+
+This calls for the `testem.json` configuration file (you can also alternatively use the YAML format with a `testem.yml` file or return json from a javascript file `testem.js`). It looks like
 
 ```json
 {

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -1,7 +1,7 @@
 Testem Configuration File
 =========================
 
-This document will go into more detail about the Testem configuration file and list in glorious detail all of its available options. The config file is in either JSON format or YAML format and can be called any of the following
+This document will go into more detail about the Testem configuration file and list in glorious detail all of its available options. The config file may be JSON, YAML, or JavaScript (CommonJS or ESM). When auto-discovered (no `--file`), Testem tries these names in order and uses the first one that exists:
 
 * `testem.json`
 * `.testem.json`
@@ -9,6 +9,8 @@ This document will go into more detail about the Testem configuration file and l
 * `.testem.yml`
 * `testem.js`
 * `.testem.js`
+* `testem.mjs`
+* `.testem.mjs`
 * `testem.cjs`
 * `.testem.cjs`
 
@@ -38,6 +40,18 @@ module.exports = {
         "tests/*_tests.js"
     ],
     "reporter": new CustomReporter()
+};
+```
+
+You can author configs as ECMAScript modules. Use `testem.mjs`, or `testem.js` in a package with [`"type": "module"`](https://nodejs.org/api/packages.html#type) in `package.json`. Export the options object as the default export (or export an async function whose resolved value is the options object):
+
+```javascript
+export default {
+    framework: 'mocha',
+    src_files: [
+        'src/*.js',
+        'tests/*_tests.js'
+    ]
 };
 ```
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,8 @@ export default [
       "**/.eslintrc.js",
       "eslint.config.js",
       "tests/fixtures/**/*.js",
+      // Intentional parse error for custom-config tests; ESLint cannot parse it.
+      "tests/custom_configs/testem-syntax-error.mjs",
     ],
   },
   {

--- a/lib/api.js
+++ b/lib/api.js
@@ -10,7 +10,7 @@ const Server = require('./server');
 /*
   CLI-level options:
 
-  file:                 [String]  configuration file (testem.json, .testem.json, testem.yml, .testem.yml)
+  file:                 [String]  configuration file path (JSON, YAML, JS: testem.js / .cjs / .mjs and dotted variants)
   host:                 [String]  server host to use (localhost)
   port:                 [Number]  server port to use (7357)
   launch:               [Array]   list of launchers to use for current runs (defaults to current mode)

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,7 @@ const yaml = require('js-yaml');
 const log = require('./log');
 const path = require('path');
 const url = require('url');
+const { pathToFileURL } = url;
 const querystring = require('querystring');
 const { filter, reduce } = require('./utils/promises');
 
@@ -76,6 +77,8 @@ class Config {
         'testem.yml',
         'testem.js',
         '.testem.js',
+        'testem.mjs',
+        '.testem.mjs',
         'testem.cjs',
         '.testem.cjs',
       ];
@@ -144,7 +147,7 @@ class Config {
       if (callback) {
         callback.call(this);
       }
-    } else if (configFile.match(/\.c?js$/)) {
+    } else if (configFile.match(/\.(c?js|mjs)$/)) {
       this.readJS(configFile, callback);
     } else if (configFile.match(/\.json$/)) {
       this.readJSON(configFile, callback);
@@ -158,21 +161,59 @@ class Config {
     }
   }
 
+  unwrapJsExport(exported) {
+    if (
+      exported &&
+      typeof exported === 'object' &&
+      exported.__esModule === true &&
+      Object.prototype.hasOwnProperty.call(exported, 'default')
+    ) {
+      return exported.default;
+    }
+    return exported;
+  }
+
+  loadJsExportedConfig(absPath) {
+    const ext = path.extname(absPath);
+    if (ext === '.cjs') {
+      return Promise.resolve(this.unwrapJsExport(require(absPath)));
+    }
+    if (ext === '.mjs') {
+      return import(pathToFileURL(absPath).href).then((mod) =>
+        mod.default !== undefined ? mod.default : mod,
+      );
+    }
+    try {
+      return Promise.resolve(this.unwrapJsExport(require(absPath)));
+    } catch (e) {
+      if (e.code === 'ERR_REQUIRE_ESM') {
+        return import(pathToFileURL(absPath).href).then((mod) =>
+          mod.default !== undefined ? mod.default : mod,
+        );
+      }
+      throw e;
+    }
+  }
+
   readJS(configFile, callback) {
-    let exportedConfig = require(this.resolveConfigPath(configFile));
-    if (typeof exportedConfig === 'function') {
-      Promise.resolve(exportedConfig()).then((obj) => {
-        this.fileOptions = obj;
+    const absPath = this.resolveConfigPath(configFile);
+    this.loadJsExportedConfig(absPath)
+      .then((exportedConfig) => {
+        if (typeof exportedConfig === 'function') {
+          return Promise.resolve(exportedConfig()).then((obj) => {
+            this.fileOptions = obj;
+          });
+        }
+        this.fileOptions = exportedConfig;
+      })
+      .catch((err) => {
+        log.error(err);
+      })
+      .then(() => {
         if (callback) {
           callback.call(this);
         }
       });
-    } else {
-      this.fileOptions = exportedConfig;
-      if (callback) {
-        callback.call(this);
-      }
-    }
   }
 
   readYAML(configFile, callback) {

--- a/testem.js
+++ b/testem.js
@@ -48,7 +48,7 @@ function parseArgs(argv, { exitOverride = false } = {}) {
     .usage('[options]')
     .option(
       '-f, --file [file]',
-      'config file - defaults to testem.json or testem.yml',
+      'config file path (JSON, YAML, or JS: testem.js / testem.cjs / testem.mjs); when omitted, picks the first match among defaults (see docs)',
     )
     .option('-p, --port [num]', 'server port - defaults to 7357', Number)
     .option('--host [hostname]', 'host name - defaults to localhost', String)

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -1,6 +1,7 @@
 
 
 const Config = require('../lib/config.js');
+const log = require('../lib/log');
 const chai = require('chai');
 const assert = chai.assert;
 const expect = chai.expect;
@@ -146,6 +147,36 @@ describe('Config', function() {
     });
   });
 
+  describe('read mjs config file', function() {
+    let config;
+    beforeEach(function(done) {
+      let progOptions = {
+        file: path.join(__dirname, 'testem.mjs')
+      };
+      config = new Config('dev', progOptions);
+      config.read(done);
+    });
+    it('gets properties from config file', function() {
+      expect(config.get('framework')).to.equal('mocha');
+      expect(String(config.get('src_files'))).to.equal('impl.js,tests.js');
+    });
+  });
+
+  describe('read esm testem.js config file', function() {
+    let config;
+    beforeEach(function(done) {
+      let progOptions = {
+        file: path.join(__dirname, 'fixtures', 'esm_js_config', 'testem.js')
+      };
+      config = new Config('dev', progOptions);
+      config.read(done);
+    });
+    it('gets properties from config file', function() {
+      expect(config.get('framework')).to.equal('mocha');
+      expect(String(config.get('src_files'))).to.equal('impl.js,tests.js');
+    });
+  });
+
   describe('read js config file from custom path', function() {
     let config;
     beforeEach(function(done) {
@@ -172,6 +203,55 @@ describe('Config', function() {
     });
     it('gets properties from config file', function() {
       expect(config.get('framework')).to.equal('qunit');
+    });
+  });
+
+  describe('resolve promise from esm mjs config', function() {
+    let config;
+    beforeEach(function(done) {
+      let progOptions = {
+        file: path.join(__dirname, 'custom_configs', 'testem-promise-esm.mjs')
+      };
+      config = new Config('dev', progOptions);
+      config.read(done);
+    });
+    it('gets properties from config file', function() {
+      expect(config.get('framework')).to.equal('qunit');
+    });
+  });
+
+  describe('broken mjs config file (syntax error)', function() {
+    it('logs error, leaves fileOptions empty, and invokes callback', function(done) {
+      sandbox.stub(log, 'error');
+      let progOptions = {
+        file: path.join(__dirname, 'custom_configs', 'testem-syntax-error.mjs'),
+      };
+      let cfg = new Config('dev', progOptions);
+      cfg.read(function() {
+        expect(log.error.called).to.be.true();
+        expect(cfg.fileOptions).to.deep.equal({});
+        expect(cfg.get('framework')).to.be.undefined();
+        done();
+      });
+    });
+  });
+
+  describe('mjs config with named exports only (no default export)', function() {
+    let config;
+    beforeEach(function(done) {
+      let progOptions = {
+        file: path.join(__dirname, 'custom_configs', 'testem-named-exports-only.mjs'),
+      };
+      config = new Config('dev', progOptions);
+      config.read(done);
+    });
+    it('does not treat a named export as the config root', function() {
+      expect(config.get('framework')).to.be.undefined();
+      expect(config.fileOptions.config.framework).to.equal('mocha');
+      expect(config.fileOptions.config.src_files).to.deep.equal([
+        'impl.js',
+        'tests.js',
+      ]);
     });
   });
 

--- a/tests/custom_configs/testem-named-exports-only.mjs
+++ b/tests/custom_configs/testem-named-exports-only.mjs
@@ -1,0 +1,4 @@
+export const config = {
+  framework: 'mocha',
+  src_files: ['impl.js', 'tests.js'],
+};

--- a/tests/custom_configs/testem-promise-esm.mjs
+++ b/tests/custom_configs/testem-promise-esm.mjs
@@ -1,0 +1,7 @@
+export default function () {
+  return new Promise((resolve) => {
+    resolve({
+      framework: 'qunit',
+    });
+  });
+};

--- a/tests/custom_configs/testem-syntax-error.mjs
+++ b/tests/custom_configs/testem-syntax-error.mjs
@@ -1,0 +1,1 @@
+export default { framework: 'mocha' Syntax error intentional for tests

--- a/tests/fixtures/esm_js_config/package.json
+++ b/tests/fixtures/esm_js_config/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "private": true
+}

--- a/tests/fixtures/esm_js_config/testem.js
+++ b/tests/fixtures/esm_js_config/testem.js
@@ -1,0 +1,4 @@
+export default {
+  framework: 'mocha',
+  src_files: ['impl.js', 'tests.js'],
+};

--- a/tests/testem.mjs
+++ b/tests/testem.mjs
@@ -1,0 +1,4 @@
+export default {
+  framework: 'mocha',
+  src_files: ['impl.js', 'tests.js'],
+};


### PR DESCRIPTION
Allow for the use of testem.js / testem.mjs files authored using esm.

Example included in docs.

This is an enhancement; next release should be a minor if included.