### PR TITLE
build(deps): bump actions/setup-node from 6 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: "npm"
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: browser-actions/setup-firefox@v1.7.2
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: "npm"
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: "npm"


### PR DESCRIPTION
## Summary
- Rebased copy of Dependabot #2023 onto current `master`. `@dependabot rebase` is limited to users with push access on testem/testem (this is the PR I tried to rebase).
- Bumps `actions/setup-node` from v6 to v7 in `.github/workflows/ci.yml`.

## Test plan
- [ ] CI on this PR (lint, unit, safari-smoke, browser-tests)

Made with [Cursor](https://cursor.com)