### PR TITLE
build(deps): bump js-yaml from 4.3.1 to 5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^5.2.1",
     "glob": "^13.0.6",
     "http-proxy": "^1.18.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^5.3.0",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.5",
     "mkdirp": "^3.0.1",


### PR DESCRIPTION
## Summary
- Rebased copy of Dependabot #2033 onto current `master`. `@dependabot rebase` is limited to users with push access on testem/testem.
- Bumps `js-yaml` from `^4.1.1` to `^5.3.0`.

## Test plan
- [ ] CI on this PR
- [ ] Confirm Testem still loads YAML config files

Made with [Cursor](https://cursor.com)