### PR TITLE
build(deps-dev): bump esbuild from 0.27.7 to 0.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "chai-shallow-deep-equal": "^1.4.6",
     "cheerio": "^1.2.0",
     "dirty-chai": "^3.0.0",
-    "esbuild": "^0.27.4",
+    "esbuild": "^0.28.2",
     "esbuild-plugins-node-modules-polyfill": "^1.8.1",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Summary
- Rebased copy of Dependabot #2032 onto current `master`. `@dependabot rebase` is limited to users with push access on testem/testem.
- Bumps `esbuild` from `^0.27.4` to `^0.28.2`.

## Test plan
- [ ] CI on this PR
- [ ] Confirm the esbuild-based browser bundle / examples still build

Made with [Cursor](https://cursor.com)