### PR TITLE
feat: replace http-proxy with httpxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ Simply add a `proxies` section to the `testem.json` configuration file.
 ```
 
 This functionality is implemented as a *transparent proxy*, hence a request to
-`http://localhost:7357/api/posts.json` will be proxied to `http://localhost:4200/api/posts.json` without removing the `/api` prefix. Setting the `secure` option to `false` as in the above `/xmlapi` configuration block will ignore TLS certificate validation and allow tests to successfully reach that URL even if testem was launched over HTTP. Other available options can be found here: https://github.com/http-party/node-http-proxy#options
+`http://localhost:7357/api/posts.json` will be proxied to `http://localhost:4200/api/posts.json` without removing the `/api` prefix. Setting the `secure` option to `false` as in the above `/xmlapi` configuration block will ignore TLS certificate validation and allow tests to successfully reach that URL even if testem was launched over HTTP. Other available options can be found here: https://github.com/unjs/httpxy#options
 
 To limit the functionality to only certain content types, use "onlyContentTypes".
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -134,7 +134,7 @@ Generally supported but deprecated: IE 11, PhantomJS (using additional transpila
     phantomjs_debug_port:        [Number]  port used to attach phantomjs debugger
     phantomjs_args:              [Array]   custom arguments for the phantomjs launcher from https://phantomjs.org/api/command-line.html
     phantomjs_launch_script:     [String]  path of custom phantomjs launch script
-    proxies                      [Object]  path to options including `onlyContentTypes` and https://github.com/http-party/node-http-proxy#options
+    proxies                      [Object]  path to options including `onlyContentTypes` and https://github.com/unjs/httpxy#options
     reporter:                    [String]  name of the reporter to be used in ci mode ("tap" (default), "xunit", "dot", "teamcity") or an object implementing https://github.com/testem/testem/blob/master/docs/custom_reporter.md
     report_file:                 [String]  file to write test results to (stdout)
     route or routes:             [Object]  overrides for assets paths

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -19,7 +19,6 @@ var EventEmitter = require('events').EventEmitter;
 var Mustache = require('consolidate').mustache;
 var http = require('http');
 var https = require('https');
-var httpProxy = require('http-proxy');
 const { fromCallback, each } = require('../utils/promises');
 const { resolveRunnerFrameworkAssets } = require('../utils/runner_framework_assets');
 const { warnJasmine1Framework } = require('../utils/jasmine1_deprecation');
@@ -48,7 +47,12 @@ class Server extends EventEmitter {
     this.nextSocketId = 0;
   }
 
-  start() {
+  async start() {
+    if (!this.createProxyServer) {
+      const { createProxyServer } = await import('httpxy');
+      this.createProxyServer = createProxyServer;
+    }
+
     this.createExpress();
 
     // Start the server!
@@ -243,10 +247,13 @@ class Server extends EventEmitter {
   configureProxy(app) {
     var proxies = this.config.get('proxies');
     if (proxies) {
-      this.proxy = new httpProxy.createProxyServer({ changeOrigin: true });
+      this.proxy = this.createProxyServer({ changeOrigin: true });
 
       this.proxy.on('error', (err, req, res) => {
-        res && res.status && res.status(500).json(err);
+        // WebSocket upgrades pass a raw socket with no Express res.
+        if (res && res.status && !res.headersSent) {
+          res.status(500).json(err);
+        }
       });
 
       Object.keys(proxies).forEach((url) => {
@@ -254,7 +261,9 @@ class Server extends EventEmitter {
           // set up proxy for WebSocket
           this.server.on('upgrade', (req, socket, head) => {
             if (req.url.startsWith(url)) {
-              this.proxy.ws(req, socket, head, proxies[url]);
+              var wsOpts = Object.assign({}, proxies[url]);
+              delete wsOpts.onlyContentTypes;
+              this.proxy.ws(req, socket, wsOpts, head).catch(() => {});
             }
           });
           return;
@@ -265,15 +274,23 @@ class Server extends EventEmitter {
         let wIdx = 0;
         const proxyPath =
           url.replace(/\*/g, () => `:_proxyW${wIdx++}`).replace(/\/$/, '') + '{/*_proxyRest}';
-        app.all(proxyPath, (req, res, next) => {
+        app.all(proxyPath, async (req, res, next) => {
           var opts = proxies[url];
           if (this.shouldProxy(req, opts)) {
-            if (opts.host) {
-              opts.target = `http://${opts.host}:${opts.port}`;
-              delete opts.host;
-              delete opts.port;
+            var proxyOpts = Object.assign({}, opts);
+            if (proxyOpts.host) {
+              proxyOpts.target = `http://${proxyOpts.host}:${proxyOpts.port}`;
+              delete proxyOpts.host;
+              delete proxyOpts.port;
             }
-            this.proxy.web(req, res, opts);
+            delete proxyOpts.onlyContentTypes;
+            try {
+              await this.proxy.web(req, res, proxyOpts);
+            } catch (err) {
+              if (!res.headersSent) {
+                res.status(500).json(err);
+              }
+            }
           } else {
             next();
           }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -244,16 +244,22 @@ class Server extends EventEmitter {
     return false;
   }
 
+  sendProxyError(res, err) {
+    const message = (err && (err.message || err.code)) || 'Proxy error';
+    log.error(message);
+    // WebSocket upgrades pass a raw socket with no Express res.
+    if (res && res.status && !res.headersSent) {
+      res.status(500).json({ error: message });
+    }
+  }
+
   configureProxy(app) {
     var proxies = this.config.get('proxies');
     if (proxies) {
       this.proxy = this.createProxyServer({ changeOrigin: true });
 
       this.proxy.on('error', (err, req, res) => {
-        // WebSocket upgrades pass a raw socket with no Express res.
-        if (res && res.status && !res.headersSent) {
-          res.status(500).json(err);
-        }
+        this.sendProxyError(res, err);
       });
 
       Object.keys(proxies).forEach((url) => {
@@ -287,9 +293,7 @@ class Server extends EventEmitter {
             try {
               await this.proxy.web(req, res, proxyOpts);
             } catch (err) {
-              if (!res.headersSent) {
-                res.status(500).json(err);
-              }
+              this.sendProxyError(res, err);
             }
           } else {
             next();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "execa": "^9.6.1",
     "express": "^5.2.1",
     "glob": "^13.0.6",
-    "http-proxy": "^1.18.1",
+    "httpxy": "^0.5.5",
     "js-yaml": "^5.3.0",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.5",

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -440,6 +440,7 @@ describe('Server', function() {
         };
         const { res, text } = await httpRequest.get(options);
         expect(res.statusCode).to.eq(500);
+        expect(JSON.parse(text)).to.have.all.keys('error');
         expect(text).to.match(/ECONNREFUSED/);
         expectMiddlewareHeaders(res);
       });


### PR DESCRIPTION
## Summary
- Swap the abandoned `http-proxy` dependency for [`httpxy`](https://github.com/unjs/httpxy) `^0.5.5` (maintained unjs fork of `node-http-proxy`; zero dependencies).
- Public `proxies` config is unchanged (`target`, `secure`, `ws`, `host`/`port`, `onlyContentTypes`).
- `httpxy` is ESM-only, so the server dynamic-imports it in `start()` (Node 20 cannot `require` it). `proxy.web` / `proxy.ws` are awaited; HTTP failures still return 500 JSON when headers are not yet sent.
- README and `docs/config_file.md` now point at https://github.com/unjs/httpxy#options.

## Test plan
- [ ] `npx mocha tests/server_tests.js` (GET/POST, HTTPS `secure: false`, `onlyContentTypes`, ECONNREFUSED → 500, ws → ws / ws → wss, trailing slash and multi-wildcard keys)
- [ ] `npm test`
- [ ] Manual: HTTP `proxies` with `target` still forwards without stripping the path prefix
- [ ] Manual: WebSocket proxy with `ws: true` (and `secure: false` against a `wss` target)