### PR TITLE
fix: bump encoding-sniffer to not install deprecated whatwg-encoding library [node 22]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - main
-      - "0.6"
-      - "0.8.x"
+      - '0.6'
+      - '0.8.x'
       - v*
   pull_request:
   schedule:
-    - cron: "23 8 * * 4" # Thursdays 08:23 UTC
+    - cron: '23 8 * * 4' # Thursdays 08:23 UTC
   workflow_dispatch:
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run lint
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         include:
           - os: macos-latest
             node: 22
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: firefox --version
       - run: npm i
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run ci:safari-smoke
@@ -83,14 +83,14 @@ jobs:
     name: browser-tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    concurrency: "sauce"
+    concurrency: 'sauce'
 
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run browser-tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Getting Started
 ---------------
 
 * Fork and checkout [github.com/testem/testem](https://github.com/testem/testem)
-* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 20.19+, 22.12+, 24.x, or 26+).
+* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 22.12+, 24.x, or 26+).
 * Run `npm install` and `npm test` to make sure you're off to a good start
 
 Brief Code Walk Through

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 
 Installation
 ------------
-Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^20.19.0**, **^22.12.0**, **^24.0.0**, or **>= 26.0.0**).
+Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^22.12.0**, **^24.0.0**, or **>= 26.0.0**).
 
 **Recommended:** install Testem **both** as a **dev dependency** (so your project pins a version) **and** **globally** (so the `testem` command is always available on your `PATH`):
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/testem/testem/issues"
   },
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || ^24.0.0 || >= 26.0.0"
+    "node": "^22.12.0 || ^24.0.0 || >= 26.0.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
     "sinon-chai": "^4.0.1",
     "socket.io-client": "^4.8.3"
   },
+  "overrides": {
+    "encoding-sniffer": "^1.0.2"
+  },
   "bin": {
     "testem": "./testem.js"
   },


### PR DESCRIPTION
Requires #1997 ; Review that PR first