### PR TITLE
[BREAKING] Remove glob dependency [4.x branch]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - main
-      - "0.6"
-      - "0.8.x"
+      - '0.6'
+      - '0.8.x'
       - v*
   pull_request:
   schedule:
-    - cron: "23 8 * * 4" # Thursdays 08:23 UTC
+    - cron: '23 8 * * 4' # Thursdays 08:23 UTC
   workflow_dispatch:
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run lint
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         include:
           - os: macos-latest
             node: 22
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: firefox --version
       - run: npm i
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run ci:safari-smoke
@@ -83,14 +83,14 @@ jobs:
     name: browser-tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    concurrency: "sauce"
+    concurrency: 'sauce'
 
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run browser-tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Getting Started
 ---------------
 
 * Fork and checkout [github.com/testem/testem](https://github.com/testem/testem)
-* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 20.19+, 22.12+, 24.x, or 26+).
+* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 22.12+, 24.x, or 26+).
 * Run `npm install` and `npm test` to make sure you're off to a good start
 
 Brief Code Walk Through

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Getting Started
 ---------------
 
 * Fork and checkout [github.com/testem/testem](https://github.com/testem/testem)
-* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 22.12+, 24.x, or 26+).
+* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 22.17+, 24.x, or 26+).
 * Run `npm install` and `npm test` to make sure you're off to a good start
 
 Brief Code Walk Through

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 
 Installation
 ------------
-Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^20.19.0**, **^22.12.0**, **^24.0.0**, or **>= 26.0.0**).
+Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^22.12.0**, **^24.0.0**, or **>= 26.0.0**).
 
 **Recommended:** install Testem **both** as a **dev dependency** (so your project pins a version) **and** **globally** (so the `testem` command is always available on your `PATH`):
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 
 Installation
 ------------
-Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^22.12.0**, **^24.0.0**, or **>= 26.0.0**).
+Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^22.17.0**, **^24.0.0**, or **>= 26.0.0**).
 
 **Recommended:** install Testem **both** as a **dev dependency** (so your project pins a version) **and** **globally** (so the `testem` command is always available on your `PATH`):
 

--- a/lib/file_watcher_impl.js
+++ b/lib/file_watcher_impl.js
@@ -1,20 +1,19 @@
 /**
  * Internal `FileWatcher` implementation (see {@link module:lib/file_watcher} for the public API).
  *
- * **Third-party pieces in use today:** `chokidar` (filesystem watch engine), `glob` (`hasMagic`
- * for validating concrete `add` paths), and `minimatch` (include-pattern magic checks). Policy
+ * **Third-party pieces in use today:** `chokidar` (filesystem watch engine) and `minimatch`
+ * (`Minimatch#hasMagic` for validating concrete `add` paths, and include-pattern magic checks). Policy
  * lists and matching live largely in {@link module:lib/utils/file_watch_glob_policy}.
  *
  * Nothing here assumes a single vendor forever: the engine is created only through
- * {@link FileWatcherImpl.createWatcher} (with `chokidar` loaded lazily there), and glob/minimatch
- * are confined to small helpers—so swapping the watcher, glob detection, or minimatch usage is
+ * {@link FileWatcherImpl.createWatcher} (with `chokidar` loaded lazily there), and minimatch
+ * is confined to small helpers—so swapping the watcher or glob detection is
  * meant to be localized work rather than a rewrite.
  *
  * @module lib/file_watcher_impl
  */
 const path = require('path');
 const EventEmitter = require('events').EventEmitter;
-const { hasMagic } = require('glob');
 const { Minimatch } = require('minimatch');
 
 const isEmfileError = require('./utils/is_emfile_error');
@@ -176,7 +175,7 @@ class FileWatcherImpl extends EventEmitter {
         new TypeError('FileWatcher.add expects a non-empty path'),
       );
     }
-    if (hasMagic(file, { magicalBraces: true })) {
+    if (new Minimatch(file, { magicalBraces: true }).hasMagic()) {
       await this._closeAfterFailedAdd(
         new TypeError(
           'FileWatcher.add does not accept glob patterns; pass a concrete file path: ' +

--- a/lib/utils/expand_glob_pattern.js
+++ b/lib/utils/expand_glob_pattern.js
@@ -1,19 +1,19 @@
-const { glob } = require('glob');
+const { glob } = require('node:fs/promises');
 
 /**
  * Expand one resolved pattern to matching file paths using the project glob backend.
  *
  * Callers pass POSIX-style paths (see `convertToPosix`); this keeps options aligned
- * with `glob` today and allows swapping the implementation later without touching Config.
+ * with native `fs.glob` and allows swapping the implementation later without touching Config.
  *
  * @param {string} resolvedPatternPosix - Single pattern (already resolved to absolute or cwd-relative form, forward slashes).
  * @param {string[]} [ignorePatternsPosix] - Ignore globs in POSIX form; empty entries are dropped.
  * @returns {Promise<string[]>} Matching paths, sorted lexicographically (same ordering as before extraction).
  */
 async function expandGlobPattern(resolvedPatternPosix, ignorePatternsPosix) {
-  const ignore = (ignorePatternsPosix || []).filter(Boolean);
-  const files = await glob(resolvedPatternPosix, { ignore });
-  return files.slice().sort();
+  const exclude = (ignorePatternsPosix || []).filter(Boolean);
+  const files = await Array.fromAsync(glob(resolvedPatternPosix, { exclude }));
+  return files.sort();
 }
 
 module.exports = expandGlobPattern;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/testem/testem/issues"
   },
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || ^24.0.0 || >= 26.0.0"
+    "node": "^22.12.0 || ^24.0.0 || >= 26.0.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/testem/testem/issues"
   },
   "engines": {
-    "node": "^22.12.0 || ^24.0.0 || >= 26.0.0"
+    "node": "^22.17.0 || ^24.0.0 || >= 26.0.0"
   },
   "license": "MIT",
   "dependencies": {
@@ -30,7 +30,6 @@
     "consolidate": "^1.0.4",
     "execa": "^9.6.1",
     "express": "^5.2.1",
-    "glob": "^13.0.6",
     "httpxy": "^0.5.5",
     "js-yaml": "^5.3.0",
     "lodash": "^4.18.1",

--- a/tests/expand_glob_pattern_tests.js
+++ b/tests/expand_glob_pattern_tests.js
@@ -37,6 +37,17 @@ describe('expandGlobPattern', function() {
     });
   });
 
+  it('expands ** across nested directories', function() {
+    const nestedPattern = convertToPosix(
+      path.join(__dirname, 'fixtures', 'nested_src_files', '**', '*.js'),
+    );
+    return expandGlobPattern(nestedPattern, []).then(function(files) {
+      expect(files).to.have.lengthOf(1);
+      expect(path.basename(files[0])).to.equal('file.js');
+      expect(convertToPosix(files[0])).to.match(/nested_src_files\/with\/nested\/file\.js$/);
+    });
+  });
+
   it('returns an empty array when the pattern matches no files', function() {
     const none = convertToPosix(
       path.join(__dirname, 'fixtures', 'no_such_prefix_zzzz', '*.js'),


### PR DESCRIPTION
## Summary
- Replace the `glob` package with Node's `fs.promises.glob` (`exclude` instead of `ignore`).
- Use `Minimatch#hasMagic()` for `FileWatcher.add` validation (minimatch 10 has no CJS `hasMagic` export).
- Require Node `^22.17.0` (stable glob with pattern-array exclude). 24.x and 26+ are unchanged.

Stacked on #1997 (`drop_node_20_support`). The glob-only commit is `[BREAKING] Drop glob dependency`. After #1997 merges, this PR's diff vs `master` is that commit alone.

Further BREAKING because fs.promises.glob and glob package are not fully compatible. Expect some configurations to break. Also bumps minimum version of node.js requirement to 22.17.

## Test plan
- [x] `npm test` (857 passing)
- [x] CI on 22 / 24 / 26
- [x] Nested `**` expansion in `expand_glob_pattern_tests`
- [x] `src_files_ignore` / inline `!` negation in `config_tests`
- [x] `FileWatcher.add` rejects `*.js`, `**`, and `{a,b}.js`


Made with [Cursor](https://cursor.com)