### PR TITLE
chore(example/vitest): bump vitest to v5 [node 22]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - main
-      - "0.6"
-      - "0.8.x"
+      - '0.6'
+      - '0.8.x'
       - v*
   pull_request:
   schedule:
-    - cron: "23 8 * * 4" # Thursdays 08:23 UTC
+    - cron: '23 8 * * 4' # Thursdays 08:23 UTC
   workflow_dispatch:
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run lint
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         include:
           - os: macos-latest
             node: 22
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: firefox --version
       - run: npm i
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run ci:safari-smoke
@@ -83,14 +83,14 @@ jobs:
     name: browser-tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    concurrency: "sauce"
+    concurrency: 'sauce'
 
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run browser-tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Getting Started
 ---------------
 
 * Fork and checkout [github.com/testem/testem](https://github.com/testem/testem)
-* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 20.19+, 22.12+, 24.x, or 26+).
+* Use a [Node.js](https://nodejs.org/) version that satisfies the `engines.node` range in [`package.json`](package.json) (currently Node 22.12+, 24.x, or 26+).
 * Run `npm install` and `npm test` to make sure you're off to a good start
 
 Brief Code Walk Through

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ There are also integration tests that run every example in the `examples` folder
 
 * **`skipExamples`** — `browserstack` and `saucelabs` (need credentials; not run in CI).
 * **`skipOnWindows`** — none. The `coffeescript` example lists CoffeeScript sources explicitly instead of `*.coffee` (cmd.exe does not expand globs for external programs). The `webpack` example uses `npx webpack` so local `webpack-cli` runs without relying on PATH. See [`examples/coffeescript`](examples/coffeescript) and [Available hooks](docs/config_file.md#available-hooks).
+* **`skipDefiningReporter`** — Node-only examples (`node_example`, `node_tap_example`, `vitest`) and `electron`. The runner otherwise appends `--launch "Headless Firefox"`, which these examples do not use.
 * **Concurrency** — Windows runs examples one at a time (Headless Firefox is flaky in parallel); set `INTEGRATION_TESTS_CONCURRENCY` to override.
 
 Examples that opt into modern built-in runners list `mocha`, `chai`, `jasmine-core`, or `qunit` in their own `package.json` (the integration runner already runs `npm install` in each example). Examples without those packages still use the CDN fallback. `mocha_simple` stays on CDN Mocha plus `expect.js`; `jshint` and `eslint` stay on CDN QUnit 1 so their global `test`/`equal` APIs keep working.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 
 Installation
 ------------
-Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^20.19.0**, **^22.12.0**, **^24.0.0**, or **>= 26.0.0**).
+Testem needs a supported **[Node.js](https://nodejs.org/)** runtime. The required range is defined in [`package.json`](package.json) under `engines` (currently **^22.12.0**, **^24.0.0**, or **>= 26.0.0**).
 
 **Recommended:** install Testem **both** as a **dev dependency** (so your project pins a version) **and** **globally** (so the `testem` command is always available on your `PATH`):
 

--- a/README.md
+++ b/README.md
@@ -522,6 +522,8 @@ If your process outputs test results in [TAP](https://en.wikipedia.org/wiki/Test
 }
 ```
 
+Vitest emits TAP with `--reporter=tap-flat` (use `vitest run`, not watch mode) plus `"protocol": "tap"`. See the [Vitest example](examples/vitest).
+
 When this is done, Testem will read in the process's stdout and parse it as TAP, and then display the test results in Testem's normal format. It will also hide the process's stdout output from the console log panel, although it will still display the stderr.
 
 Headless Chrome
@@ -698,6 +700,7 @@ Example Projects
 I've created [examples](https://github.com/testem/testem/tree/main/examples/) for various setups
 
 * [Vite (middleware + plugin)](https://github.com/testem/testem/tree/main/examples/vite)
+* [Vitest](https://github.com/testem/testem/tree/main/examples/vitest) - Vitest via a TAP process launcher (`tap-flat`).
 * [Electron](https://github.com/testem/testem/tree/main/examples/electron)
 * [TypeScript Project](https://github.com/testem/testem/tree/main/examples/typescript)
 * [ESLint Example](https://github.com/testem/testem/tree/main/examples/eslint)

--- a/bin/run-integration.js
+++ b/bin/run-integration.js
@@ -17,6 +17,7 @@ const skipOnWindows = [];
 const skipDefiningReporter = [
   'node_example',
   'node_tap_example',
+  'vitest',
   'electron'
 ];
 const examplesPath = path.join(__dirname, '../examples');

--- a/examples/vitest/.gitignore
+++ b/examples/vitest/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/examples/vitest/.npmrc
+++ b/examples/vitest/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/examples/vitest/README.md
+++ b/examples/vitest/README.md
@@ -1,0 +1,48 @@
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run tests (CI mode):
+
+```bash
+npm test
+```
+
+Interactive dev:
+
+```bash
+node ../../testem.js
+```
+
+## What this is
+
+Vitest runs as a **Node process** under a custom Testem launcher. There is no `framework: "vitest"` and no browser adapter. Testem does not execute the suite; it launches `vitest run` and displays the results.
+
+This is distinct from [node_example](../node_example) (Mocha, exit-code protocol), [node_tap_example](../node_tap_example) (the [`tap`](https://www.npmjs.com/package/tap) package), and [examples/vite](../vite) (Mocha in a real browser via Vite middleware).
+
+## How results get to Testem
+
+Vitest ships a built-in `tap-flat` reporter. This example sets `"protocol": "tap"` so Testem parses per-test `ok` / `not ok` lines.
+
+Only that reporter writes to stdout. `tap-flat` is used instead of nested `tap` so Testem shows two flat test names.
+
+## Config
+
+- [`testem.json`](testem.json) — `launchers.Vitest.command` (`npm run vitest`) and `"protocol": "tap"`.
+- [`vitest.config.js`](vitest.config.js) — `environment: "node"`, `include: ["tests.js"]`, and `reporters: ["tap-flat"]`.
+- The npm script is `vitest run`, not bare `vitest` (watch mode would hang CI).
+- `tests.js` is listed in `include` because Vitest’s default globs (`*.test.js` / `test/**`) do not discover a root `tests.js`.
+- The example is ESM (`"type": "module"`) so tests can `import` from `vitest` (Vitest 4 does not support `require('vitest')`).
+- [`.npmrc`](.npmrc) sets `legacy-peer-deps=true` so `npm install` resolves Vitest 4’s peer tree.
+
+## Run Vitest alone
+
+```bash
+npm run vitest
+```
+
+Output is TAP-flat, not the default reporter.

--- a/examples/vitest/hello.js
+++ b/examples/vitest/hello.js
@@ -1,0 +1,3 @@
+export function hello(name) {
+  return 'hello ' + (name || 'world');
+}

--- a/examples/vitest/package.json
+++ b/examples/vitest/package.json
@@ -1,0 +1,15 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node ../../testem.js ci -P 10 --launch Vitest",
+    "vitest": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/testem/testem.git"
+  },
+  "license": "MIT"
+}

--- a/examples/vitest/package.json
+++ b/examples/vitest/package.json
@@ -5,7 +5,7 @@
     "vitest": "vitest run"
   },
   "devDependencies": {
-    "vitest": "^4.0.0"
+    "vitest": "^5.0.0"
   },
   "repository": {
     "type": "git",

--- a/examples/vitest/testem.json
+++ b/examples/vitest/testem.json
@@ -1,0 +1,10 @@
+{
+  "launchers": {
+    "Vitest": {
+      "command": "npm run vitest",
+      "protocol": "tap"
+    }
+  },
+  "launch_in_dev": ["Vitest"],
+  "launch_in_ci": ["Vitest"]
+}

--- a/examples/vitest/tests.js
+++ b/examples/vitest/tests.js
@@ -1,0 +1,10 @@
+import { test, expect } from 'vitest';
+import { hello } from './hello.js';
+
+test('it says hello world', () => {
+  expect(hello()).toBe('hello world');
+});
+
+test('it says hello to person', () => {
+  expect(hello('Bob')).toBe('hello Bob');
+});

--- a/examples/vitest/vitest.config.js
+++ b/examples/vitest/vitest.config.js
@@ -1,0 +1,7 @@
+export default {
+  test: {
+    environment: 'node',
+    include: ['tests.js'],
+    reporters: ['tap-flat']
+  }
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/testem/testem/issues"
   },
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || ^24.0.0 || >= 26.0.0"
+    "node": "^22.12.0 || ^24.0.0 || >= 26.0.0"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Review first

Built on #1997 and #2080 ; review those PRs first.

## Summary

Bumps vitest to v5 in the vitest example; requires node 22.