### PR TITLE
fix(report-file): surface write stream errors instead of a TypeError

### DIFF
--- a/lib/utils/report-file.js
+++ b/lib/utils/report-file.js
@@ -14,21 +14,16 @@ module.exports = class ReportFile {
 
     this.outputStream = fs.createWriteStream(reportFile, { flags: 'w+' });
 
-    let alreadyEnded = false;
-    function finish(data) {
-      if (!alreadyEnded) {
-        alreadyEnded = true;
-        this.outputStream.end(data);
-      }
-    }
-
-    this.outputStream.on('end', finish);
-    this.outputStream.on('error', finish);
-
     this.closePromise = new Promise((resolve, reject) => {
       this.outputStream.on('finish', resolve);
       this.outputStream.on('error', reject);
     });
+
+    // The stream can fail long before anything calls close() - opening an
+    // unwritable report file rejects on the next tick. Attach a no-op handler
+    // so that rejection is not reported as unhandled; close() still returns
+    // closePromise, so the error is surfaced to the caller.
+    this.closePromise.catch(() => {});
   }
 
   close() {

--- a/tests/utils/report-file_tests.js
+++ b/tests/utils/report-file_tests.js
@@ -1,4 +1,7 @@
 const expect = require('chai').expect;
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const Writable = require('stream').Writable;
 
 const { tmpNameAsync } = require('../support/tmp-name');
@@ -28,6 +31,22 @@ describe('ReportFile', function() {
         return reportFile.close();
       }).then(function() {
         expect(finished).to.be.true();
+      });
+    });
+
+    it('rejects with the write stream error when the file cannot be opened', function() {
+      // Opening a directory for writing fails, so the write stream emits an
+      // error before anything is ever written to it.
+      let dir = fs.mkdtempSync(path.join(os.tmpdir(), 'testem-report-file-'));
+      let reportFile = new ReportFile(dir);
+
+      return reportFile.close().then(function() {
+        throw new Error('close() should not have resolved');
+      }, function(err) {
+        expect(err.syscall).to.eq('open');
+        expect(err.path).to.eq(dir);
+      }).finally(function() {
+        fs.rmSync(dir, { recursive: true, force: true });
       });
     });
   });


### PR DESCRIPTION
`testem ci` dies with `TypeError: Cannot read properties of undefined (reading 'end')` when it cannot open the report file, and the real filesystem error never reaches the user. I hit it with a `testem.json` whose `report_file` points at an existing directory, so opening it for writing fails with EISDIR.

The cause is in `lib/utils/report-file.js`. Line 26 registers `finish` as an `error` listener on the write stream, but `finish` is a plain function, so `this` inside it is the stream that emitted the event, not the `ReportFile` instance. `this.outputStream` is undefined there and line 21 throws. That throw happens inside the `error` emit, before the second `error` listener on line 30 can reject `closePromise`, so it escapes as an uncaught exception and the open error is lost. Line 25 registers the same handler for `end`, which a writable stream never emits. Both are leftovers from when `ReportFile` wrapped two separate streams, an output stream and the file stream.

This removes both listeners. `close()` already ends the stream, and `closePromise` already resolves on `finish` and rejects on `error`, so the fs error now reaches the caller and testem shuts down through its normal path with exit code 1, the same as it already does when the report file's directory cannot be created. `closePromise` also gets a no-op catch, because an open failure rejects on the next tick, long before `close()` attaches its handler, and node would otherwise kill the process for an unhandled rejection.

Verification on macOS, node 22.23.2:

```
# the new test against unmodified master
$ npx mocha tests/utils/report-file_tests.js
  1 passing
  1 failing
  1) ReportFile close rejects with the write stream error when the file cannot be opened:
     Uncaught TypeError: Cannot read properties of undefined (reading 'end')
      at WriteStream.finish (lib/utils/report-file.js:21:27)

# with this change
$ npx mocha tests/utils/report-file_tests.js
  2 passing

$ npm run lint
  no output, exit 0

$ npm test
  832 passing (12m)
  2 pending
  8 failing
```

All 8 failures are 90 second timeouts in `tests/ci/ci_tests.js` and `tests/ci/dev_tests.js`, which launch Headless Firefox, and Firefox is not installed on the machine I ran this on. `npx mocha tests/ci/ci_tests.js tests/ci/dev_tests.js -g "handles todos correctly|keeps runner association"` fails identically on unmodified master. Every report file test passes with the change: the four in `tests/ci/report_file_tests.js` and the two in `tests/utils/report-file_tests.js`.
