### PR TITLE
build(deps-dev): bump eslint-plugin-mocha from 11.3.0 to 12.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-chai-expect": "^4.0.0",
-    "eslint-plugin-mocha": "^11.2.0",
+    "eslint-plugin-mocha": "^12.0.2",
     "fresh-tape": "^5.9.1",
     "mocha": "^11.7.5",
     "saucie": "^4.1.0",


### PR DESCRIPTION
## Summary
- Rebased copy of Dependabot #2030 onto current `master`. `@dependabot rebase` is limited to users with push access on testem/testem.
- Bumps `eslint-plugin-mocha` from `^11.2.0` to `^12.0.2`.
- v12 is a major: several rule names changed and `recommended` defaults were adjusted. Lint passed on the original Dependabot PR.

## Test plan
- [ ] CI on this PR
- [ ] `npm run lint` locally if eslint config needs the renamed rules

Made with [Cursor](https://cursor.com)