### PR TITLE
chore: drop chai-files and chai-shallow-deep-equal devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "minimatch": "^10.2.5",
     "mkdirp": "^3.0.1",
     "mustache": "^4.2.0",
-    "toasted-notifier": "^10.1.0",
     "printf": "^0.6.1",
     "proc-log": "^6.1.0",
     "rimraf": "^6.1.3",
     "socket.io": "^4.8.3",
     "spawn-args": "^0.2.0",
     "styled_string": "0.0.1",
-    "tap-parser": "^18.3.0"
+    "tap-parser": "^18.3.0",
+    "toasted-notifier": "^10.1.0"
   },
   "files": [
     "lib",
@@ -68,8 +68,6 @@
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
     "chai": "^6.2.2",
-    "chai-files": "^1.4.0",
-    "chai-shallow-deep-equal": "^1.4.6",
     "cheerio": "^1.2.0",
     "dirty-chai": "^3.0.0",
     "esbuild": "^0.28.2",

--- a/tests/_prepare.js
+++ b/tests/_prepare.js
@@ -1,12 +1,8 @@
 const chai = require('chai');
 const sinonChai = require('sinon-chai').default;
-const chaiFiles = require('chai-files');
-const chaiShallowDeepEqual = require('chai-shallow-deep-equal');
 const dirtyChai = require('dirty-chai').default;
 
 chai.use(sinonChai);
-chai.use(chaiFiles);
-chai.use(chaiShallowDeepEqual);
 chai.use(dirtyChai);
 
 const path = require('path');

--- a/tests/runners/browser_test_runner_tests.js
+++ b/tests/runners/browser_test_runner_tests.js
@@ -310,23 +310,20 @@ describe('browser test runner', function() {
     it('fails when the browser fails to start', function(done) {
       launcher.settings.exe = 'not-found';
       runner.start(function() {
-        expect(reporter.results[0].result).to.shallowDeepEqual({
-          error: {},
-          failed: 1,
-          items: undefined,
-          launcherId: launcher.id,
-          logs: [{
-            type: 'error'
-          }],
-          passed: 0,
-          testContext: {}
-        });
+        const result = reporter.results[0].result;
+        expect(result.error).to.be.an('object');
+        expect(result.failed).to.equal(1);
+        expect(result.items).to.be.undefined();
+        expect(result.launcherId).to.equal(launcher.id);
+        expect(result.logs[0].type).to.equal('error');
+        expect(result.passed).to.equal(0);
+        expect(result.testContext).to.be.an('object');
         if (isWin) {
-          expect(reporter.results[0].result.error.message).to.match(/is not recognized/);
-          expect(reporter.results[0].result.logs.at(-1).text).to.match(/is not recognized/);
+          expect(result.error.message).to.match(/is not recognized/);
+          expect(result.logs.at(-1).text).to.match(/is not recognized/);
         } else {
-          expect(reporter.results[0].result.error.message).to.match(/ENOENT/);
-          expect(reporter.results[0].result.logs[0].text).to.match(/ENOENT/);
+          expect(result.error.message).to.match(/ENOENT/);
+          expect(result.logs[0].text).to.match(/ENOENT/);
         }
         done();
       });

--- a/tests/utils/known-browsers_tests.js
+++ b/tests/utils/known-browsers_tests.js
@@ -7,7 +7,6 @@ const path = require('path');
 const os = require('os');
 
 const expect = require('chai').expect;
-const file = require('chai-files').file;
 
 const knownBrowsers = require('../../lib/utils/known-browsers');
 
@@ -96,7 +95,7 @@ describe('knownBrowsers', function() {
 
       it('creates a config file on setup', function() {
         return fromCallback(cb => firefox.setup.call(launcher, config, cb)).then(function() {
-          expect(file(path.join(browserTmpDir, 'user.js'))).to.equal([
+          expect(fs.readFileSync(path.join(browserTmpDir, 'user.js'), 'utf8')).to.equal([
             'user_pref("browser.shell.checkDefaultBrowser", false);',
             'user_pref("browser.cache.disk.smart_size.first_run", false);',
             'user_pref("datareporting.policy.dataSubmissionEnabled", false);',
@@ -143,7 +142,7 @@ describe('knownBrowsers', function() {
         };
 
         return fromCallback(cb => firefox.setup.call(launcher, config, cb)).then(function() {
-          expect(file(path.join(browserTmpDir, 'user.js'))).to.equal([
+          expect(fs.readFileSync(path.join(browserTmpDir, 'user.js'), 'utf8')).to.equal([
             'user_pref("browser.shell.checkDefaultBrowser", false);',
             'user_pref("browser.cache.disk.smart_size.first_run", false);',
             'user_pref("dom.max_script_run_time", 0);'
@@ -477,7 +476,7 @@ describe('knownBrowsers', function() {
         it('creates a config file on setup', function(done) {
           safari.setup.call(launcher, config, function(err) {
             expect(err).to.be.null();
-            expect(file(path.join(browserTmpDir, 'start.html'))).to.equal(
+            expect(fs.readFileSync(path.join(browserTmpDir, 'start.html'), 'utf8')).to.equal(
               '<script>window.location = \'http://localhost:7357\'</script>'
             );
             done();


### PR DESCRIPTION
## Summary
- Remove the unmaintained `chai-files` and `chai-shallow-deep-equal` devDependencies (last releases 2016–2017). They were only used in Testem’s own Mocha suite, not in the published package.
- Replace three `chai-files` file-content checks with `fs.readFileSync` + Chai `.equal()`.
- Replace the one `shallowDeepEqual` subset check with field-level assertions that keep the same looseness (`error` / `testContext` are any object; extra keys and extra log lines are still ignored). OS-specific spawn error text is still matched with regex.

## Test plan
- [ ] `npm test`
- [ ] Confirm `tests/utils/known-browsers_tests.js` still asserts Firefox `user.js` and Safari `start.html` contents
- [ ] Confirm `fails when the browser fails to start` passes (spawn `ENOENT` / Windows “is not recognized”)