### PR TITLE
Fix testem crash if hookItoTestFramework runs more than once

### DIFF
--- a/public/testem/testem_client.js
+++ b/public/testem/testem_client.js
@@ -80,7 +80,7 @@ function appendTestemIframeOnLoad(callback) {
 var testFrameworkDidInit = false;
 function hookIntoTestFramework(socket) {
   if (testFrameworkDidInit) {
-    return;
+    return true;
   }
 
   var found = true;


### PR DESCRIPTION
We ran into an issue where `hookIntoTestFramework` seemed to run multiple times in certain situations which crashed testem throwing an error: 

https://github.com/testem/testem/blob/6507dd132a4f0366fc0da5efa7fa2b0776d40932/public/testem/testem_client.js#L344-L346

Traced it back to the return value of `hookIntoTestFramework` being `undefined` instead of `true`.

https://github.com/testem/testem/blob/6507dd132a4f0366fc0da5efa7fa2b0776d40932/public/testem/testem_client.js#L80-L84