### PR TITLE
fix(server): allow dot-prefixed path segments in static files

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -399,6 +399,12 @@ class Server extends EventEmitter {
         this.emit('file-requested', filePath);
       });
     } else {
+      // `dotfiles: 'allow'` restores the Express 4 (send@0.19) behavior of
+      // serving paths that contain intermediate dot-prefixed segments — common
+      // in pnpm projects, whose entire dependency tree lives under
+      // `node_modules/.pnpm/...`. send@1.x defaults to `'ignore'` and 404s any
+      // such path.
+      var sendOptions = { dotfiles: 'allow' };
       fs.promises.stat(filePath)
         .then(stat => {
           this.emit('file-requested', filePath);
@@ -408,11 +414,11 @@ class Server extends EventEmitter {
               res.render(dirListingPage, { files: files });
             });
           }
-          res.sendFile(filePath);
+          res.sendFile(filePath, sendOptions);
         })
         .catch(() => {
           this.emit('file-requested', filePath);
-          res.sendFile(filePath);
+          res.sendFile(filePath, sendOptions);
         });
     }
   }

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -251,6 +251,13 @@ describe('Server', function() {
         expect(res.statusCode).to.eq(200);
       });
 
+      it('serves files under a dot-prefixed directory (eg .pnpm/)', async function() {
+        await assertUrlReturnsFileContents(
+          baseUrl + 'web/.pnpm-like/inside.js',
+          'tests/web/.pnpm-like/inside.js',
+        );
+      });
+
       it('accepts other http methods', async function() {
         const { res } = await httpRequest.del(
           baseUrl + '-1' + '/web/hello.js',

--- a/tests/web/.pnpm-like/inside.js
+++ b/tests/web/.pnpm-like/inside.js
@@ -1,0 +1,3 @@
+// Fixture for the dotfile-segment static serving test.
+// The leading-dot directory name mimics layouts like `node_modules/.pnpm/...`.
+module.exports = 'dot-dir-content';


### PR DESCRIPTION
`send@1.x` (pulled in via Express 5) defaults to `dotfiles: 'ignore'` and 404s any path with a segment starting with `.`. `send@0.19` (Express 4) only rejected when the *last* segment did, so paths like `node_modules/.pnpm/qunit@2.25.0/...` worked before 3.20 and don't now.

Passes `{ dotfiles: 'allow' }` to both `res.sendFile` calls in `serveStaticFile` to restore the pre-3.20 behavior. Adds a fixture (`tests/web/.pnpm-like/inside.js`) and a test case asserting GET `/web/.pnpm-like/inside.js` returns its contents.

Closes #2012.