### PR TITLE
feat: new example for react (simple; no bunder; no jsx) [3.x branch]

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ I've created [examples](https://github.com/testem/testem/tree/main/examples/) fo
 * [Jasmine 2](https://github.com/testem/testem/tree/main/examples/jasmine2)
 * [Custom Jasmine project](https://github.com/testem/testem/tree/main/examples/jasmine_custom)
 * [Simple Mocha Project](https://github.com/testem/testem/tree/main/examples/mocha_simple)
+* [Simple React](https://github.com/testem/testem/tree/main/examples/react_simple) - React 19 in a real browser via import maps, no bundler.
 * [Mocha + Chai](https://github.com/testem/testem/tree/main/examples/mocha_chai_simple)
 * [Hybrid Project](https://github.com/testem/testem/tree/main/examples/hybrid_simple) - Mocha tests running in both the browser and Node.
 * [Custom Test Framework](https://github.com/testem/testem/tree/main/examples/custom_adapter)

--- a/examples/react_simple/.gitignore
+++ b/examples/react_simple/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/react_simple/README.md
+++ b/examples/react_simple/README.md
@@ -1,0 +1,38 @@
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run tests (CI mode):
+
+```bash
+npm test
+```
+
+Interactive dev:
+
+```bash
+node ../../testem.js
+```
+
+## What this is
+
+React 19 in a **real browser** with no bundler and no JSX. A custom `test_page` loads Mocha and Chai from `/node_modules`. Distinct from [examples/mocha_simple](../mocha_simple) (the same page shape, no React) and [examples/vite](../vite) (Mocha in a real browser via Vite middleware, no React).
+
+## How results get to Testem
+
+The custom page loads Mocha and `/testem.js` first, then calls `Testem.hookIntoTestFramework()`. The ESM spec registers `describe` / `it` and calls `mocha.run()`.
+
+## Config
+
+- [`test.html`](test.html) — import map for `react` and `react-dom/client` from [esm.sh](https://esm.sh) (`?dev` so `act` is available; the production ESM build does not export it). `?external=react` keeps one React copy.
+- [`testem.json`](testem.json) — `test_page` is `test.html`, and `src_files` watches `*.js`.
+
+The browser needs a network connection the first time it fetches those modules (esm.sh is cached afterward).
+
+## No build step
+
+There is nothing to compile. The component uses `createElement` instead of JSX so Babel is not required.

--- a/examples/react_simple/counter.js
+++ b/examples/react_simple/counter.js
@@ -1,0 +1,12 @@
+import { createElement, useState } from 'react';
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+
+  return createElement(
+    'button',
+    { type: 'button', onClick: () => setCount((n) => n + 1) },
+    'Count: ',
+    count
+  );
+}

--- a/examples/react_simple/counter_spec.js
+++ b/examples/react_simple/counter_spec.js
@@ -1,0 +1,57 @@
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { expect } from '/node_modules/chai/index.js';
+import { Counter } from './counter.js';
+
+const { afterEach, describe, it } = globalThis;
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function render(element) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  return {
+    container,
+    async mount() {
+      await act(() => {
+        root.render(element);
+      });
+    },
+    async unmount() {
+      await act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  };
+}
+
+describe('Counter', function() {
+  let view;
+
+  afterEach(async function() {
+    if (view) {
+      await view.unmount();
+      view = null;
+    }
+  });
+
+  it('starts at 0', async function() {
+    view = render(createElement(Counter));
+    await view.mount();
+    expect(view.container.querySelector('button').textContent).to.equal('Count: 0');
+  });
+
+  it('increments on click', async function() {
+    view = render(createElement(Counter));
+    await view.mount();
+    await act(() => {
+      view.container.querySelector('button').click();
+    });
+    expect(view.container.querySelector('button').textContent).to.equal('Count: 1');
+  });
+});
+
+mocha.run();

--- a/examples/react_simple/package.json
+++ b/examples/react_simple/package.json
@@ -1,0 +1,15 @@
+{
+  "description": "Example: Testem with React and no bundler",
+  "scripts": {
+    "test": "node ../../testem.js ci -P 10"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/testem/testem.git"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^6.2.2",
+    "mocha": "^12.0.0"
+  }
+}

--- a/examples/react_simple/test.html
+++ b/examples/react_simple/test.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+<title>Test'em</title>
+<link rel="stylesheet" href="/node_modules/mocha/mocha.css">
+<script type="importmap">
+{
+  "imports": {
+    "react": "https://esm.sh/react@19.1.0?dev",
+    "react-dom/client": "https://esm.sh/react-dom@19.1.0/client?dev&external=react"
+  }
+}
+</script>
+</head>
+<body>
+<div id="mocha"></div>
+<script src="/node_modules/mocha/mocha.js"></script>
+<script src="/testem.js"></script>
+<script>
+mocha.setup('bdd');
+Testem.hookIntoTestFramework();
+</script>
+<script type="module" src="counter_spec.js"></script>
+</body>
+</html>

--- a/examples/react_simple/testem.json
+++ b/examples/react_simple/testem.json
@@ -1,0 +1,6 @@
+{
+  "test_page": "test.html",
+  "src_files": [
+    "*.js"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `examples/react_simple`: React 19 in a real browser with no bundler and no JSX.
- Custom `test_page` matches `mocha_simple` (Mocha + Chai from `/node_modules`); React loads from esm.sh via an import map.
- Distinct from `mocha_simple` (same page shape, no React) and `vite` (Mocha via Vite middleware, no React).

This PR is complete on its own. Root-doc hunks are disjoint from the other example PRs (Example Projects insertion is after Simple Mocha). Accept list conflicts and keep every name.

## Test plan
- [x] `cd examples/react_simple && npm install && npm test -- --launch "Headless Firefox"` — two passing Mocha tests
- [x] Break the “starts at 0” assertion — Mocha failure and a non-zero Testem exit
- [x] Confirm no lockfile, changelog, CONTRIBUTING, TAP, or preprocessor edits
- [x] Confirm `skipDefiningReporter` / `skipOnWindows` are unchanged (Headless Firefox is correct)