### PR TITLE
ci: run the full suite weekly on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - "0.8.x"
       - v*
   pull_request:
+  schedule:
+    - cron: "23 8 * * 4" # Thursdays 08:23 UTC
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Schedule the existing CI workflow every Thursday at 08:23 UTC so master breakage is visible even when nothing has been merged
- Add `workflow_dispatch` so the same suite can be run by hand from the Actions UI

Thursday avoids GitHub’s recent Monday reliability issues and leaves Friday to react if the run fails. The cron only starts after this lands on `master`.

## Test plan
- [ ] Confirm the workflow YAML is valid (`schedule` + `workflow_dispatch` next to the existing `push` / `pull_request` triggers)
- [ ] After merge, use **Actions → CI → Run workflow** to exercise the manual trigger
- [ ] Confirm a Thursday scheduled run appears on the Actions tab (the cron does not fire until this is on `master`)


Made with [Cursor](https://cursor.com)