### PR TITLE
feat(ci): special integration tests for IE / PhantomJS [3.x branch only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
     name: legacy-phantomjs
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # PhantomJS 2.1.1 reads the system OpenSSL config. Ubuntu 24's
+    # openssl.cnf loads a providers module that the old binary cannot.
+    env:
+      OPENSSL_CONF: /dev/null
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,36 @@ jobs:
       - run: npm i
       - run: npm run ci:safari-smoke
 
+  legacy-phantomjs:
+    name: legacy-phantomjs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: package.json
+      - run: sudo apt-get install -y libfontconfig1
+      - name: Install PhantomJS 2.1.1
+        run: |
+          curl -fsSL -o /tmp/phantomjs.tar.bz2 \
+            https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
+          echo "86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f  /tmp/phantomjs.tar.bz2" | sha256sum -c -
+          tar -xjf /tmp/phantomjs.tar.bz2 -C /tmp
+          sudo mv /tmp/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+          phantomjs -v
+      - run: npm i
+      - run: npm run ci:legacy-phantomjs
+        env:
+          LEGACY_BROWSERS_REQUIRED: PhantomJS
+
   browser-tests:
     name: browser-tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     concurrency: "sauce"
 
     steps:
@@ -94,6 +120,10 @@ jobs:
           cache-dependency-path: package.json
       - run: npm i
       - run: npm run browser-tests
+        env:
+          SAUCE_USERNAME: testem-ci
+          SAUCE_ACCESS_KEY: 1f00979e-0252-4d69-98ff-f6c85d1a746b
+      - run: npm run ci:legacy-ie
         env:
           SAUCE_USERNAME: testem-ci
           SAUCE_ACCESS_KEY: 1f00979e-0252-4d69-98ff-f6c85d1a746b

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,5 +76,5 @@ Node + headless browser:
 
 Legacy browsers (IE 11 and PhantomJS) are not part of that Firefox matrix. Two smokes cover a small ES5 allowlist (`examples/jasmine_simple`, `examples/babel`):
 
-* **`npm run ci:legacy-phantomjs`** — [`scripts/legacy-phantomjs-ci-smoke.js`](scripts/legacy-phantomjs-ci-smoke.js). Skips (exit 0) when PhantomJS is not installed. CI sets `LEGACY_BROWSERS_REQUIRED=PhantomJS` so a missing binary fails the `legacy-phantomjs` job (Ubuntu installs PhantomJS 2.1.1).
+* **`npm run ci:legacy-phantomjs`** — [`scripts/legacy-phantomjs-ci-smoke.js`](scripts/legacy-phantomjs-ci-smoke.js). Skips (exit 0) when PhantomJS is not installed. CI sets `LEGACY_BROWSERS_REQUIRED=PhantomJS` so a missing binary fails the `legacy-phantomjs` job (Ubuntu installs PhantomJS 2.1.1). The job also sets `OPENSSL_CONF=/dev/null` so PhantomJS 2.1.1 can start on Ubuntu 24's OpenSSL 3.
 * **`npm run ci:legacy-ie`** — [`scripts/legacy-ie-sauce-smoke.js`](scripts/legacy-ie-sauce-smoke.js). Runs the same examples on Sauce Labs `SL_IE_11`. Skips locally when `SAUCE_USERNAME` / `SAUCE_ACCESS_KEY` are unset; in CI missing credentials fail. This is a second step on the `browser-tests` job (after `npm run browser-tests`), so it shares the `sauce` concurrency slot. The saucelabs example matrix still includes IE 10/11.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,3 +73,8 @@ Examples that opt into modern built-in runners list `mocha`, `chai`, `jasmine-co
 Node + headless browser:
 
     npm run integration
+
+Legacy browsers (IE 11 and PhantomJS) are not part of that Firefox matrix. Two smokes cover a small ES5 allowlist (`examples/jasmine_simple`, `examples/babel`):
+
+* **`npm run ci:legacy-phantomjs`** — [`scripts/legacy-phantomjs-ci-smoke.js`](scripts/legacy-phantomjs-ci-smoke.js). Skips (exit 0) when PhantomJS is not installed. CI sets `LEGACY_BROWSERS_REQUIRED=PhantomJS` so a missing binary fails the `legacy-phantomjs` job (Ubuntu installs PhantomJS 2.1.1).
+* **`npm run ci:legacy-ie`** — [`scripts/legacy-ie-sauce-smoke.js`](scripts/legacy-ie-sauce-smoke.js). Runs the same examples on Sauce Labs `SL_IE_11`. Skips locally when `SAUCE_USERNAME` / `SAUCE_ACCESS_KEY` are unset; in CI missing credentials fail. This is a second step on the `browser-tests` job (after `npm run browser-tests`), so it shares the `sauce` concurrency slot. The saucelabs example matrix still includes IE 10/11.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "integration": "node ./bin/run-integration.js",
     "ci:safari-smoke": "node ./scripts/safari-ci-smoke.js",
     "ci:legacy-phantomjs": "node ./scripts/legacy-phantomjs-ci-smoke.js",
+    "ci:legacy-ie": "node ./scripts/legacy-ie-sauce-smoke.js",
     "browser-tests": "cd examples/saucelabs/ && ../../testem.js ci -d",
     "lint": "eslint ."
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "cover": "cover run ./node_modules/.bin/_mocha tests/*_tests.js tests/**/*_tests.js; cover report html; open cover_html/index.html",
     "integration": "node ./bin/run-integration.js",
     "ci:safari-smoke": "node ./scripts/safari-ci-smoke.js",
+    "ci:legacy-phantomjs": "node ./scripts/legacy-phantomjs-ci-smoke.js",
     "browser-tests": "cd examples/saucelabs/ && ../../testem.js ci -d",
     "lint": "eslint ."
   },

--- a/scripts/legacy-ie-sauce-smoke.js
+++ b/scripts/legacy-ie-sauce-smoke.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+/**
+ * Sauce Labs IE 11 smoke for two ES5 examples (jasmine_simple, babel).
+ * Skips locally when Sauce credentials are unset. Fails in CI without them.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+const { execa } = require('execa');
+
+const root = path.join(__dirname, '..');
+const testem = path.join(root, 'testem.js');
+const sauceDir = path.join(root, 'examples', 'saucelabs');
+const TIMEOUT = 240000;
+const EXAMPLES = [
+  { name: 'jasmine_simple', needsInstall: false },
+  { name: 'babel', needsInstall: true },
+];
+
+const SL_IE_11 = {
+  exe: '../../node_modules/.bin/saucie',
+  args: ['-b', 'internet explorer', '-v', '11', '--no-connect', '--attach', '-u'],
+  protocol: 'browser',
+};
+
+function inCi() {
+  return Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
+}
+
+function hasSauceCreds() {
+  return Boolean(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY);
+}
+
+function exampleConfig(exampleName) {
+  const exampleDir = path.join(root, 'examples', exampleName);
+  if (exampleName === 'babel') {
+    const yml = yaml.load(
+      fs.readFileSync(path.join(exampleDir, 'testem.yml'), 'utf8'),
+    );
+    return Object.assign({ cwd: exampleDir }, yml);
+  }
+  return {
+    cwd: exampleDir,
+    framework: 'jasmine',
+  };
+}
+
+function mergedConfig(exampleName) {
+  const config = exampleConfig(exampleName);
+  config.launchers = { SL_IE_11 };
+  config.launch_in_ci = ['SL_IE_11'];
+  config.browser_start_timeout = 90;
+  config.disable_watching = true;
+  return config;
+}
+
+async function withSauceTunnel(fn) {
+  await execa('node', [path.join(sauceDir, 'saucie-connect.js')], {
+    cwd: sauceDir,
+    stdio: 'inherit',
+    timeout: TIMEOUT,
+  });
+  try {
+    await fn();
+  } finally {
+    try {
+      await execa('node', [path.join(sauceDir, 'saucie-disconnect.js')], {
+        cwd: sauceDir,
+        stdio: 'inherit',
+        timeout: 60000,
+      });
+    } catch (err) {
+      console.error(
+        'Sauce disconnect failed:',
+        err.shortMessage || err.message || err,
+      );
+    }
+  }
+}
+
+async function runExample(example) {
+  const exampleDir = path.join(root, 'examples', example.name);
+  if (example.needsInstall) {
+    console.log('Installing ' + example.name + '...');
+    await execa('npm', ['install'], {
+      cwd: exampleDir,
+      stdio: 'inherit',
+      timeout: TIMEOUT,
+    });
+  }
+
+  const tmpFile = path.join(
+    os.tmpdir(),
+    'testem-legacy-ie-' + example.name + '-' + process.pid + '.json',
+  );
+  fs.writeFileSync(tmpFile, JSON.stringify(mergedConfig(example.name), null, 2));
+
+  try {
+    console.log(
+      'Running Testem CI with SL_IE_11 (examples/' + example.name + ')...',
+    );
+    await execa(
+      'node',
+      [testem, 'ci', '--file', tmpFile, '--launch', 'SL_IE_11', '-P', '10', '-p', '0'],
+      {
+        cwd: exampleDir,
+        stdio: 'inherit',
+        timeout: TIMEOUT,
+      },
+    );
+  } finally {
+    fs.rmSync(tmpFile, { force: true });
+  }
+}
+
+async function main() {
+  if (!hasSauceCreds()) {
+    if (inCi()) {
+      console.error('SAUCE_USERNAME and SAUCE_ACCESS_KEY are required in CI.');
+      process.exit(1);
+    }
+    console.log('Skipping: Sauce credentials are not set.');
+    process.exit(0);
+  }
+
+  await withSauceTunnel(async () => {
+    for (const example of EXAMPLES) {
+      await runExample(example);
+    }
+  });
+}
+
+main().catch((err) => {
+  console.error('Sauce IE CI smoke failed:', err.shortMessage || err.message || err);
+  process.exit(1);
+});

--- a/scripts/legacy-phantomjs-ci-smoke.js
+++ b/scripts/legacy-phantomjs-ci-smoke.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+/**
+ * PhantomJS smoke for two ES5 examples (jasmine_simple, babel).
+ * Skips when PhantomJS is not installed unless LEGACY_BROWSERS_REQUIRED=PhantomJS.
+ */
+
+const path = require('path');
+const { execa } = require('execa');
+const Config = require('../lib/config');
+
+const root = path.join(__dirname, '..');
+const testem = path.join(root, 'testem.js');
+const TIMEOUT = 180000;
+const EXAMPLES = [
+  { name: 'jasmine_simple', needsInstall: false },
+  { name: 'babel', needsInstall: true },
+];
+
+function getAvailableLaunchers() {
+  return new Promise((resolve, reject) => {
+    const config = new Config('ci', {});
+    config.getAvailableLaunchers((err, launchers) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(launchers);
+    });
+  });
+}
+
+function requiredPhantom() {
+  return String(process.env.LEGACY_BROWSERS_REQUIRED || '').toLowerCase() === 'phantomjs';
+}
+
+async function main() {
+  const launchers = await getAvailableLaunchers();
+  if (!launchers.phantomjs) {
+    const message = 'PhantomJS is not installed.';
+    if (requiredPhantom()) {
+      console.error(message + ' LEGACY_BROWSERS_REQUIRED=PhantomJS.');
+      process.exit(1);
+    }
+    console.log('Skipping: ' + message);
+    process.exit(0);
+  }
+
+  for (const example of EXAMPLES) {
+    const exampleDir = path.join(root, 'examples', example.name);
+    if (example.needsInstall) {
+      console.log('Installing ' + example.name + '...');
+      await execa('npm', ['install'], {
+        cwd: exampleDir,
+        stdio: 'inherit',
+        timeout: TIMEOUT,
+      });
+    }
+
+    console.log('Running Testem CI with PhantomJS (examples/' + example.name + ')...');
+    await execa('node', [testem, 'ci', '--launch', 'PhantomJS', '-P', '10', '-p', '0'], {
+      cwd: exampleDir,
+      stdio: 'inherit',
+      timeout: TIMEOUT,
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error('PhantomJS CI smoke failed:', err.shortMessage || err.message || err);
+  process.exit(1);
+});

--- a/scripts/legacy-phantomjs-ci-smoke.js
+++ b/scripts/legacy-phantomjs-ci-smoke.js
@@ -35,6 +35,11 @@ function requiredPhantom() {
 }
 
 async function main() {
+  // PhantomJS 2.1.1 cannot load OpenSSL 3's providers module (Ubuntu 24+).
+  if (process.platform === 'linux' && process.env.OPENSSL_CONF === undefined) {
+    process.env.OPENSSL_CONF = '/dev/null';
+  }
+
   const launchers = await getAvailableLaunchers();
   if (!launchers.phantomjs) {
     const message = 'PhantomJS is not installed.';


### PR DESCRIPTION
## Summary
- Add `npm run ci:legacy-phantomjs` and `npm run ci:legacy-ie` to run `examples/jasmine_simple` and `examples/babel` on the remaining 3.x legacy launchers. Most examples now need a current engine (ESM, React 19, Mocha 12, Jasmine 5), so these stay off the Headless Firefox `npm run integration` matrix.
- PhantomJS is a required Ubuntu job: install 2.1.1, then fail if the binary is missing (`LEGACY_BROWSERS_REQUIRED=PhantomJS`). Locally the script skips when PhantomJS is not installed.
- IE 11 is a Sauce Labs hard gate (`SL_IE_11`), run as a second step on `browser-tests` so it shares the existing `sauce` concurrency slot. Hosted Windows `iexplore.exe` is not reliable (often missing or opens Edge). The saucelabs example matrix still includes IE 10/11.

I noticed that we aren't testing any actual examples on IE or PhantomJS, just `testem.js` itself. This branch is to make certain the 3.x branch continues to run on PhantomJS and IE 11. This branch should be merged to `main` or `v3` only. Testem 4.x will drop the built-in PhantomJS and IE launchers.

## Test plan
- [ ] `legacy-phantomjs` job installs PhantomJS 2.1.1, prints `phantomjs -v`, and both allowlisted examples pass
- [ ] Local `npm run ci:legacy-phantomjs` skips (exit 0) without PhantomJS; `LEGACY_BROWSERS_REQUIRED=PhantomJS` exits 1
- [ ] `browser-tests` still runs the Sauce matrix, then `npm run ci:legacy-ie` on IE 11 for `jasmine_simple` and `babel`
- [ ] Local `npm run ci:legacy-ie` skips (exit 0) without Sauce credentials
- [ ] Missing Sauce credentials in CI fail `ci:legacy-ie` (do not skip)
- [ ] `npm run lint` and existing unit/integration jobs still pass
- [ ] No second Sauce job; `concurrency: sauce` stays on `browser-tests` only