### PR TITLE
chore: drop mkdirp dependency

### DIFF
--- a/lib/utils/report-file.js
+++ b/lib/utils/report-file.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const mkdirp = require('mkdirp');
 const PassThrough = require('stream').PassThrough;
 module.exports = class ReportFile {
   constructor(reportFile) {
@@ -10,7 +9,7 @@ module.exports = class ReportFile {
 
     this.outputStream = new PassThrough();
 
-    mkdirp.sync(path.dirname(path.resolve(reportFile)));
+    fs.mkdirSync(path.dirname(path.resolve(reportFile)), { recursive: true });
 
     this.outputStream = fs.createWriteStream(reportFile, { flags: 'w+' });
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "js-yaml": "^5.3.0",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.5",
-    "mkdirp": "^3.0.1",
     "mustache": "^4.2.0",
     "toasted-notifier": "^10.1.0",
     "printf": "^0.6.1",


### PR DESCRIPTION
## Summary
- `mkdirp` was only used in `ReportFile` to create parent directories for `report_file`.
- Replace `mkdirp.sync(...)` with Node’s `fs.mkdirSync(..., { recursive: true })`, which is equivalent on the engines we already require (Node 20.19+).
- Remove the `mkdirp` dependency.

## Test plan
- [ ] `npx mocha tests/utils/report-file_tests.js tests/ci/report_file_tests.js tests/utils/reporter_tests.js`
- [ ] Confirm nested `report_file` paths still create missing parent directories
- [ ] `npm test` (or CI green)