### PR TITLE
fix(saucelabs): keep Sauce Connect alive and wait for API readiness

### DIFF
--- a/examples/saucelabs/README.md
+++ b/examples/saucelabs/README.md
@@ -26,3 +26,8 @@ The `on_start` hook ([`saucie-connect.js`](saucie-connect.js)) uses saucie 4.0.2
 The `on_exit` hook ([`saucie-disconnect.js`](saucie-disconnect.js)) stops that process via `saucie.disconnect()`.
 
 See the [saucie Sauce Connect tunnel options](https://github.com/johanneswuerbach/saucie#sauce-connect-tunnel-options) for details.
+
+Browser launchers
+-----------------
+
+`SL_Safari_Current` uses `-v latest` because fixed Safari versions (for example `17`) are retired on Sauce Labs over time. `SL_Safari_Last` pins an older release for regression coverage.

--- a/examples/saucelabs/README.md
+++ b/examples/saucelabs/README.md
@@ -7,9 +7,22 @@ Instructions
 ------------
 
 1. Get a [SauceLabs](https://saucelabs.com/) account.
-2. Install [saucie](https://github.com/igorlima/sauce-js-tests-integration) via `SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true npm install saucie -g`. If the SAUCE_CONNECT_DOWNLOAD_ON_INSTALL environment variable is not set then [sauce-connect-launcher will attempt to download it](https://github.com/bermi/sauce-connect-launcher#installation) on the first run which might prevent saucie from working if elevated privileges are not used.
+2. Install dependencies from the testem repo root (`npm i`). The [saucie](https://github.com/johanneswuerbach/saucie) devDependency starts Sauce Connect and runs browsers on Sauce Labs.
 3. Make sure Sauce credentials are set in env:
     * **SAUCE_USERNAME** - your SauceLabs username
     * **SAUCE_ACCESS_KEY** - your SauceLabs API/Access key.
 4. Run `testem ci --port 8080` to run it on all the listed browsers - see `testem launchers` for the full list.
-    * *It will take a while at the first time. This will only happen once to download the jar of Sauce Connect*
+    * *It will take a while at the first time. This will only happen once to download the Sauce Connect binary*
+
+Sauce Connect lifecycle
+-----------------------
+
+The `on_start` hook ([`saucie-connect.js`](saucie-connect.js)) uses saucie 4.0.2+ to:
+
+- start Sauce Connect detached so the tunnel survives hook exit
+- wait for local `/readyz` and Sauce Labs API `is_ready`
+- write the process id to `sc_client.pid`
+
+The `on_exit` hook ([`saucie-disconnect.js`](saucie-disconnect.js)) stops that process via `saucie.disconnect()`.
+
+See the [saucie Sauce Connect tunnel options](https://github.com/johanneswuerbach/saucie#sauce-connect-tunnel-options) for details.

--- a/examples/saucelabs/saucie-connect.js
+++ b/examples/saucelabs/saucie-connect.js
@@ -6,14 +6,18 @@ var pidFile = 'sc_client.pid';
 var opts = {
   username: process.env.SAUCE_USERNAME,
   accessKey: process.env.SAUCE_ACCESS_KEY,
-  verbose: true,
   logger: console.log,
   pidfile: pidFile,
+  detached: true,
+  waitForApiReady: true,
   // Keep this in sync with saucie's default tunnel name in lib/config.js.
   tunnelIdentifier: process.env.GITHUB_RUN_ID || 'saucie',
   build: process.env.GITHUB_RUN_NUMBER || 1,
 };
 
-saucie.connect(opts).then(function () {
-  process.exit();
+saucie.connect(opts).then(function() {
+  process.exit(0);
+}).catch(function(err) {
+  console.error(err);
+  process.exit(1);
 });

--- a/examples/saucelabs/testem.json
+++ b/examples/saucelabs/testem.json
@@ -28,7 +28,7 @@
     },
     "SL_Safari_Current": {
       "exe": "../../node_modules/.bin/saucie",
-      "args": ["-b", "safari", "-v", "17", "--no-connect", "--attach", "-u"],
+      "args": ["-b", "safari", "-v", "latest", "--no-connect", "--attach", "-u"],
       "protocol": "browser"
     },
     "SL_Safari_Last": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-mocha": "^11.2.0",
     "fresh-tape": "^5.9.1",
     "mocha": "^11.7.5",
-    "saucie": "github:johanneswuerbach/saucie#096def52177da81bafad5861691a0636c8272630",
+    "saucie": "^4.1.0",
     "sinon": "^21.0.3",
     "sinon-chai": "^4.0.1",
     "socket.io-client": "^4.8.3"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-mocha": "^11.2.0",
     "fresh-tape": "^5.9.1",
     "mocha": "^11.7.5",
-    "saucie": "^4.0.1",
+    "saucie": "github:johanneswuerbach/saucie#096def52177da81bafad5861691a0636c8272630",
     "sinon": "^21.0.3",
     "sinon-chai": "^4.0.1",
     "socket.io-client": "^4.8.3"

--- a/tests/examples/saucie_connect_tests.js
+++ b/tests/examples/saucie_connect_tests.js
@@ -1,0 +1,42 @@
+
+var fs = require('fs');
+var path = require('path');
+
+var expect = require('chai').expect;
+var connect = require('saucie/lib/connect');
+
+describe('saucie connect (4.0.2+)', function() {
+  it('exports waitForApiReadiness', function() {
+    expect(connect.waitForApiReadiness).to.be.a('function');
+  });
+
+  it('exports prepareScBinary', function() {
+    expect(connect.prepareScBinary).to.be.a('function');
+  });
+
+  it('preserves the SC binary path through tunnel cleanup', function() {
+    return connect.prepareScBinary({ logger: function() {} }, {
+      ensureScBinaryAsync: function() {
+        return Promise.resolve('/tmp/sc');
+      },
+      stopExistingTunnelsAsync: function() {
+        return Promise.resolve();
+      }
+    }).then(function(binPath) {
+      expect(binPath).to.equal('/tmp/sc');
+    });
+  });
+});
+
+describe('saucie-connect hook', function() {
+  it('requests detached startup with API readiness and a pid file', function() {
+    var source = fs.readFileSync(
+      path.join(__dirname, '../../examples/saucelabs/saucie-connect.js'),
+      'utf8'
+    );
+
+    expect(source).to.match(/detached:\s*true/);
+    expect(source).to.match(/waitForApiReady:\s*true/);
+    expect(source).to.match(/pidfile:/);
+  });
+});


### PR DESCRIPTION
This fixes ci.

See also https://github.com/johanneswuerbach/saucie/pull/204

Once saucie 4.0.2 is published, I will replace the github sha "^4.0.2" for saucie.