### PR TITLE
Update coffeescript example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,14 @@ If it isn't practical to write a test first, it might be my fault, feel free to 
 
 ### Integration Tests
 
-There are also some integrations tests that test running all the examples in the `examples` folder by cd'ing into each and executing `testem ci`. Examples that opt into modern built-in runners list `mocha`, `chai`, `jasmine-core`, or `qunit` in their own `package.json` (the integration runner already runs `npm install` in each example). Examples without those packages still use the CDN fallback. `mocha_simple` stays on CDN Mocha plus `expect.js`; `jshint` and `eslint` stay on CDN QUnit 1 so their global `test`/`equal` APIs keep working.
+There are also integration tests that run every example in the `examples` folder by `cd`'ing into each and executing `testem ci`. CI runs them on Linux, macOS, and Windows (`windows-latest` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)). The runner is [`bin/run-integration.js`](bin/run-integration.js):
 
-Node + headless browser
+* **`skipExamples`** — `browserstack` and `saucelabs` (need credentials; not run in CI).
+* **`skipOnWindows`** — only `webpack` (`webpack` is not on PATH in cmd.exe). The `coffeescript` example used to be skipped here because `before_tests: coffee -c *.coffee` passes a literal `*.coffee` to the CoffeeScript CLI on Windows; it now lists sources explicitly (`coffee -c hello.coffee tests.coffee`) and runs on Windows. See [`examples/coffeescript`](examples/coffeescript) and [Available hooks](docs/config_file.md#available-hooks) for that pitfall.
+* **Concurrency** — Windows runs examples one at a time (Headless Firefox is flaky in parallel); set `INTEGRATION_TESTS_CONCURRENCY` to override.
+
+Examples that opt into modern built-in runners list `mocha`, `chai`, `jasmine-core`, or `qunit` in their own `package.json` (the integration runner already runs `npm install` in each example). Examples without those packages still use the CDN fallback. `mocha_simple` stays on CDN Mocha plus `expect.js`; `jshint` and `eslint` stay on CDN QUnit 1 so their global `test`/`equal` APIs keep working.
+
+Node + headless browser:
 
     npm run integration

--- a/README.md
+++ b/README.md
@@ -629,7 +629,9 @@ Preprocessors (Babel, TypeScript, LESS, Sass, Browserify, CoffeeScript, etc)
 
 If you need to run a preprocessor (or indeed any shell command before the start of the tests) use the `before_tests` option, such as
 
-    "before_tests": "coffee -c *.coffee"
+    "before_tests": "coffee -c hello.coffee tests.coffee"
+
+On Windows, list files explicitly in string hooks like this—cmd.exe does not expand `*` for external programs (see [Available hooks](docs/config_file.md#available-hooks) and the [coffeescript example](examples/coffeescript)). Testem's own `src_files` / `watch_files` globs are expanded by Testem, not by the hook shell.
 
 or, with Babel (see the [Babel example](https://github.com/testem/testem/tree/master/examples/babel)):
 

--- a/bin/run-integration.js
+++ b/bin/run-integration.js
@@ -14,7 +14,6 @@ const skipExamples = [
   'saucelabs',  // requires credentials and doesn't work in CI
 ];
 const skipOnWindows = [
-  'coffeescript', // File not found: C:\projects\testem\examples\coffeescript\*.coffee
   'webpack' // 'webpack' is not recognized as an internal or external command, operable program or batch file.
 ];
 const skipDefiningReporter = [

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -168,6 +168,8 @@ Testem allows the test page to be served via HTTPS. To enable HTTPS either the p
 
 Hooks can be defined as a string in which case they run as a shell command or as a function in which case they will be passed 3 arguments: the Testem config object, a data object if present (see below), and a callback which should be invoked with a falsey argument (or no arguments) to indicate a passing result or with a truthy argument (such as an `Error` object) to indicate a failing result.
 
+String hooks run with `shell: true` (cmd.exe on Windows, `/bin/sh` on Unix). **Do not rely on shell glob expansion (`*.coffee`, `*.js`, etc.) in string hooks on Windows:** cmd.exe does not expand wildcards for external programs, so tools like `coffee` receive a literal `*.coffee` argument. List files explicitly (`coffee -c hello.coffee tests.coffee`), use a JavaScript hook and expand paths in Node, or call a small script from `before_tests`. Testem's own `src_files` / `watch_files` globs are expanded by Testem, not by the hook shell.
+
     on_start:             Runs on suite startup
     on_change:            Runs when a (non-config) file being watched is changed. Has a data object with a `file` property set to the changed file's path
     before_tests:         Runs before every run of tests

--- a/examples/coffeescript/README.md
+++ b/examples/coffeescript/README.md
@@ -8,4 +8,4 @@ Then, just run tests
 
     npm test
 
-Uses Testem's built-in `jasmine2` runner with Jasmine 5 from `node_modules`.
+The example compiles `hello.coffee` and `tests.coffee` to JavaScript before each run (`before_tests` in `testem.yml`), then uses Testem's built-in `jasmine2` runner with Jasmine 5 from `node_modules`. Sources are listed explicitly in the hook (not `*.coffee`) so the example runs in Windows integration tests—see [Available hooks](../../docs/config_file.md#available-hooks).

--- a/examples/coffeescript/README.md
+++ b/examples/coffeescript/README.md
@@ -1,9 +1,11 @@
 ## Setup
 
-First install dependencies
+First install dependencies (`coffeescript`, `jasmine-core`)
 
     npm install
 
 Then, just run tests
 
     npm test
+
+Uses Testem's built-in `jasmine2` runner with Jasmine 5 from `node_modules`.

--- a/examples/coffeescript/package.json
+++ b/examples/coffeescript/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
-    "coffee-script": "^1.10.0"
+    "coffeescript": "^2.7.0",
+    "jasmine-core": "^5.1.0"
   },
   "scripts": {
     "test": "node ../../testem.js ci -P 10"

--- a/examples/coffeescript/testem.yml
+++ b/examples/coffeescript/testem.yml
@@ -1,4 +1,4 @@
-framework: jasmine
+framework: jasmine2
 before_tests: coffee -c *.coffee
 on_exit: rm *.js
 src_files:

--- a/examples/coffeescript/testem.yml
+++ b/examples/coffeescript/testem.yml
@@ -1,6 +1,6 @@
 framework: jasmine2
-before_tests: coffee -c *.coffee
-on_exit: rm *.js
+before_tests: coffee -c hello.coffee tests.coffee
+on_exit: rm -f hello.js tests.js
 src_files:
 - "*.coffee"
 serve_files:


### PR DESCRIPTION
- Upgrade coffee-script v1 to coffeescript v2 (package renamed)
- Upgrade from jasmine 1 to jasmine 5
- Fix integration test on Windows
- Add note to README about cmd.exe not expanding globs like *.coffee