### PR TITLE
feat: new example for node:test [3.x branch]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ There are also integration tests that run every example in the `examples` folder
 
 * **`skipExamples`** — `browserstack` and `saucelabs` (need credentials; not run in CI).
 * **`skipOnWindows`** — none. The `coffeescript` example lists CoffeeScript sources explicitly instead of `*.coffee` (cmd.exe does not expand globs for external programs). The `webpack` example uses `npx webpack` so local `webpack-cli` runs without relying on PATH. See [`examples/coffeescript`](examples/coffeescript) and [Available hooks](docs/config_file.md#available-hooks).
+* **`skipDefiningReporter`** — Node-only examples (`node_example`, `node_tap_example`, `node_test`) and `electron`. The runner otherwise appends `--launch "Headless Firefox"`, which these examples do not use.
 * **Concurrency** — Windows runs examples one at a time (Headless Firefox is flaky in parallel); set `INTEGRATION_TESTS_CONCURRENCY` to override.
 
 Examples that opt into modern built-in runners list `mocha`, `chai`, `jasmine-core`, or `qunit` in their own `package.json` (the integration runner already runs `npm install` in each example). Examples without those packages still use the CDN fallback. `mocha_simple` stays on CDN Mocha plus `expect.js`; `jshint` and `eslint` stay on CDN QUnit 1 so their global `test`/`equal` APIs keep working.

--- a/README.md
+++ b/README.md
@@ -511,6 +511,8 @@ When you run `testem`, it will auto-launch the mocha process based on the specif
 Processes with TAP Output
 -------------------------
 
+Node's built-in test runner emits TAP with `node --test --test-reporter=tap` plus `"protocol": "tap"`. See the [node:test example](examples/node_test).
+
 If your process outputs test results in [TAP](https://en.wikipedia.org/wiki/Test_Anything_Protocol) format, you can tell that to testem via the `protocol` property. For example
 
 ```javascript
@@ -711,6 +713,7 @@ I've created [examples](https://github.com/testem/testem/tree/main/examples/) fo
 * [Hybrid Project](https://github.com/testem/testem/tree/main/examples/hybrid_simple) - Mocha tests running in both the browser and Node.
 * [Custom Test Framework](https://github.com/testem/testem/tree/main/examples/custom_adapter)
 * [Tape Example](https://github.com/testem/testem/tree/main/examples/tape_example)
+* [Node.js test runner](https://github.com/testem/testem/tree/main/examples/node_test) - `node:test` via a TAP process launcher.
 * [Browserify Project](https://github.com/testem/testem/tree/main/examples/browserify)
 * [JSHint Example](https://github.com/testem/testem/tree/main/examples/jshint)
 * [Coffeescript Project](https://github.com/testem/testem/tree/main/examples/coffeescript)

--- a/bin/run-integration.js
+++ b/bin/run-integration.js
@@ -17,6 +17,7 @@ const skipOnWindows = [];
 const skipDefiningReporter = [
   'node_example',
   'node_tap_example',
+  'node_test',
   'electron'
 ];
 const examplesPath = path.join(__dirname, '../examples');

--- a/examples/node_test/.gitignore
+++ b/examples/node_test/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/node_test/README.md
+++ b/examples/node_test/README.md
@@ -1,0 +1,44 @@
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run tests (CI mode):
+
+```bash
+npm test
+```
+
+Interactive dev:
+
+```bash
+node ../../testem.js
+```
+
+## What this is
+
+`node:test` runs as a **Node process** under a custom Testem launcher. There is no `framework: "node:test"` and no browser adapter. Testem does not execute the suite; it launches `node --test` and displays the results.
+
+This is distinct from [node_example](../node_example) (Mocha, exit-code protocol) and [node_tap_example](../node_tap_example) (the [`tap`](https://www.npmjs.com/package/tap) package).
+
+## How results get to Testem
+
+Node ships `--test-reporter=tap`. This example sets `"protocol": "tap"` so Testem parses per-test `ok` / `not ok` lines.
+
+Only that reporter writes to stdout. Nested TAP from the file-level subtest is expected; Testem’s TAP consumer already handles it.
+
+## Config
+
+- [`testem.json`](testem.json) — `launchers.NodeTest.command` (`node --test --test-reporter=tap tests.js`) and `"protocol": "tap"`.
+- `tests.js` is passed **explicitly**. `node --test` with no path does not discover a root `tests.js` (default globs are `*.test.js` / `test/**`).
+
+## Run `node:test` alone
+
+```bash
+npm run node:test
+```
+
+Output is TAP, not the default spec reporter.

--- a/examples/node_test/hello.js
+++ b/examples/node_test/hello.js
@@ -1,0 +1,5 @@
+function hello(name){
+    return 'hello ' + (name || 'world');
+}
+
+module.exports = hello;

--- a/examples/node_test/package.json
+++ b/examples/node_test/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "test": "node ../../testem.js ci -P 10 --launch NodeTest",
+    "node:test": "node --test --test-reporter=tap tests.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/testem/testem.git"
+  },
+  "license": "MIT"
+}

--- a/examples/node_test/testem.json
+++ b/examples/node_test/testem.json
@@ -1,0 +1,10 @@
+{
+  "launchers": {
+    "NodeTest": {
+      "command": "node --test --test-reporter=tap tests.js",
+      "protocol": "tap"
+    }
+  },
+  "launch_in_dev": ["NodeTest"],
+  "launch_in_ci": ["NodeTest"]
+}

--- a/examples/node_test/tests.js
+++ b/examples/node_test/tests.js
@@ -1,0 +1,11 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const hello = require('./hello');
+
+test('it says hello world', () => {
+  assert.equal(hello(), 'hello world');
+});
+
+test('it says hello to person', () => {
+  assert.equal(hello('Bob'), 'hello Bob');
+});


### PR DESCRIPTION
## Summary

- Adds `examples/node_test`: Node’s built-in test runner as a custom process launcher (`node --test --test-reporter=tap`, `"protocol": "tap"`). No extra reporter package and no browser adapter.
- Distinct from `node_example` (Mocha, exit-code protocol) and `node_tap_example` (the `tap` package).
- Lists `node_test` in `skipDefiningReporter` so integration does not append Headless Firefox.
- Documents the setup in the example README, the root README TAP section + Example Projects list, and CONTRIBUTING.

Independent of the Jest example PR. Either can merge first. Expected conflicts are `bin/run-integration.js` (`skipDefiningReporter`) and the CONTRIBUTING `skipDefiningReporter` bullet — keep **both** `jest` and `node_test` when resolving.

## Test plan

- [x] `cd examples/node_test && npm install && npm run node:test` — TAP on stdout, 2 passing
- [x] `cd examples/node_test && npm test` — Testem CI, `NodeTest` launcher, 2 passing, no Firefox
- [x] Break an assertion and confirm TAP `not ok` plus a non-zero Testem exit
- [x] Confirm `skipDefiningReporter` includes `node_test`